### PR TITLE
now the download can be repeated without errors

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"os"
 	"runtime"
@@ -67,7 +68,6 @@ func get(src, dest string, mode getter.ClientMode) error {
 
 	logrus.Debugf("complete url downloading: %s -> %s", src, dest)
 
-	humanReadableDownloadLog(src, dest)
 
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -80,8 +80,32 @@ func get(src, dest string, mode getter.ClientMode) error {
 		Mode: mode,
 	}
 	logrus.Debugf("let's get %s -> %s", src, dest)
-	err = client.Get()
+
+	gitFolder := fmt.Sprintf("%s/.git",dest)
+
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		logrus.Infof("%s already exists! removing it",dest)
+		removeContents(dest)
+		humanReadableDownloadLog(src, dest)
+		err = client.Get()
+		logrus.Infof("removing %s",gitFolder)
+		removeContents(gitFolder)
+	}else {
+		humanReadableDownloadLog(src, dest)
+		err = client.Get()
+		logrus.Infof("removing %s",gitFolder)
+		removeContents(gitFolder)
+	}
+
+
+	/*	gitFolder := fmt.Sprintf("%s/.git",dest)
+
+		if _, err := os.Stat(gitFolder); !os.IsNotExist(err) {
+			logrus.Infof("%s found, removing it!",gitFolder)
+			removeContents(gitFolder)
+		}*/
 	logrus.Debugf("done %s -> %s", src, dest)
+
 	return err
 }
 
@@ -101,4 +125,13 @@ func humanReadableDownloadLog(src string, dest string) {
 
 	logrus.Infof("downloading: %s -> %s", humanReadableSrc, dest)
 
+}
+
+
+func removeContents(dir string) error {
+	err:= os.RemoveAll(dir)
+		if err != nil {
+			return err
+		}
+	return nil
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -84,26 +84,15 @@ func get(src, dest string, mode getter.ClientMode) error {
 	gitFolder := fmt.Sprintf("%s/.git",dest)
 
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
-		logrus.Infof("%s already exists! removing it",dest)
-		removeContents(dest)
-		humanReadableDownloadLog(src, dest)
-		err = client.Get()
-		logrus.Infof("removing %s",gitFolder)
-		removeContents(gitFolder)
-	}else {
-		humanReadableDownloadLog(src, dest)
-		err = client.Get()
-		logrus.Infof("removing %s",gitFolder)
-		removeContents(gitFolder)
+		logrus.Infof("%s already exists! removing it", dest)
+		removeDir(dest)
 	}
 
+	humanReadableDownloadLog(src, dest)
+	err = client.Get()
+	logrus.Infof("removing %s",gitFolder)
+	removeDir(gitFolder)
 
-	/*	gitFolder := fmt.Sprintf("%s/.git",dest)
-
-		if _, err := os.Stat(gitFolder); !os.IsNotExist(err) {
-			logrus.Infof("%s found, removing it!",gitFolder)
-			removeContents(gitFolder)
-		}*/
 	logrus.Debugf("done %s -> %s", src, dest)
 
 	return err
@@ -127,8 +116,7 @@ func humanReadableDownloadLog(src string, dest string) {
 
 }
 
-
-func removeContents(dir string) error {
+func removeDir(dir string) error {
 	err:= os.RemoveAll(dir)
 		if err != nil {
 			return err

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -85,13 +85,21 @@ func get(src, dest string, mode getter.ClientMode) error {
 
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
 		logrus.Infof("%s already exists! removing it", dest)
-		removeDir(dest)
+		err = removeDir(dest)
+		if err != nil{
+			logrus.Error(err)
+			return err
+		}
 	}
 
 	humanReadableDownloadLog(src, dest)
-	err = client.Get()
+	_ = client.Get()
 	logrus.Infof("removing %s",gitFolder)
-	removeDir(gitFolder)
+	err = removeDir(gitFolder)
+	if err != nil{
+		logrus.Error(err)
+		return err
+	}
 
 	logrus.Debugf("done %s -> %s", src, dest)
 

--- a/go.mod
+++ b/go.mod
@@ -2,22 +2,25 @@ module github.com/sighupio/furyctl
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/aws/aws-sdk-go v1.16.26 // indirect
-	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.16.26
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
+	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/go-getter v0.0.0-20180809191950-4bda8fa99001
-	github.com/hashicorp/go-safetemp v1.0.0 // indirect
-	github.com/hashicorp/go-version v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/mitchellh/go-homedir v1.0.0 // indirect
-	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/hashicorp/go-safetemp v1.0.0
+	github.com/hashicorp/go-version v1.0.0
+	github.com/inconshreveable/mousetrap v1.0.0
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+	github.com/mitchellh/go-homedir v1.0.0
+	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.2.1
-	github.com/ulikunitz/xz v0.5.4 // indirect
+	github.com/ulikunitz/xz v0.5.4
 	golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1 // indirect
+	golang.org/x/sys v0.0.0-20190422165155-953cdadca894
+	golang.org/x/text v0.3.0
 )
 
 go 1.13


### PR DESCRIPTION
Hi everyone 👋 !
As @nutellinoit  said in a previous issue, there is currently a problem with public modules that embed also the `.git` subfolders. 
The current PR resolves the following misbehaviors: 

1. errors when you want to re-run a furyctl vendor multiple times (more than 1 actually :D ) 
2. remove automatically `.git` subfolder from the public modules that contain the `.git` subfolder

Basically now the final behavior is the same of the fury module. 
Let me know if everything looks good for you! 