### PR TITLE
fix: check if the current folder has the right write permissions

### DIFF
--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -5,9 +5,13 @@
 package cmd
 
 import (
+	"errors"
+	"os"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/sys/unix"
 )
 
 func init() {
@@ -61,6 +65,15 @@ var vendorCmd = &cobra.Command{
 			} else {
 				logrus.Infof("using %v for package %s", p.Version, p.Name)
 			}
+		}
+
+		pwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		if err := unix.Access(pwd, unix.W_OK); err != nil {
+			return errors.New("You don't have write permissions on the current directory.")
 		}
 
 		return Download(list, conf.DownloadOpts)


### PR DESCRIPTION
Running furyctl vendor -H inside a folder that the current user can't write to, shows absolutely no error and normal output but the vendor folder is nowhere to be found. So from now, furyctl check if the current folder has the right write permissions before to start the download process. 