### PR TITLE
Implement reconfigure flag

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -68,9 +68,10 @@ func bPre(cmd *cobra.Command, args []string) (err error) {
 		Project:                  prj,
 		ProvisionerConfiguration: cfg,
 		TerraformOpts: &terraform.Options{
-			GitHubToken: bGitHubToken,
-			WorkingDir:  workingDirFullPath,
-			Debug:       debug,
+			GitHubToken:        bGitHubToken,
+			WorkingDir:         workingDirFullPath,
+			Debug:              debug,
+			ReconfigureBackend: bReconfigure,
 		},
 	}
 	boot, err = bootstrap.New(bootstrapOpts)
@@ -89,6 +90,7 @@ var (
 	bGitHubToken         string
 	bTemplateProvisioner string
 	bReset               bool
+	bReconfigure         bool
 	bDryRun              bool
 
 	bootstrapCmd = &cobra.Command{
@@ -192,6 +194,10 @@ func init() {
 	bootstrapInitCmd.PersistentFlags().StringVarP(&bGitHubToken, "token", "t", "", "GitHub token to access enterprise repositories. Contact sales@sighup.io")
 	bootstrapApplyCmd.PersistentFlags().StringVarP(&bGitHubToken, "token", "t", "", "GitHub token to access enterprise repositories. Contact sales@sighup.io")
 	bootstrapDestroyCmd.PersistentFlags().StringVarP(&bGitHubToken, "token", "t", "", "GitHub token to access enterprise repositories. Contact sales@sighup.io")
+
+	bootstrapInitCmd.PersistentFlags().BoolVar(&bReconfigure, "reconfigure", false, "Reconfigure the backend, ignoring any saved configuration")
+	bootstrapApplyCmd.PersistentFlags().BoolVar(&bReconfigure, "reconfigure", false, "Reconfigure the backend, ignoring any saved configuration")
+	bootstrapDestroyCmd.PersistentFlags().BoolVar(&bReconfigure, "reconfigure", false, "Reconfigure the backend, ignoring any saved configuration")
 
 	bootstrapInitCmd.PersistentFlags().BoolVar(&bReset, "reset", false, "Forces the re-initialization of the project. It deletes the content of the workdir recreating everything")
 

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -68,9 +68,10 @@ func cPre(cmd *cobra.Command, args []string) (err error) {
 		Project:                  prj,
 		ProvisionerConfiguration: cfg,
 		TerraformOpts: &terraform.Options{
-			GitHubToken: cGitHubToken,
-			WorkingDir:  workingDirFullPath,
-			Debug:       cDryRun,
+			GitHubToken:        cGitHubToken,
+			WorkingDir:         workingDirFullPath,
+			Debug:              cDryRun,
+			ReconfigureBackend: cReconfigure,
 		},
 	}
 	clu, err = cluster.New(clusterOpts)
@@ -90,6 +91,7 @@ var (
 	cTemplateProvisioner string
 	cDryRun              bool
 	cReset               bool
+	cReconfigure         bool
 
 	clusterCmd = &cobra.Command{
 		Use:   "cluster",
@@ -194,6 +196,10 @@ func init() {
 	clusterInitCmd.PersistentFlags().StringVarP(&cGitHubToken, "token", "t", "", "GitHub token to access enterprise repositories. Contact sales@sighup.io")
 	clusterApplyCmd.PersistentFlags().StringVarP(&cGitHubToken, "token", "t", "", "GitHub token to access enterprise repositories. Contact sales@sighup.io")
 	clusterDestroyCmd.PersistentFlags().StringVarP(&cGitHubToken, "token", "t", "", "GitHub token to access enterprise repositories. Contact sales@sighup.io")
+
+	clusterInitCmd.PersistentFlags().BoolVar(&cReconfigure, "reconfigure", false, "Reconfigure the backend, ignoring any saved configuration")
+	clusterApplyCmd.PersistentFlags().BoolVar(&cReconfigure, "reconfigure", false, "Reconfigure the backend, ignoring any saved configuration")
+	clusterDestroyCmd.PersistentFlags().BoolVar(&cReconfigure, "reconfigure", false, "Reconfigure the backend, ignoring any saved configuration")
 
 	clusterInitCmd.PersistentFlags().BoolVar(&cReset, "reset", false, "Forces the re-initialization of the project. It deletes the content of the workdir recreating everything")
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/viper v1.7.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 // indirect
+	golang.org/x/sys v0.0.0-20210223212115-eede4237b368 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/tools v0.1.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 h1:SgQ6LNaYJU0JIuEHv9+s6EbhSCwYeAf5Yvj6lpYlqAE=
-golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210223212115-eede4237b368 h1:fDE3p0qf2V1co1vfj3/o87Ps8Hq6QTGNxJ5Xe7xSp80=
+golang.org/x/sys v0.0.0-20210223212115-eede4237b368/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -137,7 +137,7 @@ func (c *Bootstrap) Init(reset bool) (err error) {
 	c.s.Suffix = " Initializing terraform project"
 	c.s.Start()
 
-	err = tf.Init(context.Background())
+	err = tf.Init(context.Background(), tfexec.Reconfigure(c.options.TerraformOpts.ReconfigureBackend))
 	if err != nil {
 		log.Errorf("error while running terraform init in the project dir: %v", err)
 		return err
@@ -260,7 +260,7 @@ func (c *Bootstrap) Update(dryrun bool) (err error) {
 	c.s.Suffix = " Re-Initializing terraform project"
 	c.s.Start()
 
-	err = tf.Init(context.Background())
+	err = tf.Init(context.Background(), tfexec.Reconfigure(c.options.TerraformOpts.ReconfigureBackend))
 	if err != nil {
 		log.Errorf("error while running terraform init in the project dir: %v", err)
 		return err
@@ -352,7 +352,7 @@ func (c *Bootstrap) Destroy() (err error) {
 	c.s.Suffix = " Re-Initializing terraform project"
 	c.s.Start()
 
-	err = tf.Init(context.Background())
+	err = tf.Init(context.Background(), tfexec.Reconfigure(c.options.TerraformOpts.ReconfigureBackend))
 	if err != nil {
 		log.Errorf("error while running terraform init in the project dir: %v", err)
 		return err

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -137,7 +137,7 @@ func (c *Cluster) Init(reset bool) (err error) {
 	c.s.Suffix = " Initializing terraform project"
 	c.s.Start()
 
-	err = tf.Init(context.Background())
+	err = tf.Init(context.Background(), tfexec.Reconfigure(c.options.TerraformOpts.ReconfigureBackend))
 	if err != nil {
 		log.Errorf("error while running terraform init in the project dir: %v", err)
 		return err
@@ -264,7 +264,7 @@ func (c *Cluster) Update(dryrun bool) (err error) {
 	c.s.Suffix = " Re-Initializing terraform project"
 	c.s.Start()
 
-	err = tf.Init(context.Background())
+	err = tf.Init(context.Background(), tfexec.Reconfigure(c.options.TerraformOpts.ReconfigureBackend))
 	if err != nil {
 		log.Errorf("error while running terraform init in the project dir: %v", err)
 		return err
@@ -374,7 +374,7 @@ func (c *Cluster) Destroy() (err error) {
 	c.s.Suffix = " Re-Initializing terraform project"
 	c.s.Start()
 
-	err = tf.Init(context.Background())
+	err = tf.Init(context.Background(), tfexec.Reconfigure(c.options.TerraformOpts.ReconfigureBackend))
 	if err != nil {
 		log.Errorf("error while running terraform init in the project dir: %v", err)
 		return err

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -20,8 +20,9 @@ type Options struct {
 	Version    string
 	BinaryPath string
 
-	Backend       string
-	BackendConfig map[string]string
+	Backend            string
+	BackendConfig      map[string]string
+	ReconfigureBackend bool
 
 	WorkingDir string
 	ConfigDir  string


### PR DESCRIPTION
Add `--reconfigure` flag.

It enables backend reconfiguration on demand. Useful in a scenario where you update the executor version (terraform).
