### PR TITLE
Feature/first wave adjustments

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
       - curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$${GLIBC_VER}/glibc-$${GLIBC_VER}.apk
       - curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$${GLIBC_VER}/glibc-bin-$${GLIBC_VER}.apk
       - curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$${GLIBC_VER}/glibc-i18n-$${GLIBC_VER}.apk
-      - apk add --virtual --force-overwrite .glibc glibc-$${GLIBC_VER}.apk glibc-bin-$${GLIBC_VER}.apk glibc-i18n-$${GLIBC_VER}.apk
+      - apk add --force-overwrite --virtual .glibc glibc-$${GLIBC_VER}.apk glibc-bin-$${GLIBC_VER}.apk glibc-i18n-$${GLIBC_VER}.apk
       - /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8
       - curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-$${AWSCLI_VERSION}.zip -o awscliv2.zip
       - unzip awscliv2.zip

--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
       - curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$${GLIBC_VER}/glibc-$${GLIBC_VER}.apk
       - curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$${GLIBC_VER}/glibc-bin-$${GLIBC_VER}.apk
       - curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$${GLIBC_VER}/glibc-i18n-$${GLIBC_VER}.apk
-      - apk add --virtual .glibc glibc-$${GLIBC_VER}.apk glibc-bin-$${GLIBC_VER}.apk glibc-i18n-$${GLIBC_VER}.apk
+      - apk add --virtual --force-overwrite .glibc glibc-$${GLIBC_VER}.apk glibc-bin-$${GLIBC_VER}.apk glibc-i18n-$${GLIBC_VER}.apk
       - /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8
       - curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-$${AWSCLI_VERSION}.zip -o awscliv2.zip
       - unzip awscliv2.zip

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ name: main
 
 steps:
   - name: prepare
-    image: quay.io/sighup/golang:1.19.1
+    image: quay.io/sighup/golang:1.19.4
     depends_on:
       - clone
     pull: always
@@ -17,7 +17,7 @@ steps:
       - go mod download
 
   - name: license
-    image: quay.io/sighup/golang:1.19.1
+    image: quay.io/sighup/golang:1.19.4
     depends_on:
       - clone
     pull: always
@@ -30,7 +30,7 @@ steps:
       GOTMPDIR: /drone/src/.go/tmp
 
   - name: lint
-    image: quay.io/sighup/golang:1.19.1
+    image: quay.io/sighup/golang:1.19.4
     depends_on:
       - prepare
     pull: always
@@ -43,7 +43,7 @@ steps:
       GOTMPDIR: /drone/src/.go/tmp
 
   - name: test-unit
-    image: quay.io/sighup/golang:1.19.1
+    image: quay.io/sighup/golang:1.19.4
     depends_on:
       - prepare
     pull: always
@@ -56,7 +56,7 @@ steps:
       GOTMPDIR: /drone/src/.go/tmp
 
   - name: test-integration
-    image: quay.io/sighup/golang:1.19.1
+    image: quay.io/sighup/golang:1.19.4
     depends_on:
       - prepare
     commands:
@@ -71,7 +71,7 @@ steps:
         from_secret: NETRC_FILE
 
   - name: test-e2e
-    image: quay.io/sighup/golang:1.19.1
+    image: quay.io/sighup/golang:1.19.4
     depends_on:
       - prepare
     commands:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 _PROJECT_DIRECTORY = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-_GOLANG_IMAGE = golang:1.19.1
+_GOLANG_IMAGE = golang:1.19.4
 _PROJECTNAME = furyctl
 _GOARCH = "amd64"
 _BIN_OPEN = "open"

--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -173,17 +173,22 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 				vpnAutoConnect = true
 			}
 
+			// Define cluster creation paths.
+			paths := cluster.CreatorPaths{
+				ConfigPath: furyctlPath,
+				WorkDir:    basePath,
+				DistroPath: res.RepoPath,
+				BinPath:    binPath,
+				Kubeconfig: kubeconfig,
+			}
+
 			// Create the cluster.
 			clusterCreator, err := cluster.NewCreator(
 				res.MinimalConf,
 				res.DistroManifest,
-				basePath,
-				res.RepoPath,
-				binPath,
-				furyctlPath,
+				paths,
 				phase,
 				vpnAutoConnect,
-				kubeconfig,
 			)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)

--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -70,6 +70,19 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("error while getting current working directory: %w", err)
 			}
 
+			// Check if kubeconfig is needed.
+			if flags.Phase == "distribution" || flags.SkipPhase == "kubernetes" {
+				if flags.Kubeconfig == "" {
+					kubeconfigFromEnv := os.Getenv("KUBECONFIG")
+
+					if kubeconfigFromEnv == "" {
+						return ErrKubeconfigReq
+					}
+
+					logrus.Warnf("Missing --kubeconfig flag, fallback to KUBECONFIG from environment: %s", kubeconfigFromEnv)
+				}
+			}
+
 			if flags.BinPath == "" {
 				flags.BinPath = filepath.Join(homeDir, ".furyctl", "bin")
 			}
@@ -139,19 +152,6 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 			// Auto connect to the VPN if doing complete cluster creation or skipping distribution phase.
 			if flags.Phase == "" || flags.SkipPhase == "distribution" {
 				flags.VpnAutoConnect = true
-			}
-
-			// Check if kubeconfig is needed.
-			if flags.Phase == "distribution" || flags.SkipPhase == "kubernetes" {
-				if flags.Kubeconfig == "" {
-					kubeconfigFromEnv := os.Getenv("KUBECONFIG")
-
-					if kubeconfigFromEnv == "" {
-						return ErrKubeconfigReq
-					}
-
-					logrus.Warnf("Missing --kubeconfig flag, fallback to KUBECONFIG from environment: %s", kubeconfigFromEnv)
-				}
 			}
 
 			// Define cluster creation paths.

--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -27,8 +27,8 @@ import (
 
 var (
 	ErrParsingFlag                = errors.New("error while parsing flag")
-	ErrDownloadDependenciesFailed = errors.New("download dependencies failed")
-	ErrKubeconfigReq              = errors.New("$KUBECONFIG is not set, so --kubeconfig is required when doing distribution phase alone")
+	ErrDownloadDependenciesFailed = errors.New("dependencies download failed")
+	ErrKubeconfigReq              = errors.New("when running distribution phase alone, either the KUBECONFIG environment variable or the --kubeconfig flag should be set")
 )
 
 type ClusterCmdFlags struct {
@@ -79,7 +79,7 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 						return ErrKubeconfigReq
 					}
 
-					logrus.Warnf("Missing --kubeconfig flag, fallback to KUBECONFIG from environment: %s", kubeconfigFromEnv)
+					logrus.Infof("Missing --kubeconfig flag, fallback to KUBECONFIG from environment: %s", kubeconfigFromEnv)
 				}
 			}
 
@@ -336,12 +336,12 @@ func setupClusterCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(
 		"vpn-auto-connect",
 		false,
-		"Automatically connect to the VPN after the infrastructure phase",
+		"When set will automatically connect to the created VPN in the infrastructure phase",
 	)
 
 	cmd.Flags().String(
 		"kubeconfig",
 		"",
-		"Path to the kubeconfig file, mandatory if you want to run the distribution phase and $KUBECONFIG is not set",
+		"Path to the kubeconfig file, mandatory if you want to run the distribution phase and the KUBECONFIG environment variable is not set",
 	)
 }

--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -88,6 +88,11 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("%w: %s", ErrParsingFlag, "skip-deps-validation")
 			}
 
+			kubeconfig, err := cmdutil.StringFlag(cmd, "kubeconfig", tracker, cmdEvent)
+			if err != nil {
+				return fmt.Errorf("%w: %s", ErrParsingFlag, "kubeconfig")
+			}
+
 			// Init paths.
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
@@ -163,6 +168,7 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 				}
 			}
 
+			// Auto connect to the VPN if doing complete cluster creation or skipping distribution phase.
 			if phase == "" || skipPhase == "distribution" {
 				vpnAutoConnect = true
 			}
@@ -177,6 +183,7 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 				furyctlPath,
 				phase,
 				vpnAutoConnect,
+				kubeconfig,
 			)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
@@ -276,5 +283,11 @@ func setupClusterCmdFlags(cmd *cobra.Command) {
 		"vpn-auto-connect",
 		false,
 		"Automatically connect to the VPN after the infrastructure phase",
+	)
+
+	cmd.Flags().String(
+		"kubeconfig",
+		"",
+		"Path to the kubeconfig file",
 	)
 }

--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -79,7 +79,7 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 						return ErrKubeconfigReq
 					}
 
-					logrus.Infof("Missing --kubeconfig flag, fallback to KUBECONFIG from environment: %s", kubeconfigFromEnv)
+					logrus.Warnf("Missing --kubeconfig flag, falling back to KUBECONFIG from environment: %s", kubeconfigFromEnv)
 				}
 			}
 

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -91,7 +91,7 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 						return ErrKubeconfigReq
 					}
 
-					logrus.Warnf("Missing --kubeconfig flag, fallback to KUBECONFIG from environment: %s", kubeconfigFromEnv)
+					logrus.Infof("Missing --kubeconfig flag, fallback to KUBECONFIG from environment: %s", kubeconfigFromEnv)
 				}
 			}
 

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	ErrParsingFlag   = errors.New("error while parsing flag")
-	ErrKubeconfigReq = errors.New("$KUBECONFIG is not set, so --kubeconfig is required when doing distribution phase")
+	ErrKubeconfigReq = errors.New("when running distribution phase, either the KUBECONFIG environment variable or the --kubeconfig flag should be set")
 )
 
 func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -230,7 +230,7 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 		"kubeconfig",
 		"",
 		"Path to the kubeconfig file, mandatory if you want to run the distribution phase alone or "+
-			"if you want to delete a cluster and $KUBECONFIG is not set",
+			"if you want to delete a cluster and the KUBECONFIG environment variable is not set",
 	)
 
 	return cmd

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -68,6 +68,11 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("%w: force", ErrParsingFlag)
 			}
 
+			kubeconfig, err := cmdutil.StringFlag(cmd, "kubeconfig", tracker, cmdEvent)
+			if err != nil {
+				return fmt.Errorf("%w: %s", ErrParsingFlag, "kubeconfig")
+			}
+
 			// Init paths.
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
@@ -108,7 +113,14 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("error while validating dependencies: %w", err)
 			}
 
-			clusterDeleter, err := cluster.NewDeleter(res.MinimalConf, res.DistroManifest, phase, basePath, binPath)
+			clusterDeleter, err := cluster.NewDeleter(
+				res.MinimalConf,
+				res.DistroManifest,
+				phase,
+				basePath,
+				binPath,
+				kubeconfig,
+			)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
@@ -196,6 +208,12 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 		"force",
 		false,
 		"Force deletion of the cluster",
+	)
+
+	cmd.Flags().String(
+		"kubeconfig",
+		"",
+		"Path to the kubeconfig file",
 	)
 
 	return cmd

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -91,7 +91,7 @@ func NewClusterCmd(version string, tracker *analytics.Tracker) *cobra.Command {
 						return ErrKubeconfigReq
 					}
 
-					logrus.Infof("Missing --kubeconfig flag, fallback to KUBECONFIG from environment: %s", kubeconfigFromEnv)
+					logrus.Warnf("Missing --kubeconfig flag, falling back to KUBECONFIG from environment: %s", kubeconfigFromEnv)
 				}
 			}
 

--- a/internal/apis/kfd/v1alpha2/eks/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/distribution.go
@@ -69,6 +69,7 @@ func NewDistribution(
 	infraOutputsPath,
 	binPath string,
 	dryRun bool,
+	kubeconfig string,
 ) (*Distribution, error) {
 	distroDir := path.Join(workDir, "distribution")
 
@@ -104,8 +105,9 @@ func NewDistribution(
 		kubeRunner: kubectl.NewRunner(
 			execx.NewStdExecutor(),
 			kubectl.Paths{
-				Kubectl: phase.KubectlPath,
-				WorkDir: path.Join(phase.Path, "manifests"),
+				Kubectl:    phase.KubectlPath,
+				WorkDir:    path.Join(phase.Path, "manifests"),
+				Kubeconfig: kubeconfig,
 			},
 			true,
 			true,

--- a/internal/apis/kfd/v1alpha2/eks/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/distribution.go
@@ -61,19 +61,15 @@ type injectType struct {
 }
 
 func NewDistribution(
-	furyctlConfPath string,
+	paths cluster.CreatorPaths,
 	furyctlConf schema.EksclusterKfdV1Alpha2,
 	kfdManifest config.KFD,
-	workDir,
-	distroPath,
-	infraOutputsPath,
-	binPath string,
+	infraOutputsPath string,
 	dryRun bool,
-	kubeconfig string,
 ) (*Distribution, error) {
-	distroDir := path.Join(workDir, "distribution")
+	distroDir := path.Join(paths.WorkDir, "distribution")
 
-	phase, err := cluster.NewOperationPhase(distroDir, kfdManifest.Tools, binPath)
+	phase, err := cluster.NewOperationPhase(distroDir, kfdManifest.Tools, paths.BinPath)
 	if err != nil {
 		return nil, fmt.Errorf("error creating distribution phase: %w", err)
 	}
@@ -83,8 +79,8 @@ func NewDistribution(
 		furyctlConf:      furyctlConf,
 		kfdManifest:      kfdManifest,
 		infraOutputsPath: infraOutputsPath,
-		distroPath:       distroPath,
-		furyctlConfPath:  furyctlConfPath,
+		distroPath:       paths.DistroPath,
+		furyctlConfPath:  paths.ConfigPath,
 		tfRunner: terraform.NewRunner(
 			execx.NewStdExecutor(),
 			terraform.Paths{
@@ -107,7 +103,7 @@ func NewDistribution(
 			kubectl.Paths{
 				Kubectl:    phase.KubectlPath,
 				WorkDir:    path.Join(phase.Path, "manifests"),
-				Kubeconfig: kubeconfig,
+				Kubeconfig: paths.Kubeconfig,
 			},
 			true,
 			true,

--- a/internal/apis/kfd/v1alpha2/eks/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/infrastructure.go
@@ -51,13 +51,12 @@ type Infrastructure struct {
 func NewInfrastructure(
 	furyctlConf schema.EksclusterKfdV1Alpha2,
 	kfdManifest config.KFD,
-	workDir,
-	binPath string,
+	paths cluster.CreatorPaths,
 	dryRun bool,
 ) (*Infrastructure, error) {
-	infraDir := path.Join(workDir, "infrastructure")
+	infraDir := path.Join(paths.WorkDir, "infrastructure")
 
-	phase, err := cluster.NewOperationPhase(infraDir, kfdManifest.Tools, binPath)
+	phase, err := cluster.NewOperationPhase(infraDir, kfdManifest.Tools, paths.BinPath)
 	if err != nil {
 		return nil, fmt.Errorf("error creating infrastructure phase: %w", err)
 	}
@@ -79,7 +78,7 @@ func NewInfrastructure(
 			},
 		),
 		faRunner: furyagent.NewRunner(executor, furyagent.Paths{
-			Furyagent: path.Join(binPath, "furyagent", kfdManifest.Tools.Common.Furyagent.Version, "furyagent"),
+			Furyagent: path.Join(paths.BinPath, "furyagent", kfdManifest.Tools.Common.Furyagent.Version, "furyagent"),
 			WorkDir:   phase.SecretsPath,
 		}),
 		ovRunner: openvpn.NewRunner(executor, openvpn.Paths{

--- a/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
@@ -54,14 +54,13 @@ type Kubernetes struct {
 func NewKubernetes(
 	furyctlConf schema.EksclusterKfdV1Alpha2,
 	kfdManifest config.KFD,
-	workDir,
-	infraOutputsPath,
-	binPath string,
+	infraOutputsPath string,
+	paths cluster.CreatorPaths,
 	dryRun bool,
 ) (*Kubernetes, error) {
-	kubeDir := path.Join(workDir, "kubernetes")
+	kubeDir := path.Join(paths.WorkDir, "kubernetes")
 
-	phase, err := cluster.NewOperationPhase(kubeDir, kfdManifest.Tools, binPath)
+	phase, err := cluster.NewOperationPhase(kubeDir, kfdManifest.Tools, paths.BinPath)
 	if err != nil {
 		return nil, fmt.Errorf("error creating kubernetes phase: %w", err)
 	}

--- a/internal/apis/kfd/v1alpha2/eks/creator.go
+++ b/internal/apis/kfd/v1alpha2/eks/creator.go
@@ -18,15 +18,11 @@ import (
 var ErrUnsupportedPhase = errors.New("unsupported phase")
 
 type ClusterCreator struct {
-	configPath     string
-	workDir        string
+	paths          cluster.CreatorPaths
 	furyctlConf    schema.EksclusterKfdV1Alpha2
 	kfdManifest    config.KFD
-	distroPath     string
-	binPath        string
 	phase          string
 	vpnAutoConnect bool
-	kubeconfig     string
 }
 
 func (v *ClusterCreator) SetProperties(props []cluster.CreatorProperty) {
@@ -41,7 +37,7 @@ func (v *ClusterCreator) SetProperty(name string, value any) {
 	switch lcName {
 	case cluster.CreatorPropertyConfigPath:
 		if s, ok := value.(string); ok {
-			v.configPath = s
+			v.paths.ConfigPath = s
 		}
 
 	case cluster.CreatorPropertyFuryctlConf:
@@ -66,47 +62,50 @@ func (v *ClusterCreator) SetProperty(name string, value any) {
 
 	case cluster.CreatorPropertyDistroPath:
 		if s, ok := value.(string); ok {
-			v.distroPath = s
+			v.paths.DistroPath = s
 		}
 
 	case cluster.CreatorPropertyWorkDir:
 		if s, ok := value.(string); ok {
-			v.workDir = s
+			v.paths.WorkDir = s
 		}
 
 	case cluster.CreatorPropertyBinPath:
 		if s, ok := value.(string); ok {
-			v.binPath = s
+			v.paths.BinPath = s
 		}
 
 	case cluster.CreatorPropertyKubeconfig:
 		if s, ok := value.(string); ok {
-			v.kubeconfig = s
+			v.paths.Kubeconfig = s
 		}
 	}
 }
 
 func (v *ClusterCreator) Create(dryRun bool, skipPhase string) error {
-	infra, err := create.NewInfrastructure(v.furyctlConf, v.kfdManifest, v.workDir, v.binPath, dryRun)
+	infra, err := create.NewInfrastructure(v.furyctlConf, v.kfdManifest, v.paths.WorkDir, v.paths.BinPath, dryRun)
 	if err != nil {
 		return fmt.Errorf("error while initiating infrastructure phase: %w", err)
 	}
 
-	kube, err := create.NewKubernetes(v.furyctlConf, v.kfdManifest, v.workDir, infra.OutputsPath, v.binPath, dryRun)
+	kube, err := create.NewKubernetes(
+		v.furyctlConf,
+		v.kfdManifest,
+		v.paths.WorkDir,
+		infra.OutputsPath,
+		v.paths.BinPath,
+		dryRun,
+	)
 	if err != nil {
 		return fmt.Errorf("error while initiating kubernetes phase: %w", err)
 	}
 
 	distro, err := create.NewDistribution(
-		v.configPath,
+		v.paths,
 		v.furyctlConf,
 		v.kfdManifest,
-		v.workDir,
-		v.distroPath,
 		infra.OutputsPath,
-		v.binPath,
 		dryRun,
-		v.kubeconfig,
 	)
 	if err != nil {
 		return fmt.Errorf("error while initiating distribution phase: %w", err)

--- a/internal/apis/kfd/v1alpha2/eks/creator.go
+++ b/internal/apis/kfd/v1alpha2/eks/creator.go
@@ -26,6 +26,7 @@ type ClusterCreator struct {
 	binPath        string
 	phase          string
 	vpnAutoConnect bool
+	kubeconfig     string
 }
 
 func (v *ClusterCreator) SetProperties(props []cluster.CreatorProperty) {
@@ -77,6 +78,11 @@ func (v *ClusterCreator) SetProperty(name string, value any) {
 		if s, ok := value.(string); ok {
 			v.binPath = s
 		}
+
+	case cluster.CreatorPropertyKubeconfig:
+		if s, ok := value.(string); ok {
+			v.kubeconfig = s
+		}
 	}
 }
 
@@ -100,6 +106,7 @@ func (v *ClusterCreator) Create(dryRun bool, skipPhase string) error {
 		infra.OutputsPath,
 		v.binPath,
 		dryRun,
+		v.kubeconfig,
 	)
 	if err != nil {
 		return fmt.Errorf("error while initiating distribution phase: %w", err)

--- a/internal/apis/kfd/v1alpha2/eks/creator.go
+++ b/internal/apis/kfd/v1alpha2/eks/creator.go
@@ -83,7 +83,7 @@ func (v *ClusterCreator) SetProperty(name string, value any) {
 }
 
 func (v *ClusterCreator) Create(dryRun bool, skipPhase string) error {
-	infra, err := create.NewInfrastructure(v.furyctlConf, v.kfdManifest, v.paths.WorkDir, v.paths.BinPath, dryRun)
+	infra, err := create.NewInfrastructure(v.furyctlConf, v.kfdManifest, v.paths, dryRun)
 	if err != nil {
 		return fmt.Errorf("error while initiating infrastructure phase: %w", err)
 	}
@@ -91,9 +91,8 @@ func (v *ClusterCreator) Create(dryRun bool, skipPhase string) error {
 	kube, err := create.NewKubernetes(
 		v.furyctlConf,
 		v.kfdManifest,
-		v.paths.WorkDir,
 		infra.OutputsPath,
-		v.paths.BinPath,
+		v.paths,
 		dryRun,
 	)
 	if err != nil {

--- a/internal/apis/kfd/v1alpha2/eks/delete/distribution.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/distribution.go
@@ -84,7 +84,7 @@ func NewDistribution(dryRun bool, workDir, binPath string, kfdManifest config.KF
 }
 
 func (d *Distribution) Exec() error {
-	logrus.Info("Deleting distribution phase")
+	logrus.Info("Deleting distribution phase...")
 
 	err := iox.CheckDirIsEmpty(d.OperationPhase.Path)
 	if err == nil {
@@ -93,44 +93,44 @@ func (d *Distribution) Exec() error {
 		return nil
 	}
 
-	logrus.Info("Deleting ingresses")
+	logrus.Info("Deleting ingresses...")
 
 	if err = d.deleteIngresses(); err != nil {
 		return err
 	}
 
-	logrus.Info("Deleting blocking resources")
+	logrus.Info("Deleting blocking resources...")
 
 	if err = d.deleteBlockingResources(); err != nil {
 		return err
 	}
 
-	logrus.Info("Building manifests")
+	logrus.Info("Building manifests...")
 
 	manifestsOutPath, err := d.buildManifests()
 	if err != nil {
 		return err
 	}
 
-	logrus.Info("Deleting manifests")
+	logrus.Info("Deleting manifests...")
 
 	err = d.kubeRunner.Delete(manifestsOutPath)
 	if err != nil {
 		logrus.Errorf("error while deleting resources: %v", err)
 	}
 
-	logrus.Info("Checking pending resources")
+	logrus.Info("Checking pending resources...")
 
 	err = d.checkPendingResources()
 	if err != nil {
 		return err
 	}
 
-	logrus.Info("Deleting terraform resources")
+	logrus.Info("Deleting infra resources...")
 
 	err = d.tfRunner.Destroy()
 	if err != nil {
-		return fmt.Errorf("error running terraform destroy: %w", err)
+		return fmt.Errorf("error while deleting infra resources: %w", err)
 	}
 
 	return nil
@@ -198,6 +198,7 @@ func (d *Distribution) deleteIngresses() error {
 		return fmt.Errorf("error deleting ingresses: %w", err)
 	}
 
+	logrus.Debugf("waiting for records to be deleted...")
 	time.Sleep(dur)
 
 	return nil
@@ -236,6 +237,7 @@ func (d *Distribution) deleteBlockingResources() error {
 		return fmt.Errorf("error deleting svc in namespace 'ingress-nginx': %w", err)
 	}
 
+	logrus.Debugf("waiting for resources to be deleted...")
 	time.Sleep(dur)
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/eks/delete/distribution.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/distribution.go
@@ -43,7 +43,13 @@ type Distribution struct {
 	dryRun     bool
 }
 
-func NewDistribution(dryRun bool, workDir, binPath string, kfdManifest config.KFD) (*Distribution, error) {
+func NewDistribution(
+	dryRun bool,
+	workDir,
+	binPath string,
+	kfdManifest config.KFD,
+	kubeconfig string,
+) (*Distribution, error) {
 	distroDir := path.Join(workDir, "distribution")
 
 	phase, err := cluster.NewOperationPhase(distroDir, kfdManifest.Tools, binPath)
@@ -73,8 +79,9 @@ func NewDistribution(dryRun bool, workDir, binPath string, kfdManifest config.KF
 		kubeRunner: kubectl.NewRunner(
 			execx.NewStdExecutor(),
 			kubectl.Paths{
-				Kubectl: phase.KubectlPath,
-				WorkDir: path.Join(phase.Path, "manifests"),
+				Kubectl:    phase.KubectlPath,
+				WorkDir:    path.Join(phase.Path, "manifests"),
+				Kubeconfig: kubeconfig,
 			},
 			true,
 			true,

--- a/internal/apis/kfd/v1alpha2/eks/delete/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/infrastructure.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//nolint:dupl // better readability
 package del
 
 import (

--- a/internal/apis/kfd/v1alpha2/eks/delete/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/infrastructure.go
@@ -49,19 +49,22 @@ func NewInfrastructure(dryRun bool, workDir, binPath string, kfdManifest config.
 }
 
 func (i *Infrastructure) Exec() error {
-	logrus.Info("Deleting infrastructure phase")
+	logrus.Info("Deleting infrastructure phase...")
 
 	err := iox.CheckDirIsEmpty(i.OperationPhase.Path)
 	if err == nil {
-		logrus.Infof("infrastructure phase already executed, skipping")
+		logrus.Infof("infrastructure phase already executed, skipping...")
 
 		return nil
 	}
 
 	err = i.tfRunner.Destroy()
 	if err != nil {
-		return fmt.Errorf("error running terraform destroy: %w", err)
+		return fmt.Errorf("error while deleting infrastructure: %w", err)
 	}
+
+	logrus.Warnf("Please, remember to kill the OpenVPN process if" +
+		" you have chosen to create it in the infrastructure phase")
 
 	return nil
 }

--- a/internal/apis/kfd/v1alpha2/eks/delete/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/kubernetes.go
@@ -49,18 +49,18 @@ func NewKubernetes(dryRun bool, workDir, binPath string, kfdManifest config.KFD)
 }
 
 func (k *Kubernetes) Exec() error {
-	logrus.Info("Deleting kubernetes phase")
+	logrus.Info("Deleting kubernetes phase...")
 
 	err := iox.CheckDirIsEmpty(k.OperationPhase.Path)
 	if err == nil {
-		logrus.Infof("kubernetes phase already executed, skipping")
+		logrus.Infof("kubernetes phase already executed, skipping...")
 
 		return nil
 	}
 
 	err = k.tfRunner.Destroy()
 	if err != nil {
-		return fmt.Errorf("error running terraform destroy: %w", err)
+		return fmt.Errorf("error while deleting kubernetes phase: %w", err)
 	}
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/eks/delete/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/kubernetes.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//nolint:dupl // better readability
 package del
 
 import (

--- a/internal/apis/kfd/v1alpha2/eks/deleter.go
+++ b/internal/apis/kfd/v1alpha2/eks/deleter.go
@@ -18,6 +18,7 @@ type ClusterDeleter struct {
 	phase       string
 	workDir     string
 	binPath     string
+	kubeconfig  string
 }
 
 func (d *ClusterDeleter) SetProperties(props []cluster.DeleterProperty) {
@@ -49,11 +50,16 @@ func (d *ClusterDeleter) SetProperty(name string, value any) {
 		if s, ok := value.(string); ok {
 			d.binPath = s
 		}
+
+	case cluster.DeleterPropertyKubeconfig:
+		if s, ok := value.(string); ok {
+			d.kubeconfig = s
+		}
 	}
 }
 
 func (d *ClusterDeleter) Delete(dryRun bool) error {
-	distro, err := del.NewDistribution(dryRun, d.workDir, d.binPath, d.kfdManifest)
+	distro, err := del.NewDistribution(dryRun, d.workDir, d.binPath, d.kfdManifest, d.kubeconfig)
 	if err != nil {
 		return fmt.Errorf("error while creating distribution phase: %w", err)
 	}

--- a/internal/cluster/creator.go
+++ b/internal/cluster/creator.go
@@ -31,6 +31,14 @@ var (
 	errResourceNotSupported = errors.New("resource is not supported")
 )
 
+type CreatorPaths struct {
+	ConfigPath string
+	WorkDir    string
+	DistroPath string
+	BinPath    string
+	Kubeconfig string
+}
+
 type CreatorFactory func(configPath string, props []CreatorProperty) (Creator, error)
 
 type CreatorProperty struct {
@@ -47,19 +55,15 @@ type Creator interface {
 func NewCreator(
 	minimalConf config.Furyctl,
 	kfdManifest config.KFD,
-	workDir string,
-	distroPath string,
-	binPath string,
-	configPath string,
+	paths CreatorPaths,
 	phase string,
 	vpnAutoConnect bool,
-	kubeconfig string,
 ) (Creator, error) {
 	lcAPIVersion := strings.ToLower(minimalConf.APIVersion)
 	lcResourceType := strings.ToLower(minimalConf.Kind)
 
 	if factoryFn, ok := crFactories[lcAPIVersion][lcResourceType]; ok {
-		return factoryFn(configPath, []CreatorProperty{
+		return factoryFn(paths.ConfigPath, []CreatorProperty{
 			{
 				Name:  CreatorPropertyKfdManifest,
 				Value: kfdManifest,
@@ -74,19 +78,19 @@ func NewCreator(
 			},
 			{
 				Name:  CreatorPropertyDistroPath,
-				Value: distroPath,
+				Value: paths.DistroPath,
 			},
 			{
 				Name:  CreatorPropertyBinPath,
-				Value: binPath,
+				Value: paths.BinPath,
 			},
 			{
 				Name:  CreatorPropertyWorkDir,
-				Value: workDir,
+				Value: paths.WorkDir,
 			},
 			{
 				Name:  CreatorPropertyKubeconfig,
-				Value: kubeconfig,
+				Value: paths.Kubeconfig,
 			},
 		})
 	}

--- a/internal/cluster/creator.go
+++ b/internal/cluster/creator.go
@@ -22,6 +22,7 @@ const (
 	CreatorPropertyBinPath        = "binpath"
 	CreatorPropertyPhase          = "phase"
 	CreatorPropertyVpnAutoConnect = "vpnautoconnect"
+	CreatorPropertyKubeconfig     = "kubeconfig"
 )
 
 var (
@@ -52,6 +53,7 @@ func NewCreator(
 	configPath string,
 	phase string,
 	vpnAutoConnect bool,
+	kubeconfig string,
 ) (Creator, error) {
 	lcAPIVersion := strings.ToLower(minimalConf.APIVersion)
 	lcResourceType := strings.ToLower(minimalConf.Kind)
@@ -81,6 +83,10 @@ func NewCreator(
 			{
 				Name:  CreatorPropertyWorkDir,
 				Value: workDir,
+			},
+			{
+				Name:  CreatorPropertyKubeconfig,
+				Value: kubeconfig,
 			},
 		})
 	}

--- a/internal/cluster/deleter.go
+++ b/internal/cluster/deleter.go
@@ -16,6 +16,7 @@ const (
 	DeleterPropertyWorkDir     = "workdir"
 	DeleterPropertyKfdManifest = "kfdmanifest"
 	DeleterPropertyBinPath     = "binpath"
+	DeleterPropertyKubeconfig  = "kubeconfig"
 )
 
 var delFactories = make(map[string]map[string]DeleterFactory) //nolint:gochecknoglobals, lll // This patterns requires factories
@@ -39,7 +40,8 @@ func NewDeleter(
 	kfdManifest config.KFD,
 	phase,
 	workDir,
-	binPath string,
+	binPath,
+	kubeconfig string,
 ) (Deleter, error) {
 	lcAPIVersion := strings.ToLower(minimalConf.APIVersion)
 	lcResourceType := strings.ToLower(minimalConf.Kind)
@@ -61,6 +63,10 @@ func NewDeleter(
 			{
 				Name:  DeleterPropertyBinPath,
 				Value: binPath,
+			},
+			{
+				Name:  DeleterPropertyKubeconfig,
+				Value: kubeconfig,
 			},
 		})
 	}

--- a/internal/tool/kubectl/runner.go
+++ b/internal/tool/kubectl/runner.go
@@ -16,8 +16,9 @@ const (
 )
 
 type Paths struct {
-	Kubectl string
-	WorkDir string
+	Kubectl    string
+	WorkDir    string
+	Kubeconfig string
 }
 
 type Runner struct {
@@ -43,6 +44,10 @@ func (r *Runner) CmdPath() string {
 func (r *Runner) Apply(manifestPath string) error {
 	args := []string{"apply"}
 
+	if r.paths.Kubeconfig != "" {
+		args = append(args, "--kubeconfig", r.paths.Kubeconfig)
+	}
+
 	if r.serverSide {
 		args = append(args, "--server-side")
 	}
@@ -63,6 +68,10 @@ func (r *Runner) Apply(manifestPath string) error {
 
 func (r *Runner) Get(ns string, params ...string) (string, error) {
 	args := []string{"get"}
+
+	if r.paths.Kubeconfig != "" {
+		args = append(args, "--kubeconfig", r.paths.Kubeconfig)
+	}
 
 	if ns != "all" {
 		args = append(args, "-n", ns)
@@ -93,6 +102,10 @@ func (r *Runner) DeleteAllResources(res, ns string) (string, error) {
 		args = append(args, "-A")
 	}
 
+	if r.paths.Kubeconfig != "" {
+		args = append(args, "--kubeconfig", r.paths.Kubeconfig)
+	}
+
 	out, err := execx.CombinedOutput(execx.NewCmd(r.paths.Kubectl, execx.CmdOptions{
 		Args:     args,
 		Executor: r.executor,
@@ -107,6 +120,10 @@ func (r *Runner) DeleteAllResources(res, ns string) (string, error) {
 
 func (r *Runner) Delete(manifestPath string) error {
 	args := []string{"delete"}
+
+	if r.paths.Kubeconfig != "" {
+		args = append(args, "--kubeconfig", r.paths.Kubeconfig)
+	}
 
 	if r.skipNotFound {
 		args = append(args, "--ignore-not-found=true")

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -210,9 +210,9 @@ var (
 				Expect(out).To(ContainSubstring("kubectl:"))
 				Expect(out).To(ContainSubstring("kustomize:"))
 				Expect(out).To(ContainSubstring("furyagent:"))
-				Expect(out).To(ContainSubstring("missing environment variable: AWS_ACCESS_KEY_ID"))
-				Expect(out).To(ContainSubstring("missing environment variable: AWS_SECRET_ACCESS_KEY"))
-				Expect(out).To(ContainSubstring("missing environment variable: AWS_DEFAULT_REGION"))
+				Expect(out).To(ContainSubstring("AWS_ACCESS_KEY_ID:"))
+				Expect(out).To(ContainSubstring("AWS_SECRET_ACCESS_KEY:"))
+				Expect(out).To(ContainSubstring("AWS_DEFAULT_REGION:"))
 			})
 
 			It("should report an error when dependencies are wrong", Serial, func() {
@@ -248,9 +248,9 @@ var (
 				Expect(out).To(
 					ContainSubstring("terraform: wrong tool version - installed = 0.15.3, expected = 0.15.4"),
 				)
-				Expect(out).To(ContainSubstring("missing environment variable: AWS_ACCESS_KEY_ID"))
-				Expect(out).To(ContainSubstring("missing environment variable: AWS_SECRET_ACCESS_KEY"))
-				Expect(out).To(ContainSubstring("missing environment variable: AWS_DEFAULT_REGION"))
+				Expect(out).To(ContainSubstring("AWS_ACCESS_KEY_ID: missing environment variable"))
+				Expect(out).To(ContainSubstring("AWS_SECRET_ACCESS_KEY: missing environment variable"))
+				Expect(out).To(ContainSubstring("AWS_DEFAULT_REGION: missing environment variable"))
 			})
 
 			It("should exit without errors when dependencies are correct", Serial, func() {


### PR DESCRIPTION
Changelist:

- add debug message when waiting for cluster resources removal
- append '...' to Deleting x phase messages
- when deleting a cluster or deleting just phase infrastructure print a WARN telling the user to kill the openvpn process
- add a --kubeconfig flag (mandatory if running distribution phase alone and $KUBECONFIG is not set) to `create cluster`
- add a --kubeconfig flag (mandatory if running distribution phase alone or all phases and $KUBECONFIG is not set) to `delete cluster`
- bumped up golang version to 1.19.4, golangci-lint to 1.50.1
- refactored functions with too many parameters
