### PR TITLE
fix(vendor): downgrade repository fallaback message to Info

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -126,7 +126,7 @@ func downloadProcess(wg *sync.WaitGroup, opts DownloadOpts, data Package, errCha
 			pU.Prefix = fallbackSshRepoPrefix
 		}
 
-		logrus.Warningf("error downloading %s, falling back to %s", o, humanReadableSource(pU.getConsumableURL()))
+		logrus.Infof("error downloading %s, falling back to %s", o, humanReadableSource(pU.getConsumableURL()))
 
 		downloadErr = get(pU.getConsumableURL(), data.Dir, getter.ClientModeDir, true)
 		if downloadErr != nil {


### PR DESCRIPTION
After seeing the reaction of a user that is not familiar with Fury on the WARN messages thrown by the fallback logic in the vendor command, I believe is better to downgrade them to INFO to avoid alarming the user unnecessary, at least until we decide to move on with the renaming.