### PR TITLE
Dropped unused 'toggle' boolean flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Available Commands:
 
 Flags:
   -h, --help     help for furyctl
-  -t, --toggle   Help message for toggle
 
 Use "furyctl [command] --help" for more information about a command.
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,6 @@ func Execute() {
 
 func init() {
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.furyctl.yaml)")
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.AddCommand(versionCmd)
 }
 


### PR DESCRIPTION
There was a bogus `--toggle` flag that did nothing, probably copy&pasted from an example. This PR removes it.