### PR TITLE
WIP: Including new features to cluster-self provisioning

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -157,6 +157,17 @@ steps:
     commands:
       - bats -t ./automated-tests/e2e-tests/vsphere/tests.sh
 
+  - <<: *e2e
+    name: e2e-vsphere-destroy
+    depends_on: 
+      - e2e-vsphere
+    failure: ignore
+    commands:
+      - echo " Our vsphere environment is not so stable"
+      - echo " The destroy phase fails randomly because of disconnection events between vsphere nodes and the API"
+      - echo " Ignore errors on this step"
+      - bats -t ./automated-tests/e2e-tests/vsphere/tests-destroy.sh
+
   - name: build-release
     image: ghcr.io/goreleaser/goreleaser:v0.149.0
     pull: always

--- a/automated-tests/e2e-tests/aws-eks/cluster.tpl.yml
+++ b/automated-tests/e2e-tests/aws-eks/cluster.tpl.yml
@@ -6,7 +6,7 @@ kind: Cluster
 metadata:
   name: e2e-${CI_BUILD_NUMBER}
 spec:
-  version: "1.18"
+  version: "1.20"
   network: ${NETWORK_ID}
   subnetworks: ${PRIVATE_SUBNETS}
   dmzCIDRRange: ${NETWORK_CIDR}

--- a/automated-tests/e2e-tests/gcp-gke/cluster.tpl.yml
+++ b/automated-tests/e2e-tests/gcp-gke/cluster.tpl.yml
@@ -6,7 +6,7 @@ kind: Cluster
 metadata:
   name: e2e-${CI_BUILD_NUMBER}
 spec:
-  version: 1.19.9-gke.1900
+  version: 1.20.9-gke.700
   network: e2e-${CI_BUILD_NUMBER}
   subnetworks:
     - e2e-${CI_BUILD_NUMBER}-cluster-subnet

--- a/automated-tests/e2e-tests/vsphere/.gitignore
+++ b/automated-tests/e2e-tests/vsphere/.gitignore
@@ -1,2 +1,4 @@
 cluster.yml
 cluster
+sshkey
+sshkey.pub

--- a/automated-tests/e2e-tests/vsphere/tests-destroy.sh
+++ b/automated-tests/e2e-tests/vsphere/tests-destroy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+load "./../../helper"
+
+OS="linux"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    OS="darwin"
+fi
+
+@test "Prepare temporal ssh key" {
+    info
+    ssh_keys(){
+        cp ./automated-tests/e2e-tests/vsphere/sshkey.pub /tmp/sshkey.pub
+    }
+    run ssh_keys
+    if [[ $status -ne 0 ]]; then
+        echo "$output" >&3
+    fi
+    [ "$status" -eq 0 ]
+}
+
+@test "Cluster destroy" {
+    info
+    destroy(){
+        ./dist/furyctl-${OS}_${OS}_amd64/furyctl -d --debug cluster destroy --force --config ./automated-tests/e2e-tests/vsphere/cluster.yml -w ./automated-tests/e2e-tests/vsphere/cluster
+    }
+    run destroy
+
+    if [[ $status -ne 0 ]]; then
+        echo "$output" >&3
+        echo "  TERRAFORM LOGS:" >&3
+        cat ./automated-tests/e2e-tests/vsphere/cluster/logs/terraform.logs >&3
+    fi
+    [ "$status" -eq 0 ]
+}

--- a/automated-tests/e2e-tests/vsphere/tests.sh
+++ b/automated-tests/e2e-tests/vsphere/tests.sh
@@ -14,7 +14,8 @@ fi
 @test "Prepare temporal ssh key" {
     info
     ssh_keys(){
-        ssh-keygen -b 2048 -t rsa -f /tmp/sshkey -q -N ""
+        ssh-keygen -b 2048 -t rsa -f ./automated-tests/e2e-tests/vsphere/sshkey -q -N ""
+        cp ./automated-tests/e2e-tests/vsphere/sshkey.pub /tmp/sshkey.pub
     }
     run ssh_keys
     if [[ $status -ne 0 ]]; then
@@ -113,21 +114,6 @@ fi
     if [[ $status -ne 0 ]]; then
         echo "$output" >&3
         cat ./automated-tests/e2e-tests/vsphere/cluster/secrets/kubeconfig >&3
-    fi
-    [ "$status" -eq 0 ]
-}
-
-@test "Cluster destroy" {
-    info
-    destroy(){
-        ./dist/furyctl-${OS}_${OS}_amd64/furyctl -d --debug cluster destroy --force --config ./automated-tests/e2e-tests/vsphere/cluster.yml -w ./automated-tests/e2e-tests/vsphere/cluster
-    }
-    run destroy
-
-    if [[ $status -ne 0 ]]; then
-        echo "$output" >&3
-        echo "  TERRAFORM LOGS:" >&3
-        cat ./automated-tests/e2e-tests/vsphere/cluster/logs/terraform.logs >&3
     fi
     [ "$status" -eq 0 ]
 }

--- a/automated-tests/integration/aws-eks/cluster.yml
+++ b/automated-tests/integration/aws-eks/cluster.yml
@@ -7,7 +7,7 @@ metadata:
   name: furyctl
 provisioner: eks
 spec:
-  version: "1.18"
+  version: "1.20"
   network: vpc-tobedefined
   subnetworks:
   - subnet-tobedefined-1

--- a/automated-tests/integration/gcp-gke/cluster.yml
+++ b/automated-tests/integration/gcp-gke/cluster.yml
@@ -7,7 +7,7 @@ metadata:
   name: furyctl
 provisioner: gke
 spec:
-  version: 1.19.9-gke.1900
+  version: 1.20.9-gke.700
   network: furyctl
   subnetworks:
   - furyctl-cluster-subnet

--- a/data/provisioners/cluster/eks/main.tf
+++ b/data/provisioners/cluster/eks/main.tf
@@ -5,6 +5,7 @@
  */
 
 terraform {
+  experiments      = [module_variable_optional_attrs]
   required_version = "0.15.4"
   required_providers {
     aws        = "= 3.37.0"
@@ -17,7 +18,7 @@ terraform {
 }
 
 module "fury" {
-  source = "github.com/sighupio/fury-eks-installer//modules/eks?ref=v1.7.1"
+  source = "github.com/sighupio/fury-eks-installer//modules/eks?ref=no-spot-instance_eks-ami-id-rename"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/data/provisioners/cluster/eks/main.tf
+++ b/data/provisioners/cluster/eks/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "fury" {
-  source = "github.com/sighupio/fury-eks-installer//modules/eks?ref=no-spot-instance_eks-ami-id-rename"
+  source = "github.com/sighupio/fury-eks-installer//modules/eks?ref=v1.8.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/data/provisioners/cluster/eks/variables.tf
+++ b/data/provisioners/cluster/eks/variables.tf
@@ -20,7 +20,7 @@ variable "network" {
 }
 
 variable "subnetworks" {
-  type        = list
+  type        = list(any)
   description = "List of subnets where the cluster will be hosted"
 }
 
@@ -36,17 +36,19 @@ variable "ssh_public_key" {
 variable "node_pools" {
   description = "An object list defining node pools configurations"
   type = list(object({
-    name          = string
-    version       = string # null to use cluster_version
-    min_size      = number
-    max_size      = number
-    instance_type = string
-    max_pods      = number # null to use default upstream configuration
-    volume_size   = number
-    subnetworks   = list(string) # null to use default upstream configuration
-    labels        = map(string)
-    taints        = list(string)
-    tags          = map(string)
+    name                  = string
+    version               = string # null to use cluster_version
+    min_size              = number
+    max_size              = number
+    instance_type         = string
+    os                    = optional(string)
+    max_pods              = number # null to use default upstream configuration
+    volume_size           = number
+    subnetworks           = list(string) # null to use default upstream configuration
+    labels                = map(string)
+    taints                = list(string)
+    tags                  = map(string)
+    eks_target_group_arns = optional(list(string))
     additional_firewall_rules = list(object({
       name       = string
       direction  = string
@@ -60,7 +62,7 @@ variable "node_pools" {
 }
 
 variable "tags" {
-  type        = map
+  type        = map(any)
   description = "The tags to apply to all resources"
   default     = {}
 }

--- a/data/provisioners/cluster/gke/main.tf
+++ b/data/provisioners/cluster/gke/main.tf
@@ -5,6 +5,7 @@
  */
 
 terraform {
+  experiments      = [module_variable_optional_attrs]
   required_version = "0.15.4"
   required_providers {
     google      = "3.55.0"
@@ -17,7 +18,7 @@ terraform {
 }
 
 module "fury" {
-  source = "github.com/sighupio/fury-gke-installer//modules/gke?ref=v1.7.0"
+  source = "github.com/sighupio/fury-gke-installer//modules/gke?ref=no-preemtible-instances_os-parameter"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/data/provisioners/cluster/gke/main.tf
+++ b/data/provisioners/cluster/gke/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "fury" {
-  source = "github.com/sighupio/fury-gke-installer//modules/gke?ref=no-preemtible-instances_os-parameter"
+  source = "github.com/sighupio/fury-gke-installer//modules/gke?ref=v1.8.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/data/provisioners/cluster/gke/variables.tf
+++ b/data/provisioners/cluster/gke/variables.tf
@@ -41,6 +41,7 @@ variable "node_pools" {
     min_size      = number
     max_size      = number
     instance_type = string
+    os            = optional(string)
     max_pods      = number # null to use default upstream configuration
     volume_size   = number
     subnetworks   = list(string) # "" to use default upstream configuration

--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,9 @@ require (
 	github.com/spf13/viper v1.8.1
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/net v0.0.0-20210420072503-d25e30425868 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/sys v0.0.0-20210902050250-f475640dd07b // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
-	golang.org/x/tools v0.1.4 // indirect
+	golang.org/x/tools v0.1.5 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -639,8 +639,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210902050250-f475640dd07b h1:S7hKs0Flbq0bbc9xgYt4stIEG1zNDFqyrPwAX2Wj/sE=
+golang.org/x/sys v0.0.0-20210902050250-f475640dd07b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
@@ -710,8 +710,8 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.4 h1:cVngSRcfgyZCzys3KYOpCFa+4dqX/Oub9tAq00ttGVs=
-golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/cluster/configuration/eks.go
+++ b/internal/cluster/configuration/eks.go
@@ -38,6 +38,8 @@ type EKSNodePool struct {
 	MinSize                 int                 `yaml:"minSize"`
 	MaxSize                 int                 `yaml:"maxSize"`
 	InstanceType            string              `yaml:"instanceType"`
+	OS                      string              `yaml:"os"`
+	TargetGroups            []string            `yaml:"targetGroups"`
 	MaxPods                 int                 `yaml:"maxPods"`
 	VolumeSize              int                 `yaml:"volumeSize"`
 	Labels                  map[string]string   `yaml:"labels"`

--- a/internal/cluster/configuration/gke.go
+++ b/internal/cluster/configuration/gke.go
@@ -29,6 +29,7 @@ type GKENodePool struct {
 	MinSize                 int                 `yaml:"minSize"`
 	MaxSize                 int                 `yaml:"maxSize"`
 	InstanceType            string              `yaml:"instanceType"`
+	OS                      string              `yaml:"os"`
 	MaxPods                 int                 `yaml:"maxPods"`
 	VolumeSize              int                 `yaml:"volumeSize"`
 	Labels                  map[string]string   `yaml:"labels"`

--- a/internal/cluster/provisioners/eks/provisioner.go
+++ b/internal/cluster/provisioners/eks/provisioner.go
@@ -163,6 +163,14 @@ func (e EKS) createVarFile() (err error) {
 			buffer.WriteString(fmt.Sprintf("min_size = %v\n", np.MinSize))
 			buffer.WriteString(fmt.Sprintf("max_size = %v\n", np.MaxSize))
 			buffer.WriteString(fmt.Sprintf("instance_type = \"%v\"\n", np.InstanceType))
+
+			if np.OS != "" {
+				buffer.WriteString(fmt.Sprintf("os = %v\n", np.OS))
+			}
+			if len(np.TargetGroups) > 0 {
+				buffer.WriteString(fmt.Sprintf("eks_target_group_arns = [\"%v\"]\n", strings.Join(np.TargetGroups, "\",\"")))
+			}
+
 			if np.MaxPods > 0 {
 				buffer.WriteString(fmt.Sprintf("max_pods = %v\n", np.MaxPods))
 			} else {

--- a/internal/cluster/provisioners/gke/provisioner.go
+++ b/internal/cluster/provisioners/gke/provisioner.go
@@ -126,6 +126,9 @@ func (e GKE) createVarFile() (err error) {
 			buffer.WriteString(fmt.Sprintf("min_size = %v\n", np.MinSize))
 			buffer.WriteString(fmt.Sprintf("max_size = %v\n", np.MaxSize))
 			buffer.WriteString(fmt.Sprintf("instance_type = \"%v\"\n", np.InstanceType))
+			if np.OS != "" {
+				buffer.WriteString(fmt.Sprintf("os = %v\n", np.OS))
+			}
 			buffer.WriteString(fmt.Sprintf("max_pods = %v\n", np.MaxPods))
 			buffer.WriteString(fmt.Sprintf("volume_size = %v\n", np.VolumeSize))
 			if len(np.SubNetworks) > 0 {

--- a/internal/configuration/assets/eks-cluster.yml
+++ b/internal/configuration/assets/eks-cluster.yml
@@ -30,6 +30,10 @@ spec:
       maxSize: 10
       instanceType: "m"
       maxPods: 100
+      os: "centos"
+      targetGroups:
+        - "t1"
+        - "t2"
       volumeSize: 50
       labels:
         hello: World

--- a/internal/configuration/config_test.go
+++ b/internal/configuration/config_test.go
@@ -66,6 +66,8 @@ func init() {
 				MaxSize:      10,
 				InstanceType: "m",
 				MaxPods:      100,
+				OS:           "centos",
+				TargetGroups: []string{"t1", "t2"},
 				VolumeSize:   50,
 				Labels: map[string]string{
 					"hello": "World",

--- a/internal/configuration/templates.go
+++ b/internal/configuration/templates.go
@@ -209,6 +209,7 @@ func clusterTemplate(config *Configuration) error {
 					MinSize:      1,
 					MaxSize:      1,
 					InstanceType: "n1-standard-1. Required. GCP instance types",
+					OS:           "COS # The operating system to use. Do not specify to use the default one (COS)",
 					MaxPods:      110,
 					VolumeSize:   50,
 					SubNetworks:  []string{"subnet-1", "# availability zones (example: us-central1-a) where to place the nodes. Useful to don't create them on all zones"},

--- a/internal/configuration/templates.go
+++ b/internal/configuration/templates.go
@@ -121,7 +121,7 @@ func clusterTemplate(config *Configuration) error {
 	switch {
 	case config.Provisioner == "eks":
 		spec := clustercfg.EKS{
-			Version:      "1.18 # EKS Control plane version",
+			Version:      "1.20 # EKS Control plane version",
 			Network:      "vpc-id1 # Identificator of the VPC",
 			SubNetworks:  []string{"subnet-id1 # Identificator of the subnets"},
 			DMZCIDRRange: clustercfg.DMZCIDRRange{Values: []string{"10.0.0.0/8", "Required. Network CIDR range from where cluster control plane will be accessible"}},
@@ -159,7 +159,9 @@ func clusterTemplate(config *Configuration) error {
 					Labels: map[string]string{
 						"environment": "dev. # Node labels. Use it to tag nodes then use it on Kubernetes",
 					},
-					Taints: []string{"key1=value1:NoSchedule. As an example"},
+					OS:           "ami-12345 # The ami-id to use. Do not specify to use the default one",
+					TargetGroups: []string{"target-12345", "the target-id to associate the instance to a loadbalancer"},
+					Taints:       []string{"key1=value1:NoSchedule. As an example"},
 					Tags: map[string]string{
 						"myTag": "MyValue # Use this tags to annotate nodepool resources. Optional",
 					},


### PR DESCRIPTION
This PR includes a couple of features (to be released) from the cloud-installers (eks, gke, aks).

- os: Specify the operating system to use on **eks** or **gke**.
- targetGroups: Specify the target group id to the instances of a node_pool so it can be linked to a different LB in **eks**.

I am marking this PR as WIP because first, the following PR has to be reviewed and merged:

- https://github.com/sighupio/fury-gke-installer/pull/20
- https://github.com/sighupio/fury-aks-installer/pull/9
- https://github.com/sighupio/fury-eks-installer/pull/25

In addition, I had to decouple the cluster destroy phase on vsphere because of the lack of stability in the environment. 

Pipeline seems to be working: https://ci.sighup.io/sighupio/furyctl/447/2/11 (e2e included)