### PR TITLE
Creating furyagent/.gitattributes

### DIFF
--- a/data/provisioners/cluster/vsphere/furyagent/.gitattributes
+++ b/data/provisioners/cluster/vsphere/furyagent/.gitattributes
@@ -1,0 +1,1 @@
+*pki/** filter=git-crypt diff=git-crypt


### PR DESCRIPTION
This will be used to encrypt the content of furyagent/pki folder, which contains etcd and master certificates for kubernetes.