### PR TITLE
Github urls fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Download right binary for your architecture and add it to your PATH. Assuming it
 `~/Downloads` folder, you can run following commands (replacing `{arch}` with your architecture):
 
 ```
-chmod +x  ~/Downloads/furyctl-{arch}-amd64.dms && mv ~/Downloads/furyctl-{arch}-amd64.dms /usr/local/bin/furyctl
+chmod +x  ~/Downloads/furyctl-{arch}-amd64 && mv ~/Downloads/furyctl-{arch}-amd64 /usr/local/bin/furyctl
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can get all packages in a group by using group name (like `logging`) or sing
 
 ### Install 
 
-You can find `furyctl` binaries on the [Releases page](https://github.com/sighup-io/furyctl/releases). 
+You can find `furyctl` binaries on the [Releases page](https://github.com/sighupio/furyctl/releases). 
 
 Supported architectures are (64 bit):
 - `linux`
@@ -50,7 +50,7 @@ Download right binary for your architecture and add it to your PATH. Assuming it
 `~/Downloads` folder, you can run following commands (replacing `{arch}` with your architecture):
 
 ```
-chmod +x  ~/Downloads/furyctl-{arch}-amd64 && mv ~/Downloads/furyctl-{arch}-amd64 /usr/local/bin/furyctl
+chmod +x  ~/Downloads/furyctl-{arch}-amd64.dms && mv ~/Downloads/furyctl-{arch}-amd64.dms /usr/local/bin/furyctl
 ```
 
 ### Usage

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	configFile              = "Furyfile"
-	repoPrefix              = "git@github.com:sighup-io/fury-kubernetes"
+	repoPrefix              = "git@github.com:sighupio/fury-kubernetes"
 	defaultVendorFolderName = "vendor"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sighup-io/furyctl
+module github.com/sighupio/furyctl
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.3.0 // indirect

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/sighup-io/furyctl/cmd"
+	"github.com/sighupio/furyctl/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Github urls changed from `.../sighup-io/...` to `.../sighupio/...`


Bonus: I have found a little mistake in the installation instructions, the extension of the downloaded binary was missing.