### PR TITLE
Furyfile overridable "global versions" for roles/modules/bases

### DIFF
--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -1,6 +1,7 @@
 
 versions:
   aws: v1.15.4
+  monitoring: v1.15.4
 
 roles:
   - name: aws/etcd
@@ -16,6 +17,5 @@ bases:
   - name: monitoring
     version: master
   - name: monitoring/prometheus-operator
-    version: master
   - name: logging/curator
     version: master

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -1,7 +1,7 @@
 
 versions:
-  aws/: v1.15.4
-  
+  aws: v1.15.4
+
 roles:
   - name: aws/etcd
 

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -1,5 +1,10 @@
 
-# roles:
+versions:
+  aws/: v1.15.4
+  
+roles:
+  - name: aws/etcd
+
 #   - name: kube-node-common
 #     version: master
 

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -1,21 +1,17 @@
 
 versions:
   aws: v1.15.4
-  monitoring: v1.15.4
+  monitoring: master
 
 roles:
   - name: aws/etcd
+  - name: aws/kube-control-plane
 
-#   - name: kube-node-common
-#     version: master
-
-# modules:
-#   - name: aws-ark
-#     version: master
+modules:
+  - name: aws/aws-vpc
+  - name: aws/aws-kubernetes
 
 bases:
   - name: monitoring
-    version: master
-  - name: monitoring/prometheus-operator
-  - name: logging/curator
+  - name: logging
     version: master

--- a/README.md
+++ b/README.md
@@ -14,24 +14,26 @@ You can omit a type if you don't need any of its packages. An example Furyfile w
 would be like following:
 
 ```
+# all sections are optional
+
+# map of prefixes and versions used to force a specific version for all the matching roles/modules/bases
+versions:
+  # e.g. will force version v1.15.4 if the name matches "aws*"
+  aws: v1.15.4
+  monitoring: master
+
 roles:
-  - name: kube-node
-    version: master
-  - name: kube-single-master
-    version: master
+  - name: aws/etcd
+  - name: aws/kube-control-plane
 
 modules:
-  - name: aws-single-master
-    version: master
-  - name: aws-ark
-    version: master
+  - name: aws/aws-vpc
+  - name: aws/aws-kubernetes
 
 bases:
-  - name: monitoring/prometheus-operator
-    version: master
-  - name: monitoring/prometheus-operated
-    version: master
+  - name: monitoring
   - name: logging
+  # versions can be overridden if needed by specifying them for each package
     version: master
 ```
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -78,6 +79,7 @@ func (f *Furyconf) Parse() ([]Package, error) {
 			for k, v := range f.Versions {
 				if strings.HasPrefix(pkgs[i].Name, k) {
 					version = v
+					log.Printf("using %v for package %s\n", version, pkgs[i].Name)
 					break
 				}
 			}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -59,9 +59,7 @@ func download(packages []Package) error {
 }
 
 func get(src, dest string) error {
-	log.Println("----")
-	log.Println("SRC: ", src)
-	log.Println("DST: ", dest)
+	log.Printf("downloading: %s -> %s\n", src, dest)
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -24,7 +24,7 @@ import (
 // Execute is the main entrypoint of furyctl
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		log.Println(err)
 		os.Exit(1)
 	}
 }
@@ -49,7 +49,7 @@ var versionCmd = &cobra.Command{
 	Short: "Prints the client version information",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Furyctl version ", FuryctlVersion)
+		log.Println("Furyctl version ", FuryctlVersion)
 	},
 }
 
@@ -59,7 +59,7 @@ var printDefaultCmd = &cobra.Command{
 	Short: "Prints a basic Furyfile used to generate an INFRA project",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(InitFuryfile)
+		log.Println(InitFuryfile)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/go-ini/ini v1.39.0 // indirect
+	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
@@ -46,3 +47,5 @@ require (
 	k8s.io/kubernetes v1.12.1 // indirect
 	k8s.io/utils v0.0.0-20181022192358-4c3feeb576b0 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-ini/ini v1.39.0 h1:/CyW/jTlZLjuzy52jc1XnhJm6IUKEuunpJFpecywNeI=
 github.com/go-ini/ini v1.39.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
I'm using the keys in the "versions" map as a prefix to decide if a module has to use the global version specified. I was thinking about using regexes, but sounded overkill.
You can find an updated and commented example in the Readme and a Furyfile in the root of the repo.