### PR TITLE
feat!(eks): add support for EKS Installer v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can find `furyctl` binaries on the [Releases page](https://github.com/sighup
 To download the latest release, run:
 
 ```bash
-wget -q "https://github.com/sighupio/furyctl/releases/download/v0.8.0/furyctl-$(uname -s)-amd64" -O /tmp/furyctl
+wget -q "https://github.com/sighupio/furyctl/releases/download/v0.9.0/furyctl-$(uname -s)-amd64" -O /tmp/furyctl
 chmod +x /tmp/furyctl
 sudo mv /tmp/furyctl /usr/local/bin/furyctl
 ```
@@ -60,14 +60,13 @@ Check that everything is working correctly with `furyctl version`:
 
 ```bash
 furyctl version
-INFO[0000] Furyctl version 0.8.0
-INFO[0000] built 2022-09-13T16:52:19Z from commit b3c9df89803ed7a4fe4a05d6c3eb859cc00276b6
+INFO[0000] Furyctl version 0.9.0
 ```
 
 > 💡 **TIP**
 >
-> Enable autocompletion for `furyctl` cli on your shell (currently autocompletion is supported for `bash`, `zsh`, `fish`).
-> To see the instruction to enable it, run `furyctl completion -h`
+> Enable autocompletion for `furyctl` CLI on your shell (currently autocompletion is provided for `bash`, `zsh`, `fish`).
+> To see the instruction on how to enable it, run `furyctl completion -h`
 
 ## Usage
 
@@ -290,7 +289,7 @@ Before contributing, please read first the [Contributing Guidelines](docs/CONTRI
 
 ### Reporting Issues
 
-In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/furyctl/issues/new/choose).
+In case you experience any problems, please [open a new issue](https://github.com/sighupio/furyctl/issues/new/choose).
 
 ## License
 

--- a/automated-tests/e2e-tests/aws-eks/cluster.tpl.yml
+++ b/automated-tests/e2e-tests/aws-eks/cluster.tpl.yml
@@ -11,6 +11,7 @@ spec:
   subnetworks: ${PRIVATE_SUBNETS}
   dmzCIDRRange: ${NETWORK_CIDR}
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCjjHeHnfhplyak6p+HaDnl7Vz8knFjUfgpvtx2FzfrzVmNWh7EuBWrisYeh/vwCFvluOQtt5/J56Gu+N5q70XAEeuh1COeeYlRm0EHZtm0dAM7PCvZ4Ga20PYWGJAGWiKo3g+jh2AexEXw+t6O9qvTy1G2OQ7uOGBfu+fa4tpBpGpHI0IrdwVJ6m1sd08ghmyjvWeIlxOwIF2SCcQqFosUngrvVieemEeojRRc7sedqUrehLEOX8udF+vLV8cRvzUMqrpmyLnEBRtcFzOhKMKiE+xlk9IKKWnMXYDhXlj4AFDQ19Yii2Z9uRUMVr/YVpDNvR7lBZo+EvRg0w5w9u9
+  nodePoolsLaunchKind: "launch_templates"
   nodePools:
     - name: my-node-pool
       minSize: 1

--- a/automated-tests/integration/aws-eks/cluster.yml
+++ b/automated-tests/integration/aws-eks/cluster.yml
@@ -13,6 +13,7 @@ spec:
   - subnet-tobedefined-1
   dmzCIDRRange: 10.0.0.0/16
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCefFo9ASM8grncpLpJr+DAeGzTtoIaxnqSqrPeSWlCyManFz5M/DDkbnql8PdrENFU28blZyIxu93d5U0RhXZumXk1utpe0L/9UtImnOGG6/dKv9fV9vcJH45XdD3rCV21ZMG1nuhxlN0DftcuUubt/VcHXflBGaLrs18DrMuHVIbyb5WO4wQ9Od/SoJZyR6CZmIEqag6ADx4aFcdsUwK1Cpc51LhPbkdXGGjipiwP45q0I6/Brjxv/Kia1e+RmIRHiltsVBdKKTL9hqu9esbAod9I5BkBtbB5bmhQUVFZehi+d/opPvsIszE/coW5r/g/EVf9zZswebFPcsNr85+x
+  nodePoolsLaunchKind: "launch_templates"
   nodePools:
   - name: my-node-pool
     minSize: 1

--- a/data/provisioners/bootstrap/aws/main.tf
+++ b/data/provisioners/bootstrap/aws/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+ * Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -15,7 +15,7 @@ terraform {
 }
 
 module "vpc-and-vpn" {
-  source = "github.com/sighupio/fury-eks-installer//modules/vpc-and-vpn?ref=v1.9.1"
+  source = "github.com/sighupio/fury-eks-installer//modules/vpc-and-vpn?ref=v1.10.0"
 
   name                     = var.name
   network_cidr             = var.network_cidr

--- a/data/provisioners/cluster/eks/main.tf
+++ b/data/provisioners/cluster/eks/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+ * Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -18,16 +18,18 @@ terraform {
 }
 
 module "fury" {
-  source = "github.com/sighupio/fury-eks-installer//modules/eks?ref=v1.9.0"
+  source = "github.com/sighupio/fury-eks-installer//modules/eks?ref=v1.10.0"
 
-  cluster_name    = var.cluster_name
-  cluster_version = var.cluster_version
-  network         = var.network
-  subnetworks     = var.subnetworks
-  dmz_cidr_range  = var.dmz_cidr_range
-  ssh_public_key  = var.ssh_public_key
-  node_pools      = var.node_pools
-  tags            = var.tags
+  cluster_name               = var.cluster_name
+  cluster_version            = var.cluster_version
+  cluster_log_retention_days = var.cluster_log_retention_days
+  network                    = var.network
+  subnetworks                = var.subnetworks
+  dmz_cidr_range             = var.dmz_cidr_range
+  ssh_public_key             = var.ssh_public_key
+  node_pools                 = var.node_pools
+  node_pools_launch_kind     = var.node_pools_launch_kind
+  tags                       = var.tags
 
   # Specific AWS variables.
   # Enables managing auth using these variables

--- a/data/provisioners/cluster/eks/output.tf
+++ b/data/provisioners/cluster/eks/output.tf
@@ -55,7 +55,7 @@ users:
 - name: aws-${var.cluster_name}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: aws
       args:
         - "eks"

--- a/data/provisioners/cluster/eks/variables.tf
+++ b/data/provisioners/cluster/eks/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+ * Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
@@ -14,6 +14,10 @@ variable "cluster_version" {
   description = "Kubernetes Cluster Version. Look at the cloud providers documentation to discover available versions. EKS example -> 1.16, GKE example -> 1.16.8-gke.9"
 }
 
+variable "cluster_log_retention_days" {
+  type = number
+  default = 90
+}
 variable "network" {
   type        = string
   description = "Network where the Kubernetes cluster will be hosted"
@@ -60,6 +64,11 @@ variable "node_pools" {
     }))
   }))
   default = []
+}
+
+variable "node_pools_launch_kind" {
+  type = string
+  description = "Choose if the node pools will use launch_configurations, launch_templates or both"
 }
 
 variable "tags" {

--- a/internal/cluster/configuration/eks.go
+++ b/internal/cluster/configuration/eks.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -6,15 +6,16 @@ package configuration
 
 // EKS represents the configuration spec of a EKS Cluster
 type EKS struct {
-	Version          string            `yaml:"version"`
-	Network          string            `yaml:"network"`
-	SubNetworks      []string          `yaml:"subnetworks"`
-	DMZCIDRRange     DMZCIDRRange      `yaml:"dmzCIDRRange"`
-	SSHPublicKey     string            `yaml:"sshPublicKey"`
-	NodePools        []EKSNodePool     `yaml:"nodePools"`
-	Tags             map[string]string `yaml:"tags"`
-	Auth             EKSAuth           `yaml:"auth"`
-	LogRetentionDays int               `yaml:"logRetentionDays"`
+	Version             string            `yaml:"version"`
+	Network             string            `yaml:"network"`
+	SubNetworks         []string          `yaml:"subnetworks"`
+	DMZCIDRRange        DMZCIDRRange      `yaml:"dmzCIDRRange"`
+	SSHPublicKey        string            `yaml:"sshPublicKey"`
+	NodePools           []EKSNodePool     `yaml:"nodePools"`
+	NodePoolsLaunchKind string            `yaml:"nodePoolsLaunchKind"`
+	Tags                map[string]string `yaml:"tags"`
+	Auth                EKSAuth           `yaml:"auth"`
+	LogRetentionDays    int               `yaml:"logRetentionDays"`
 }
 
 // EKSAuth represent a auth structure

--- a/internal/cluster/provisioners/eks/provisioner.go
+++ b/internal/cluster/provisioners/eks/provisioner.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -22,12 +22,12 @@ import (
 
 // InitMessage return a custom provisioner message the user will see once the cluster is ready to be updated
 func (e *EKS) InitMessage() string {
-	return `[EKS] Fury
+	return `Kubernetes Fury EKS
 
-This provisioner creates a battle-tested AWS EKS Kubernetes Cluster
-with a private and production-grade setup.
+This provisioner creates a battle-tested Kubernetes Fury Cluster based on AWS EKS
+with a private control plane and a production-grade setup.
 
-Requires to connect to a VPN server to deploy the cluster from this computer.
+Requires network connectivity to the target VPC (like a VPN connection) to deploy the cluster.
 Use a bastion host (inside the EKS VPC) as an alternative method to deploy the cluster.
 
 The provisioner requires the following software installed:
@@ -55,22 +55,24 @@ func (e *EKS) UpdateMessage() string {
 		log.Error("Can not get `operator_ssh_user` value")
 	}
 	return fmt.Sprintf(
-		`[EKS] Fury
+		`Kubernetes Fury EKS
 
 All the cluster components are up to date.
-EKS Kubernetes cluster ready.
+
+Kubernetes Fury EKS cluster is ready.
 
 EKS Cluster Endpoint: %v
 SSH Operator Name: %v
 
 Use the ssh %v username to access the EKS instances with the configured SSH key.
+
 Discover the instances by running
 
 $ kubectl get nodes
 
-Then access by running:
+Then access them by running:
 
-$ ssh %v@node-name-reported-by-kubectl-get-nodes
+$ ssh %v@<node-name-reported-by-kubectl-get-nodes>
 
 `, clusterEndpoint, clusterOperatorName, clusterOperatorName, clusterOperatorName,
 	)
@@ -78,11 +80,13 @@ $ ssh %v@node-name-reported-by-kubectl-get-nodes
 
 // DestroyMessage return a custom provisioner message the user will see once the cluster is destroyed
 func (e *EKS) DestroyMessage() string {
-	return `[EKS] Fury
+	return `Kubernetes Fury EKS
+
 All cluster components were destroyed.
+
 EKS control plane and workers went away.
 
-Had problems, contact us at sales@sighup.io.
+If you faced any problems, please contact support if you have a subscription or write us to sales@sighup.io.
 `
 }
 
@@ -108,7 +112,7 @@ func (e EKS) createVarFile() (err error) {
 	buffer.WriteString(fmt.Sprintf("cluster_name = \"%v\"\n", e.config.Metadata.Name))
 	buffer.WriteString(fmt.Sprintf("cluster_version = \"%v\"\n", spec.Version))
 	if spec.LogRetentionDays != 0 {
-		buffer.WriteString(fmt.Sprintf("cluster_log_retention_in_days = %v\n", spec.LogRetentionDays))
+		buffer.WriteString(fmt.Sprintf("cluster_log_retention_days = %v\n", spec.LogRetentionDays))
 	}
 	buffer.WriteString(fmt.Sprintf("network = \"%v\"\n", spec.Network))
 	buffer.WriteString(fmt.Sprintf("subnetworks = [\"%v\"]\n", strings.Join(spec.SubNetworks, "\",\"")))
@@ -265,6 +269,15 @@ func (e EKS) createVarFile() (err error) {
 		}
 		buffer.WriteString("]\n")
 	}
+	// For this version we will check for this field value to be present, otherwise we could trigger an unwanted rollout of the node pools for existing clusters.
+	// The switch from launch configurations to launch templates for the Node Pools requires some manual intervention.
+	// We could automate this away though.
+	if spec.NodePoolsLaunchKind == "" {
+		// I know, sorry for the length 
+		log.Fatalf(".spec.nodePoolsKind is not set in the cluster configuration file. Please set it explicitly to `launch_configurations`, `launch_templates` or `both` to avoid unwanted node pools rollouts. For new clusters you can use `launch_templates`, for existing clusters please check the Fury EKS Installer docs: https://github.com/sighupio/fury-eks-installer/blob/master/docs/upgrades/v1.9-to-v1.10.0.md")
+	} else {
+		buffer.WriteString(fmt.Sprintf("node_pools_launch_kind = \"%v\"\n", spec.NodePoolsLaunchKind))
+	}
 	err = ioutil.WriteFile(fmt.Sprintf("%v/eks.tfvars", e.terraform.WorkingDir()), buffer.Bytes(), 0600)
 	if err != nil {
 		return err
@@ -331,11 +344,11 @@ func (e EKS) Plan() (err error) {
 		tfexec.VarFile(fmt.Sprintf("%v/eks.tfvars", e.terraform.WorkingDir())),
 	)
 	if err != nil {
-		log.Fatalf("[DRYRUN] Something went wrong while updating eks. %v", err)
+		log.Fatalf("[DRYRUN] Got error while updating EKS: %v", err)
 		return err
 	}
 	if changes {
-		log.Warn("[DRYRUN] Something changed along the time. Remove dryrun option to apply the desired state")
+		log.Warn("[DRYRUN] Something has changed in the mean time. Remove --dry-run flag to apply the desired state")
 	} else {
 		log.Info("[DRYRUN] Everything is up to date")
 	}
@@ -356,7 +369,7 @@ func (e EKS) Update() (string, error) {
 		tfexec.VarFile(fmt.Sprintf("%v/eks.tfvars", e.terraform.WorkingDir())),
 	)
 	if err != nil {
-		log.Fatalf("Something went wrong while updating eks. %v", err)
+		log.Fatalf("Got error while updating EKS: %v", err)
 		return "", err
 	}
 
@@ -376,7 +389,7 @@ func (e EKS) Destroy() (err error) {
 		tfexec.VarFile(fmt.Sprintf("%v/eks.tfvars", e.terraform.WorkingDir())),
 	)
 	if err != nil {
-		log.Fatalf("Something went wrong while destroying EKS cluster project. %v", err)
+		log.Fatalf("Got error while destroying EKS cluster project: %v", err)
 		return err
 	}
 	log.Info("EKS destroyed")

--- a/internal/cluster/provisioners/eks/provisioner.go
+++ b/internal/cluster/provisioners/eks/provisioner.go
@@ -273,7 +273,6 @@ func (e EKS) createVarFile() (err error) {
 	// The switch from launch configurations to launch templates for the Node Pools requires some manual intervention.
 	// We could automate this away though.
 	if spec.NodePoolsLaunchKind == "" {
-		// I know, sorry for the length 
 		log.Fatalf(".spec.nodePoolsKind is not set in the cluster configuration file. Please set it explicitly to `launch_configurations`, `launch_templates` or `both` to avoid unwanted node pools rollouts. For new clusters you can use `launch_templates`, for existing clusters please check the Fury EKS Installer docs: https://github.com/sighupio/fury-eks-installer/blob/master/docs/upgrades/v1.9-to-v1.10.0.md")
 	} else {
 		buffer.WriteString(fmt.Sprintf("node_pools_launch_kind = \"%v\"\n", spec.NodePoolsLaunchKind))

--- a/internal/configuration/assets/eks-cluster.yml
+++ b/internal/configuration/assets/eks-cluster.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -24,6 +24,7 @@ spec:
     - "subnet-3"
   dmzCIDRRange: "0.0.0.0/0"
   sshPublicKey: "123"
+  nodePoolsLaunchKind: "launch_template"
   nodePools:
     - name: "one"
       version: "1.18"

--- a/internal/configuration/config_test.go
+++ b/internal/configuration/config_test.go
@@ -53,12 +53,13 @@ func init() {
 	}
 	sampleEKSConfig.Provisioner = "eks"
 	sampleEKSConfig.Spec = clustercfg.EKS{
-		Version:          "1.18",
-		Network:          "vpc-1",
-		LogRetentionDays: 30,
-		SubNetworks:      []string{"subnet-1", "subnet-2", "subnet-3"},
-		DMZCIDRRange:     clustercfg.DMZCIDRRange{Values: []string{"0.0.0.0/0"}},
-		SSHPublicKey:     "123",
+		Version:             "1.18",
+		Network:             "vpc-1",
+		LogRetentionDays:    30,
+		SubNetworks:         []string{"subnet-1", "subnet-2", "subnet-3"},
+		DMZCIDRRange:        clustercfg.DMZCIDRRange{Values: []string{"0.0.0.0/0"}},
+		SSHPublicKey:        "123",
+		NodePoolsLaunchKind: "launch_template",
 		NodePools: []clustercfg.EKSNodePool{
 			{
 				Name:         "one",

--- a/internal/configuration/templates.go
+++ b/internal/configuration/templates.go
@@ -147,6 +147,7 @@ func clusterTemplate(config *Configuration) error {
 					},
 				},
 			},
+			NodePoolsLaunchKind: "# either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.",
 			NodePools: []clustercfg.EKSNodePool{
 				{
 					Name:         "my-node-pool. Required. Name of the node pool",


### PR DESCRIPTION
- add missing mappings for EKS  ClusterLogRetentionDays parameter
- expose new parameter for EKS NodePoolsLaunchKind
- Enforce that NodePoolsLaunchKind is set and not defaulted to avoid node pools rollouts
- improve EKS cluster console messages
- update test to consider the new parameters
- update docs to prepare for releasing v0.9.0
- fix Kubeconfig generation. v1alpha1 is deprecated.

BREAKING CHANGE: there are two 2 parameters in the configuration file, ClusterLogRotationDays can be left as default in most cases, but users need to set explicitly the new NodePoolsLaunchKind parameter, because migrating to the new kind requires a rollout of all the existing node pools.