### PR TITLE
feat(template): load _helpers.tpl together with the template

### DIFF
--- a/internal/template/generator.go
+++ b/internal/template/generator.go
@@ -52,7 +52,6 @@ func (g *generator) ProcessTemplate() *template.Template {
 			template.New(filepath.Base(g.source)).Funcs(g.funcMap.FuncMap).ParseFiles(g.source))
 	} else {
 		logrus.Fatalf("got unexpected error when checking if helper file exists at path %s: %s\n", helpersPath, err)
-		panic(err)
 	}
 }
 

--- a/internal/template/model.go
+++ b/internal/template/model.go
@@ -164,7 +164,10 @@ func (tm *Model) applyTemplates(
 	}
 
 	if strings.HasSuffix(info.Name(), tm.Suffix) {
-		tmpl := gen.ProcessTemplate()
+		tmpl, err := gen.ProcessTemplate()
+		if err != nil {
+			return err
+		}
 
 		if tmpl == nil {
 			return fmt.Errorf("no template found for %s", relSource)


### PR DESCRIPTION
load a `_helpers.tpl` file if exists and load it together with the temlpate to be rendered, allowing to define helper functions in the template logic.

This allows for example to have common logic shared between template files, for example, e function to get the ingress class.

Please feel free to modify the code as you wish