### PR TITLE
Enable v1.5.0 feature in eks cluster provisioner

### DIFF
--- a/data/provisioners/cluster/eks/variables.tf
+++ b/data/provisioners/cluster/eks/variables.tf
@@ -25,7 +25,6 @@ variable "subnetworks" {
 }
 
 variable "dmz_cidr_range" {
-  type        = string
   description = "Network CIDR range from where cluster control plane will be accessible"
 }
 

--- a/internal/cluster/configuration/eks.go
+++ b/internal/cluster/configuration/eks.go
@@ -9,11 +9,42 @@ type EKS struct {
 	Version      string            `yaml:"version"`
 	Network      string            `yaml:"network"`
 	SubNetworks  []string          `yaml:"subnetworks"`
-	DMZCIDRRange string            `yaml:"dmzCIDRRange"`
+	DMZCIDRRange DMZCIDRRange      `yaml:"dmzCIDRRange"`
 	SSHPublicKey string            `yaml:"sshPublicKey"`
 	NodePools    []EKSNodePool     `yaml:"nodePools"`
 	Tags         map[string]string `yaml:"tags"`
 	Auth         EKSAuth           `yaml:"auth"`
+}
+
+// DMZCIDRRange represents a string or a list of strings
+type DMZCIDRRange struct {
+	Values []string
+}
+
+//UnmarshalYAML unmarshall the DMZCIDRRange
+func (sm *DMZCIDRRange) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err != nil {
+		var single string
+		err := unmarshal(&single)
+		if err != nil {
+			return err
+		}
+		sm.Values = make([]string, 1)
+		sm.Values[0] = single
+	} else {
+		sm.Values = multi
+	}
+	return nil
+}
+
+//MarshalYAML marshall the DMZCIDRRange
+func (sm DMZCIDRRange) MarshalYAML() (interface{}, error) {
+	if len(sm.Values) == 1 {
+		return sm.Values[0], nil
+	}
+	return sm.Values, nil
 }
 
 // EKSAuth represent a auth structure

--- a/internal/cluster/provisioners/eks/provisioner.go
+++ b/internal/cluster/provisioners/eks/provisioner.go
@@ -106,7 +106,7 @@ func (e EKS) createVarFile() (err error) {
 	buffer.WriteString(fmt.Sprintf("cluster_version = \"%v\"\n", spec.Version))
 	buffer.WriteString(fmt.Sprintf("network = \"%v\"\n", spec.Network))
 	buffer.WriteString(fmt.Sprintf("subnetworks = [\"%v\"]\n", strings.Join(spec.SubNetworks, "\",\"")))
-	buffer.WriteString(fmt.Sprintf("dmz_cidr_range = \"%v\"\n", spec.DMZCIDRRange))
+	buffer.WriteString(fmt.Sprintf("dmz_cidr_range = [\"%v\"]\n", strings.Join(spec.DMZCIDRRange.Values, "\",\"")))
 	buffer.WriteString(fmt.Sprintf("ssh_public_key = \"%v\"\n", spec.SSHPublicKey))
 	if len(spec.Tags) > 0 {
 		var tags []byte

--- a/internal/configuration/config_test.go
+++ b/internal/configuration/config_test.go
@@ -57,7 +57,7 @@ func init() {
 		Version:      "1.18",
 		Network:      "vpc-1",
 		SubNetworks:  []string{"subnet-1", "subnet-2", "subnet-3"},
-		DMZCIDRRange: "0.0.0.0/0",
+		DMZCIDRRange: clustercfg.DMZCIDRRange{Values: []string{"0.0.0.0/0"}},
 		SSHPublicKey: "123",
 		NodePools: []clustercfg.EKSNodePool{
 			{

--- a/internal/configuration/templates.go
+++ b/internal/configuration/templates.go
@@ -99,7 +99,7 @@ func clusterTemplate(config *Configuration) error {
 			Version:      "1.18 # EKS Control plane version",
 			Network:      "vpc-id1 # Identificator of the VPC",
 			SubNetworks:  []string{"subnet-id1 # Identificator of the subnets"},
-			DMZCIDRRange: "10.0.0.0/8. Required. Network CIDR range from where cluster control plane will be accessible",
+			DMZCIDRRange: clustercfg.DMZCIDRRange{Values: []string{"10.0.0.0/8", "Required. Network CIDR range from where cluster control plane will be accessible"}},
 			SSHPublicKey: "sha-rsa 190jd0132w. Required. Cluster administrator public ssh key. Used to access cluster nodes.",
 			Tags: map[string]string{
 				"myTag": "MyValue # Use this tags to annotate all resources. Optional",


### PR DESCRIPTION
This PR enables the possibility to specify from 1 to n number of DMZ CIDR ranges added in the cloud installer v1.5.0