### PR TITLE
Feature/eks add alb attachment to autoscaling groups

### DIFF
--- a/internal/cluster/configuration/eks.go
+++ b/internal/cluster/configuration/eks.go
@@ -44,6 +44,7 @@ type EKSNodePool struct {
 	Taints                  []string            `yaml:"taints"`
 	SubNetworks             []string            `yaml:"subnetworks"`
 	Tags                    map[string]string   `yaml:"tags"`
+	TargetGroupArns         []string            `yaml:"target_group_arns"`
 	AdditionalFirewallRules []EKSNodePoolFwRule `yaml:"additionalFirewallRules"`
 }
 

--- a/internal/cluster/provisioners/eks/provisioner.go
+++ b/internal/cluster/provisioners/eks/provisioner.go
@@ -170,6 +170,12 @@ func (e EKS) createVarFile() (err error) {
 			}
 			buffer.WriteString(fmt.Sprintf("volume_size = %v\n", np.VolumeSize))
 
+			if len(np.TargetGroupArns) > 0 {
+				buffer.WriteString(fmt.Sprintf("target_group_arns = [\"%v\"]\n", strings.Join(np.TargetGroupArns, "\",\"")))
+			} else {
+				buffer.WriteString("target_group_arns = []\n")
+			}
+
 			if len(np.AdditionalFirewallRules) > 0 {
 
 				buffer.WriteString("additional_firewall_rules = [\n")

--- a/internal/configuration/assets/eks-cluster.yml
+++ b/internal/configuration/assets/eks-cluster.yml
@@ -31,6 +31,9 @@ spec:
       instanceType: "m"
       maxPods: 100
       volumeSize: 50
+      target_group_arns: 
+        - "targetgroup-id1"
+        - "targetgroup-id2"
       labels:
         hello: World
       taints:

--- a/internal/configuration/assets/eks-cluster.yml
+++ b/internal/configuration/assets/eks-cluster.yml
@@ -33,7 +33,6 @@ spec:
       volumeSize: 50
       target_group_arns: 
         - "targetgroup-id1"
-        - "targetgroup-id2"
       labels:
         hello: World
       taints:

--- a/internal/configuration/config_test.go
+++ b/internal/configuration/config_test.go
@@ -60,13 +60,14 @@ func init() {
 		SSHPublicKey: "123",
 		NodePools: []clustercfg.EKSNodePool{
 			{
-				Name:         "one",
-				Version:      "1.18",
-				MinSize:      0,
-				MaxSize:      10,
-				InstanceType: "m",
-				MaxPods:      100,
-				VolumeSize:   50,
+				Name:            "one",
+				Version:         "1.18",
+				MinSize:         0,
+				MaxSize:         10,
+				InstanceType:    "m",
+				MaxPods:         100,
+				VolumeSize:      50,
+				TargetGroupArns: []string{"targetgroup-id1"},
 				Labels: map[string]string{
 					"hello": "World",
 				},

--- a/internal/configuration/templates.go
+++ b/internal/configuration/templates.go
@@ -163,6 +163,7 @@ func clusterTemplate(config *Configuration) error {
 					Tags: map[string]string{
 						"myTag": "MyValue # Use this tags to annotate nodepool resources. Optional",
 					},
+					TargetGroupArns: []string{"target-group-arn-1", "# target group arns to configure the autoscaling group"},
 					AdditionalFirewallRules: []clustercfg.EKSNodePoolFwRule{
 						{
 							Name:      "The name of rule # Identify the rule using a description",


### PR DESCRIPTION
This PR implements the solution proposed in https://github.com/sighupio/furyctl/issues/47 to prevent the detachment of the ALB to the autoscaling groups of the worker nodes.

Better solutions might exist but this was the quickest one to implement and a good starting point.

A user can now specify `target_group_arns` in the `config.yaml` to avoid the detachment.

```yaml
nodePools:
  - name: fury
    version: null
    ....
    target_group_arns: 
      - "arn:aws:elasticloadbalancing:eu-central-1:...."
```

