### PR TITLE
Add EKS LogRetentionDays

### DIFF
--- a/internal/cluster/configuration/eks.go
+++ b/internal/cluster/configuration/eks.go
@@ -6,14 +6,15 @@ package configuration
 
 // EKS represents the configuration spec of a EKS Cluster
 type EKS struct {
-	Version      string            `yaml:"version"`
-	Network      string            `yaml:"network"`
-	SubNetworks  []string          `yaml:"subnetworks"`
-	DMZCIDRRange DMZCIDRRange      `yaml:"dmzCIDRRange"`
-	SSHPublicKey string            `yaml:"sshPublicKey"`
-	NodePools    []EKSNodePool     `yaml:"nodePools"`
-	Tags         map[string]string `yaml:"tags"`
-	Auth         EKSAuth           `yaml:"auth"`
+	Version          string            `yaml:"version"`
+	Network          string            `yaml:"network"`
+	SubNetworks      []string          `yaml:"subnetworks"`
+	DMZCIDRRange     DMZCIDRRange      `yaml:"dmzCIDRRange"`
+	SSHPublicKey     string            `yaml:"sshPublicKey"`
+	NodePools        []EKSNodePool     `yaml:"nodePools"`
+	Tags             map[string]string `yaml:"tags"`
+	Auth             EKSAuth           `yaml:"auth"`
+	LogRetentionDays int               `yaml:"logRetentionDays"`
 }
 
 // EKSAuth represent a auth structure

--- a/internal/cluster/provisioners/eks/provisioner.go
+++ b/internal/cluster/provisioners/eks/provisioner.go
@@ -107,6 +107,9 @@ func (e EKS) createVarFile() (err error) {
 	spec := e.config.Spec.(cfg.EKS)
 	buffer.WriteString(fmt.Sprintf("cluster_name = \"%v\"\n", e.config.Metadata.Name))
 	buffer.WriteString(fmt.Sprintf("cluster_version = \"%v\"\n", spec.Version))
+	if spec.LogRetentionDays != 0 {
+		buffer.WriteString(fmt.Sprintf("cluster_log_retention_in_days = %v\n", spec.LogRetentionDays))
+	}
 	buffer.WriteString(fmt.Sprintf("network = \"%v\"\n", spec.Network))
 	buffer.WriteString(fmt.Sprintf("subnetworks = [\"%v\"]\n", strings.Join(spec.SubNetworks, "\",\"")))
 	buffer.WriteString(fmt.Sprintf("dmz_cidr_range = [\"%v\"]\n", strings.Join(spec.DMZCIDRRange.Values, "\",\"")))

--- a/internal/configuration/assets/eks-cluster.yml
+++ b/internal/configuration/assets/eks-cluster.yml
@@ -16,6 +16,7 @@ executor:
 provisioner: eks
 spec:
   version: "1.18"
+  logRetentionDays: 30
   network: "vpc-1"
   subnetworks: 
     - "subnet-1"

--- a/internal/configuration/config_test.go
+++ b/internal/configuration/config_test.go
@@ -53,11 +53,12 @@ func init() {
 	}
 	sampleEKSConfig.Provisioner = "eks"
 	sampleEKSConfig.Spec = clustercfg.EKS{
-		Version:      "1.18",
-		Network:      "vpc-1",
-		SubNetworks:  []string{"subnet-1", "subnet-2", "subnet-3"},
-		DMZCIDRRange: clustercfg.DMZCIDRRange{Values: []string{"0.0.0.0/0"}},
-		SSHPublicKey: "123",
+		Version:          "1.18",
+		Network:          "vpc-1",
+		LogRetentionDays: 30,
+		SubNetworks:      []string{"subnet-1", "subnet-2", "subnet-3"},
+		DMZCIDRRange:     clustercfg.DMZCIDRRange{Values: []string{"0.0.0.0/0"}},
+		SSHPublicKey:     "123",
 		NodePools: []clustercfg.EKSNodePool{
 			{
 				Name:         "one",

--- a/internal/configuration/templates.go
+++ b/internal/configuration/templates.go
@@ -121,11 +121,12 @@ func clusterTemplate(config *Configuration) error {
 	switch {
 	case config.Provisioner == "eks":
 		spec := clustercfg.EKS{
-			Version:      "1.20 # EKS Control plane version",
-			Network:      "vpc-id1 # Identificator of the VPC",
-			SubNetworks:  []string{"subnet-id1 # Identificator of the subnets"},
-			DMZCIDRRange: clustercfg.DMZCIDRRange{Values: []string{"10.0.0.0/8", "Required. Network CIDR range from where cluster control plane will be accessible"}},
-			SSHPublicKey: "sha-rsa 190jd0132w. Required. Cluster administrator public ssh key. Used to access cluster nodes.",
+			Version:          "1.20 # EKS Control plane version",
+			Network:          "vpc-id1 # Identificator of the VPC",
+			LogRetentionDays: 30,
+			SubNetworks:      []string{"subnet-id1 # Identificator of the subnets"},
+			DMZCIDRRange:     clustercfg.DMZCIDRRange{Values: []string{"10.0.0.0/8", "Required. Network CIDR range from where cluster control plane will be accessible"}},
+			SSHPublicKey:     "sha-rsa 190jd0132w. Required. Cluster administrator public ssh key. Used to access cluster nodes.",
 			Tags: map[string]string{
 				"myTag": "MyValue # Use this tags to annotate all resources. Optional",
 			},


### PR DESCRIPTION
This change requires the following PR on `fury-eks-installer` to work: https://github.com/sighupio/fury-eks-installer/pull/40
Together, the two changes allow the user to (optionally) specify a custom log retention days number, like in the following snippet:
```
kind: Cluster
metadata:
  name: demo
provisioner: eks
spec:
  version: "1.22"
  logRetentionDays: 30
  network: "vpc-1"
...
```