### PR TITLE
Init Distribution

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -23,14 +23,15 @@ Current availability versions are:
 
 ```
 furyctl
-├── install : looks for a Furyfile (default `./Furyfile.yaml`) and download it's content`
-├── printDefault : prints a Furyfile example
+├── init : Downloads Furyfile.yml and kustomization.yaml from the distribution repository to the current directory.
+├── vendor : Downloads Fury packages specified inside Furyfile.yaml
+├── printDefault : prints an example Furyfile
 ├── help
 └── version
 ```
 
-Write a [`Furyfile.yml`](Furyfile.yml) in the root of your project and then simply run `furyctl install`.
-It will download what you have specified in the `vendor` directory in your project root.
+Write a [`Furyfile.yml`](Furyfile.yml) in the root of your project and then simply run `furyctl vendor`.
+It will download packages specified inside 'Furyfile.yaml' to the 'vendor' directory.
 
 
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -25,7 +25,6 @@ Current availability versions are:
 furyctl
 ├── init : Downloads Furyfile.yml and kustomization.yaml from the distribution repository to the current directory.
 ├── vendor : Downloads Fury packages specified inside Furyfile.yaml
-├── printDefault : prints an example Furyfile
 ├── help
 └── version
 ```

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ## Furyctl
 
-Furyctl is package manager for Fury distribution. It’s simple to use and reads a single Furyfile to download 
+Furyctl is package manager for Fury distribution. It’s simple to use and reads a single Furyfile to download
 packages you need. Fury distribution offers three types of packages:
 
-- **Bases** : Sets of Kustomize bases to deploy basic components in Kubernetes 
+- **Bases** : Sets of Kustomize bases to deploy basic components in Kubernetes
 - **Modules**: Terraform modules to deploy kubernetes infrastructure and it’s dependencies
 - **Roles**: Ansible roles for deploying, configuring and managing a Kubernetes infrastructure
 
 ### Furyfile
 
-Furyfile is a simple YAML formatted file where you list which packages(and versions) you want to have. 
-You can omit a type if you don't need any of its packages. An example Furyfile with packages listed 
+Furyfile is a simple YAML formatted file where you list which packages(and versions) you want to have.
+You can omit a type if you don't need any of its packages. An example Furyfile with packages listed
 would be like following:
 
 ```
@@ -37,10 +37,10 @@ bases:
     version: master
 ```
 
-You can get all packages in a group by using group name (like `logging`) or single packages under a group 
+You can get all packages in a group by using group name (like `logging`) or single packages under a group
 (like `monitoring/prometheus-operator`).
 
-### Install 
+### Install
 
 #### Github Releases
 
@@ -80,8 +80,9 @@ Usage:
 
 Available Commands:
   help         Help about any command
-  install      Download dependencies specified in Furyfile.yml
+  init         Initialize the minimum distribution configuration
   printDefault Prints a basic Furyfile used to generate an INFRA project
+  vendor       Download dependencies specified in Furyfile.yml
   version      Prints the client version information
 
 Flags:
@@ -91,28 +92,36 @@ Flags:
 Use "furyctl [command] --help" for more information about a command.
 ```
 
-- To install packages, you can run `furyctl install` (within the same directory where your Furyfile is located): 
+- To download the minimal Kubernetes Fury Distribution files (within the same directory) you can run `furyctl init` command:
+```bash
+$ furyctl init --version v1.0.0
+2020/02/05 09:48:05 downloading: http::https://github.com/sighupio/poc-fury-distribution/releases/download/1.0.0/Furyfile.yml -> Furyfile.yml
+2020/02/05 09:49:05 downloading: http::https://github.com/sighupio/poc-fury-distribution/releases/download/1.0.0/kustomization.yaml -> kustomization.yaml
+```
+
+- To download packages, you can run `furyctl vendor` (within the same directory where your Furyfile is located):
 
 ```bash
-$ furyctl install
-
-2019/02/04 17:46:07 ----
-2019/02/04 17:46:07 SRC:  git@github.com:sighup-io/fury-kubernetes-monitoring//katalog/prometheus-operator?ref=master
-2019/02/04 17:46:07 DST:  vendor/katalog/monitoring/prometheus-operator
-2019/02/04 17:46:07 ----
-2019/02/04 17:46:07 SRC:  git@github.com:sighup-io/fury-kubernetes-monitoring//katalog/prometheus-operator?ref=master
-2019/02/04 17:46:07 DST:  vendor/katalog/monitoring/prometheus-operator
-...
-```   
+$ furyctl vendor
+2020/02/05 10:49:47 using v1.15.4 for package aws/etcd
+2020/02/05 10:49:47 using v1.15.4 for package aws/kube-control-plane
+2020/02/05 10:49:47 using v1.15.4 for package aws/aws-vpc
+2020/02/05 10:49:47 using v1.15.4 for package aws/aws-kubernetes
+2020/02/05 10:49:47 using master for package monitoring
+2020/02/05 10:49:47 downloading: git@github.com:sighupio/fury-kubernetes-aws//roles/kube-control-plane?ref=v1.15.4 -> vendor/roles/aws/kube-control-plane
+2020/02/05 10:49:47 downloading: git@github.com:sighupio/fury-kubernetes-aws//modules/aws-kubernetes?ref=v1.15.4 -> vendor/modules/aws/aws-kubernetes
+2020/02/05 10:49:47 downloading: git@github.com:sighupio/fury-kubernetes-monitoring//katalog?ref=master -> vendor/katalog/monitoring
+2020/02/05 10:49:47 downloading: git@github.com:sighupio/fury-kubernetes-aws//modules/aws-vpc?ref=v1.15.4 -> vendor/modules/aws/aws-vpc
+2020/02/05 10:49:47 downloading: git@github.com:sighupio/fury-kubernetes-aws//roles/etcd?ref=v1.15.4 -> vendor/roles/aws/etcd
+2020/02/05 10:49:49 downloading: git@github.com:sighupio/fury-kubernetes-logging//katalog?ref=master -> vendor/katalog/logging
+```
 You will find your packages under `vendor/{roles,modules,katalog}` directories created where you called `furyctl`.
-
 
 - You can get furyctl version with `furyctl version`:
 
 ```bash
 $ furyctl version
-
-Furyctl version  0.1.0
+2020/02/05 10:50:46 Furyctl version  0.1.4
 ```
 
 - You can print a Furyfile example with `furyctl printDefault`:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Usage:
 Available Commands:
   help         Help about any command
   init         Initialize the minimum distribution configuration
-  printDefault Prints a basic Furyfile used to generate an INFRA project
   vendor       Download dependencies specified in Furyfile.yml
   version      Prints the client version information
 
@@ -121,21 +120,5 @@ You will find your packages under `vendor/{roles,modules,katalog}` directories c
 
 ```bash
 $ furyctl version
-2020/02/05 10:50:46 Furyctl version  0.1.4
-```
-
-- You can print a Furyfile example with `furyctl printDefault`:
-
-```bash
-$ furyctl printDefault
-
-roles:
-  - name: aws/kube-node-common
-    version: v1.0.0
-
-bases:
-  - name: monitoring/prometheus-operated
-    version: v1.0.0
-  - name: monitoring/prometheus-operator
-    version: v1.0.0
+2020/02/06 13:44:44 Furyctl version  0.1.7
 ```

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -36,7 +36,7 @@ func download(packages []Package) error {
 		go func(i int) {
 			for data := range jobs {
 				//log.Printf("%d : received data %v", i, data)
-				res := get(data.url, data.dir)
+				res := get(data.url, data.dir, getter.ClientModeDir)
 				errChan <- res
 				//log.Printf("%d : finished with data %v", i, data)
 			}
@@ -59,7 +59,7 @@ func download(packages []Package) error {
 	return nil
 }
 
-func get(src, dest string) error {
+func get(src, dest string, mode getter.ClientMode) error {
 	log.Printf("downloading: %s -> %s\n", src, dest)
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -69,7 +69,7 @@ func get(src, dest string) error {
 		Src:  src,
 		Dst:  dest,
 		Pwd:  pwd,
-		Mode: getter.ClientModeDir,
+		Mode: mode,
 	}
 	//log.Printf("let's get %s -> %s", src, dest)
 	err = client.Get()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"log"
+
+	getter "github.com/hashicorp/go-getter"
+	"github.com/spf13/cobra"
+)
+
+const (
+	furyFile                    = "Furyfile.yml"
+	kustomizationFile           = "kustomization.yaml"
+	httpsDistributionRepoPrefix = "http::https://github.com/sighupio/poc-fury-distribution/releases/download/"
+)
+
+var fileNames = [...]string{furyFile, kustomizationFile}
+var distributionVersion string
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().StringVar(&distributionVersion, "version", "", "Specify the Kubernetes Fury Distribution version")
+	initCmd.MarkFlagRequired("version")
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize the minimum distribution configuration",
+	Long:  "Initialize the current directory with the minimum distribution configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, fileName := range fileNames {
+			url := httpsDistributionRepoPrefix + distributionVersion + "/" + fileName
+			downloadFile(url, fileName)
+		}
+	},
+}
+
+func downloadFile(url string, outputFileName string) error {
+	err := get(url, outputFileName, getter.ClientModeFile)
+	if err != nil {
+		log.Print(err)
+	}
+	return err
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -65,7 +66,7 @@ var printDefaultCmd = &cobra.Command{
 	Short: "Prints a basic Furyfile used to generate an INFRA project",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Println(InitFuryfile)
+		fmt.Println(InitFuryfile)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -40,7 +39,6 @@ func init() {
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.furyctl.yaml)")
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(printDefaultCmd)
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -59,26 +57,3 @@ var versionCmd = &cobra.Command{
 		log.Println("Furyctl version ", version)
 	},
 }
-
-// printDefaultCmd represents the printDefault command
-var printDefaultCmd = &cobra.Command{
-	Use:   "printDefault",
-	Short: "Prints a basic Furyfile used to generate an INFRA project",
-	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(InitFuryfile)
-	},
-}
-
-// InitFuryfile default initial Furyfile config
-const InitFuryfile = `
-roles:
-  - name: aws/kube-node-common
-    version: v1.0.0
-
-bases:
-  - name: monitoring/prometheus-operated
-    version: v1.0.0
-  - name: monitoring/prometheus-operator
-    version: v1.0.0
-`

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -22,14 +22,14 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(installCmd)
-	installCmd.PersistentFlags().BoolVarP(&parallel, "parallel", "p", true, "if true enables parallel downloads")
-	installCmd.PersistentFlags().BoolVarP(&https, "https", "H", false, "if true downloads using https instead of ssh")
+	rootCmd.AddCommand(vendorCmd)
+	vendorCmd.PersistentFlags().BoolVarP(&parallel, "parallel", "p", true, "if true enables parallel downloads")
+	vendorCmd.PersistentFlags().BoolVarP(&https, "https", "H", false, "if true downloads using https instead of ssh")
 }
 
-// installCmd represents the install command
-var installCmd = &cobra.Command{
-	Use:   "install",
+// vendorCmd represents the vendor command
+var vendorCmd = &cobra.Command{
+	Use:   "vendor",
 	Short: "Download dependencies specified in Furyfile.yml",
 	Long:  "Download dependencies specified in Furyfile.yml",
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Hi team!

This PR implements: https://github.com/sighupio/poc-fury-distribution/issues/1

**It can not be merged until we open the https://github.com/sighupio/poc-fury-distribution/ repository**, but you can see what's the idea ;)

In this PR you can find:

- Added `furyctl init --version XYZ` command with the `--version flag configured as required`
- Renamed `furyctl install` into `furyctl vendor`.
- ~~BUGFIX: `furyctl printDefault` used log instead of fmt causing an incorrect Furyfile.yml output if `furyctl printDefault > Furyfile.yml` executed.~~
- Removed `furyctl printDefault`

Thanks for your time!