### PR TITLE
Custom ami_id for eks provisioner, #51

### DIFF
--- a/internal/cluster/configuration/eks.go
+++ b/internal/cluster/configuration/eks.go
@@ -38,6 +38,7 @@ type EKSNodePool struct {
 	MinSize                 int                 `yaml:"minSize"`
 	MaxSize                 int                 `yaml:"maxSize"`
 	InstanceType            string              `yaml:"instanceType"`
+	AmiId                   string              `yaml:"amiId"`
 	MaxPods                 int                 `yaml:"maxPods"`
 	VolumeSize              int                 `yaml:"volumeSize"`
 	Labels                  map[string]string   `yaml:"labels"`

--- a/internal/cluster/provisioners/eks/provisioner.go
+++ b/internal/cluster/provisioners/eks/provisioner.go
@@ -163,6 +163,7 @@ func (e EKS) createVarFile() (err error) {
 			buffer.WriteString(fmt.Sprintf("min_size = %v\n", np.MinSize))
 			buffer.WriteString(fmt.Sprintf("max_size = %v\n", np.MaxSize))
 			buffer.WriteString(fmt.Sprintf("instance_type = \"%v\"\n", np.InstanceType))
+			buffer.WriteString(fmt.Sprintf("eks_ami_id = \"%v\"\n", np.AmiId))
 			if np.MaxPods > 0 {
 				buffer.WriteString(fmt.Sprintf("max_pods = %v\n", np.MaxPods))
 			} else {

--- a/internal/configuration/assets/eks-cluster.yml
+++ b/internal/configuration/assets/eks-cluster.yml
@@ -29,6 +29,7 @@ spec:
       minSize: 0
       maxSize: 10
       instanceType: "m"
+      amiId: "ami-123456"
       maxPods: 100
       volumeSize: 50
       labels:

--- a/internal/configuration/config_test.go
+++ b/internal/configuration/config_test.go
@@ -65,6 +65,7 @@ func init() {
 				MinSize:      0,
 				MaxSize:      10,
 				InstanceType: "m",
+				AmiId:        "ami-123456",
 				MaxPods:      100,
 				VolumeSize:   50,
 				Labels: map[string]string{

--- a/internal/configuration/templates.go
+++ b/internal/configuration/templates.go
@@ -153,6 +153,7 @@ func clusterTemplate(config *Configuration) error {
 					MinSize:      0,
 					MaxSize:      1,
 					InstanceType: "t3.micro. Required. AWS EC2 isntance types",
+					AmiId:        "ami-123456 # Custom ami_id for nodes",
 					MaxPods:      110,
 					VolumeSize:   50,
 					SubNetworks:  []string{"subnet-1", "# any subnet id where you want your nodes running"},


### PR DESCRIPTION
This change requires the following PR on `fury-eks-installer` to work: https://github.com/sighupio/fury-eks-installer/pull/23
Together, the two changes allow the user to specify a custom AMI id for the nodes, for each node pool in an EKS-provisioned cluster, like in the following snippet:
```
nodePools:
  - name: fury
    version: null
    ....
    eks_ami_id: "ami-123456"
```
