### PR TITLE
Adds (ba|z|fi)sh autocomplete for furyctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ $ furyctl version
 INFO[0000] Furyctl version 0.2.3
 ```
 
+#### Autocomplete
+
+You can enable autocompletion for `furyctl` cli on your shell similar to the one
+for `kubectl`. Currently autocompletion is supported for `bash`, `zsh`, `fish`
+and `powershell`. To see the options and info about how to setup, run the
+command:
+
+``` bash
+$ furyctl completion -h
+```
+
+
 ### Self-Provisioning
 
 The self-provisioning feature is available with two commands:

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,18 +1,7 @@
-/*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+// Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
 var completionCmd = &cobra.Command{
 	Use:   "completion [bash|zsh|fish|powershell]",
 	Short: "Generate completion script",

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -23,7 +23,7 @@ import (
 var completionCmd = &cobra.Command{
 	Use:   "completion [bash|zsh|fish|powershell]",
 	Short: "Generate completion script",
-	Long: `To load completions:
+	Long: `To load furyctl completions:
 
 Bash:
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,84 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+  $ source <(furyctl completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ furyctl completion bash > /etc/bash_completion.d/furyctl
+  # macOS:
+  $ furyctl completion bash > /usr/local/etc/bash_completion.d/furyctl
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ furyctl completion zsh > "${fpath[1]}/_furyctl"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ furyctl completion fish | source
+
+  # To load completions for each session, execute once:
+  $ furyctl completion fish > ~/.config/fish/completions/furyctl.fish
+
+PowerShell:
+
+  PS> furyctl completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> furyctl completion powershell > furyctl.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,16 +1,6 @@
-// Copyright © 2018 Sighup SRL support@sighup.io
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 package cmd
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,16 +1,6 @@
-// Copyright © 2018 Sighup SRL support@sighup.io
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 package cmd
 

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -1,16 +1,6 @@
-// Copyright © 2018 Sighup SRL support@sighup.io
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 package cmd
 


### PR DESCRIPTION
This MR addresses issue #3. The cobra generator was used to auto-generate the completion scripts. The configuration to add the completion scripts to the shell configurations will be available on running the command `furyctl completion -h` as follows:
```bash
To load furyctl completions:

Bash:

  $ source <(furyctl completion bash)

  # To load completions for each session, execute once:
  # Linux:
  $ furyctl completion bash > /etc/bash_completion.d/furyctl
  # macOS:
  $ furyctl completion bash > /usr/local/etc/bash_completion.d/furyctl

Zsh:

  # If shell completion is not already enabled in your environment,
  # you will need to enable it.  You can execute the following once:

  $ echo "autoload -U compinit; compinit" >> ~/.zshrc

  # To load completions for each session, execute once:
  $ furyctl completion zsh > "${fpath[1]}/_furyctl"

  # You will need to start a new shell for this setup to take effect.

fish:

  $ furyctl completion fish | source

  # To load completions for each session, execute once:
  $ furyctl completion fish > ~/.config/fish/completions/furyctl.fish

PowerShell:

  PS> furyctl completion powershell | Out-String | Invoke-Expression

  # To load completions for every new session, run:
  PS> furyctl completion powershell > furyctl.ps1
  # and source this file from your PowerShell profile.

Usage:
  furyctl completion [bash|zsh|fish|powershell]

Flags:
  -h, --help   help for completion

Global Flags:
      --debug     Enables furyctl debug output
  -d, --disable   Disable analytics
```