### PR TITLE
Little flag to filter updates in Furyfile

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -89,20 +89,38 @@ func (f *Furyconf) Validate() error {
 }
 
 // Parse reads the furyconf structs and created a list of packaged to be downloaded
-func (f *Furyconf) Parse() ([]Package, error) {
+func (f *Furyconf) Parse(filter string) ([]Package, error) {
 	pkgs := make([]Package, 0, 0)
 	// First we aggreggate all packages in one single list
 	for _, v := range f.Roles {
 		v.kind = "roles"
-		pkgs = append(pkgs, v)
+		if len(filter)>0 {
+			if strings.HasPrefix(v.Name, filter) {
+				pkgs = append(pkgs, v)
+			}
+		}else{
+			pkgs = append(pkgs, v)
+		}
 	}
 	for _, v := range f.Modules {
 		v.kind = "modules"
-		pkgs = append(pkgs, v)
+		if len(filter)>0 {
+			if strings.HasPrefix(v.Name, filter) {
+				pkgs = append(pkgs, v)
+			}
+		}else{
+			pkgs = append(pkgs, v)
+		}
 	}
 	for _, v := range f.Bases {
 		v.kind = "katalog"
-		pkgs = append(pkgs, v)
+		if len(filter)>0 {
+			if strings.HasPrefix(v.Name, filter) {
+				pkgs = append(pkgs, v)
+			}
+		}else{
+			pkgs = append(pkgs, v)
+		}
 	}
 	repoPrefix := sshRepoPrefix
 	dotGitParticle := ""

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -94,31 +94,19 @@ func (f *Furyconf) Parse(prefix string) ([]Package, error) {
 	// First we aggreggate all packages in one single list
 	for _, v := range f.Roles {
 		v.kind = "roles"
-		if len(prefix) > 0 {
-			if strings.HasPrefix(v.Name, prefix) {
-				pkgs = append(pkgs, v)
-			}
-		} else {
+		if strings.HasPrefix(v.Name, prefix) {
 			pkgs = append(pkgs, v)
 		}
 	}
 	for _, v := range f.Modules {
 		v.kind = "modules"
-		if len(prefix) > 0 {
-			if strings.HasPrefix(v.Name, prefix) {
-				pkgs = append(pkgs, v)
-			}
-		} else {
+		if strings.HasPrefix(v.Name, prefix) {
 			pkgs = append(pkgs, v)
 		}
 	}
 	for _, v := range f.Bases {
 		v.kind = "katalog"
-		if len(prefix) > 0 {
-			if strings.HasPrefix(v.Name, prefix) {
-				pkgs = append(pkgs, v)
-			}
-		} else {
+		if strings.HasPrefix(v.Name, prefix) {
 			pkgs = append(pkgs, v)
 		}
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -89,13 +89,13 @@ func (f *Furyconf) Validate() error {
 }
 
 // Parse reads the furyconf structs and created a list of packaged to be downloaded
-func (f *Furyconf) Parse(filter string) ([]Package, error) {
+func (f *Furyconf) Parse(prefix string) ([]Package, error) {
 	pkgs := make([]Package, 0, 0)
 	// First we aggreggate all packages in one single list
 	for _, v := range f.Roles {
 		v.kind = "roles"
-		if len(filter)>0 {
-			if strings.HasPrefix(v.Name, filter) {
+		if len(prefix)>0 {
+			if strings.HasPrefix(v.Name, prefix) {
 				pkgs = append(pkgs, v)
 			}
 		}else{
@@ -104,8 +104,8 @@ func (f *Furyconf) Parse(filter string) ([]Package, error) {
 	}
 	for _, v := range f.Modules {
 		v.kind = "modules"
-		if len(filter)>0 {
-			if strings.HasPrefix(v.Name, filter) {
+		if len(prefix)>0 {
+			if strings.HasPrefix(v.Name, prefix) {
 				pkgs = append(pkgs, v)
 			}
 		}else{
@@ -114,8 +114,8 @@ func (f *Furyconf) Parse(filter string) ([]Package, error) {
 	}
 	for _, v := range f.Bases {
 		v.kind = "katalog"
-		if len(filter)>0 {
-			if strings.HasPrefix(v.Name, filter) {
+		if len(prefix)>0 {
+			if strings.HasPrefix(v.Name, prefix) {
 				pkgs = append(pkgs, v)
 			}
 		}else{

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -94,31 +94,31 @@ func (f *Furyconf) Parse(prefix string) ([]Package, error) {
 	// First we aggreggate all packages in one single list
 	for _, v := range f.Roles {
 		v.kind = "roles"
-		if len(prefix)>0 {
+		if len(prefix) > 0 {
 			if strings.HasPrefix(v.Name, prefix) {
 				pkgs = append(pkgs, v)
 			}
-		}else{
+		} else {
 			pkgs = append(pkgs, v)
 		}
 	}
 	for _, v := range f.Modules {
 		v.kind = "modules"
-		if len(prefix)>0 {
+		if len(prefix) > 0 {
 			if strings.HasPrefix(v.Name, prefix) {
 				pkgs = append(pkgs, v)
 			}
-		}else{
+		} else {
 			pkgs = append(pkgs, v)
 		}
 	}
 	for _, v := range f.Bases {
 		v.kind = "katalog"
-		if len(prefix)>0 {
+		if len(prefix) > 0 {
 			if strings.HasPrefix(v.Name, prefix) {
 				pkgs = append(pkgs, v)
 			}
-		}else{
+		} else {
 			pkgs = append(pkgs, v)
 		}
 	}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -13,6 +13,7 @@ import (
 
 var parallel bool
 var https bool
+var filter string
 
 func download(packages []Package) error {
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -13,7 +13,7 @@ import (
 
 var parallel bool
 var https bool
-var filter string
+var prefix string
 
 func download(packages []Package) error {
 

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -24,7 +24,7 @@ func init() {
 	rootCmd.AddCommand(vendorCmd)
 	vendorCmd.PersistentFlags().BoolVarP(&parallel, "parallel", "p", true, "if true enables parallel downloads")
 	vendorCmd.PersistentFlags().BoolVarP(&https, "https", "H", false, "if true downloads using https instead of ssh")
-	vendorCmd.PersistentFlags().StringVarP(&filter, "filter", "f", "","Add filtering on download, to reduce update scope")
+	vendorCmd.PersistentFlags().StringVarP(&prefix, "prefix", "P", "","Add filtering on download with prefix, to reduce update scope")
 }
 
 // vendorCmd represents the vendor command
@@ -50,7 +50,7 @@ var vendorCmd = &cobra.Command{
 			logrus.WithError(err).Error("ERROR VALIDATING")
 		}
 
-		list, err := config.Parse(filter)
+		list, err := config.Parse(prefix)
 
 		if err != nil {
 			//logrus.Errorln("ERROR PARSING: ", err)

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -24,6 +24,7 @@ func init() {
 	rootCmd.AddCommand(vendorCmd)
 	vendorCmd.PersistentFlags().BoolVarP(&parallel, "parallel", "p", true, "if true enables parallel downloads")
 	vendorCmd.PersistentFlags().BoolVarP(&https, "https", "H", false, "if true downloads using https instead of ssh")
+	vendorCmd.PersistentFlags().StringVarP(&filter, "filter", "f", "","Add filtering on download, to reduce update scope")
 }
 
 // vendorCmd represents the vendor command
@@ -49,7 +50,7 @@ var vendorCmd = &cobra.Command{
 			logrus.WithError(err).Error("ERROR VALIDATING")
 		}
 
-		list, err := config.Parse()
+		list, err := config.Parse(filter)
 
 		if err != nil {
 			//logrus.Errorln("ERROR PARSING: ", err)

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -24,7 +24,7 @@ func init() {
 	rootCmd.AddCommand(vendorCmd)
 	vendorCmd.PersistentFlags().BoolVarP(&parallel, "parallel", "p", true, "if true enables parallel downloads")
 	vendorCmd.PersistentFlags().BoolVarP(&https, "https", "H", false, "if true downloads using https instead of ssh")
-	vendorCmd.PersistentFlags().StringVarP(&prefix, "prefix", "P", "","Add filtering on download with prefix, to reduce update scope")
+	vendorCmd.PersistentFlags().StringVarP(&prefix, "prefix", "P", "", "Add filtering on download with prefix, to reduce update scope")
 }
 
 // vendorCmd represents the vendor command


### PR DESCRIPTION
Hi team!

I added a little flag on the furyctl vendor command ~`--filter`~ `--prefix` to add a prefix on the modules i want to update, eg: ~`furyctl vendor --filter dr/velero`~  `furyctl vendor --prefix dr/velero`.

This can useful when we do stack upgrades.