### PR TITLE
[BUGFIX] don't delete Furyfile if wrong KFD --version tag is supplied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean: deps
 
 .PHONY: build
 ## build: Builds the solution for linux and macos amd64 
-build: deps clean test
+build: lint deps clean test
 	@GO111MODULE=on packr2 build
 	@GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -o bin/linux/$(version)/furyctl  .
 	@GO111MODULE=on CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -o bin/darwin/$(version)/furyctl .

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -72,7 +72,7 @@ func download(packages []Package) error {
 
 func get(src, dest string, mode getter.ClientMode, cleanGitFolder bool) error {
 
-	logrus.Debugf("complete url downloading: %s -> %s", src, dest)
+	logrus.Debugf("starting download process: %s -> %s", src, dest)
 
 	var tempDest = dest + ".tmp"
 
@@ -88,24 +88,21 @@ func get(src, dest string, mode getter.ClientMode, cleanGitFolder bool) error {
 		Mode: mode,
 	}
 
-	logrus.Debugf("let's get %s -> %s", src, dest)
+	logrus.Debugf("downloading temporary file: %s -> %s", src, tempDest)
 
 	humanReadableDownloadLog(src, dest)
+
+	err = removeDir(tempDest)
+	if err != nil {
+		logrus.Errorf("failed to remove: %s", tempDest)
+		return err
+	}
 
 	err = client.Get()
 	if err != nil {
 		_ = removeDir(tempDest)
 		return err
 	} else {
-		if _, err := os.Stat(dest); !os.IsNotExist(err) {
-			logrus.Infof("%s already exists! removing it", dest)
-			err = removeDir(dest)
-			if err != nil {
-				logrus.Error(err)
-				return err
-			}
-		}
-
 		err = renameDir(tempDest, dest)
 		if err != nil {
 			logrus.Error(err)
@@ -116,7 +113,7 @@ func get(src, dest string, mode getter.ClientMode, cleanGitFolder bool) error {
 
 	if cleanGitFolder {
 		gitFolder := fmt.Sprintf("%s/.git", dest)
-		logrus.Infof("removing %s", gitFolder)
+		logrus.Infof("cleaning git subfolder: %s", gitFolder)
 		err = removeDir(gitFolder)
 	}
 
@@ -125,7 +122,7 @@ func get(src, dest string, mode getter.ClientMode, cleanGitFolder bool) error {
 		return err
 	}
 
-	logrus.Debugf("done %s -> %s", src, dest)
+	logrus.Debugf("download process finished: %s -> %s", src, dest)
 
 	return err
 }
@@ -157,6 +154,14 @@ func removeDir(dir string) error {
 }
 
 func renameDir(src string, dest string) error {
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		logrus.Infof("removing target path: %s", dest)
+		err = removeDir(dest)
+		if err != nil {
+			logrus.Error(err)
+			return err
+		}
+	}
 	err := os.Rename(src, dest)
 	if err != nil {
 		return err

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -96,7 +96,7 @@ func get(src, dest string, mode getter.ClientMode, cleanGitFolder bool) error {
 	if err != nil {
 		_ = removeDir(tempDest)
 		return err
-	}else{
+	} else {
 		if _, err := os.Stat(dest); !os.IsNotExist(err) {
 			logrus.Infof("%s already exists! removing it", dest)
 			err = removeDir(dest)


### PR DESCRIPTION
In the event of a wrong supplied tag, furyctl removes the Furyfile.yml.