### PR TITLE
feat: handle unsupported phases

### DIFF
--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -60,6 +60,11 @@ func NewClusterCmd(tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("%w: phase", ErrParsingFlag)
 			}
 
+			err = cluster.CheckPhase(phase)
+			if err != nil {
+				return fmt.Errorf("%w: %s: %s", ErrParsingFlag, "phase", err.Error())
+			}
+
 			binPath := cobrax.Flag[string](cmd, "bin-path").(string) //nolint:errcheck,forcetypeassert // optional flag
 			dryRun, err := cmdutil.BoolFlag(cmd, "dry-run", tracker, cmdEvent)
 			if err != nil {
@@ -83,7 +88,7 @@ func NewClusterCmd(tracker *analytics.Tracker) *cobra.Command {
 			}
 
 			// Check if kubeconfig is needed.
-			if phase == "distribution" || phase == "" {
+			if phase == cluster.OperationPhaseDistribution || phase == cluster.OperationPhaseAll {
 				if kubeconfig == "" {
 					kubeconfigFromEnv := os.Getenv("KUBECONFIG")
 

--- a/internal/apis/kfd/v1alpha2/eks/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/distribution.go
@@ -67,7 +67,7 @@ func NewDistribution(
 	infraOutputsPath string,
 	dryRun bool,
 ) (*Distribution, error) {
-	distroDir := path.Join(paths.WorkDir, "distribution")
+	distroDir := path.Join(paths.WorkDir, cluster.OperationPhaseDistribution)
 
 	phase, err := cluster.NewOperationPhase(distroDir, kfdManifest.Tools, paths.BinPath)
 	if err != nil {
@@ -455,7 +455,7 @@ func (d *Distribution) copyFromTemplate(cfg template.Config) error {
 	}
 
 	templateModel, err := template.NewTemplateModel(
-		path.Join(d.distroPath, "templates", "distribution"),
+		path.Join(d.distroPath, "templates", cluster.OperationPhaseDistribution),
 		path.Join(d.Path),
 		confPath,
 		outDirPath,

--- a/internal/apis/kfd/v1alpha2/eks/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/infrastructure.go
@@ -54,7 +54,7 @@ func NewInfrastructure(
 	paths cluster.CreatorPaths,
 	dryRun bool,
 ) (*Infrastructure, error) {
-	infraDir := path.Join(paths.WorkDir, "infrastructure")
+	infraDir := path.Join(paths.WorkDir, cluster.OperationPhaseInfrastructure)
 
 	phase, err := cluster.NewOperationPhase(infraDir, kfdManifest.Tools, paths.BinPath)
 	if err != nil {

--- a/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
@@ -58,7 +58,7 @@ func NewKubernetes(
 	paths cluster.CreatorPaths,
 	dryRun bool,
 ) (*Kubernetes, error) {
-	kubeDir := path.Join(paths.WorkDir, "kubernetes")
+	kubeDir := path.Join(paths.WorkDir, cluster.OperationPhaseKubernetes)
 
 	phase, err := cluster.NewOperationPhase(kubeDir, kfdManifest.Tools, paths.BinPath)
 	if err != nil {

--- a/internal/apis/kfd/v1alpha2/eks/delete/distribution.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/distribution.go
@@ -50,7 +50,7 @@ func NewDistribution(
 	kfdManifest config.KFD,
 	kubeconfig string,
 ) (*Distribution, error) {
-	distroDir := path.Join(workDir, "distribution")
+	distroDir := path.Join(workDir, cluster.OperationPhaseDistribution)
 
 	phase, err := cluster.NewOperationPhase(distroDir, kfdManifest.Tools, binPath)
 	if err != nil {

--- a/internal/apis/kfd/v1alpha2/eks/delete/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/infrastructure.go
@@ -24,7 +24,7 @@ type Infrastructure struct {
 }
 
 func NewInfrastructure(dryRun bool, workDir, binPath string, kfdManifest config.KFD) (*Infrastructure, error) {
-	infraDir := path.Join(workDir, "infrastructure")
+	infraDir := path.Join(workDir, cluster.OperationPhaseInfrastructure)
 
 	phase, err := cluster.NewOperationPhase(infraDir, kfdManifest.Tools, binPath)
 	if err != nil {

--- a/internal/apis/kfd/v1alpha2/eks/delete/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/kubernetes.go
@@ -24,7 +24,7 @@ type Kubernetes struct {
 }
 
 func NewKubernetes(dryRun bool, workDir, binPath string, kfdManifest config.KFD) (*Kubernetes, error) {
-	kubeDir := path.Join(workDir, "kubernetes")
+	kubeDir := path.Join(workDir, cluster.OperationPhaseKubernetes)
 
 	phase, err := cluster.NewOperationPhase(kubeDir, kfdManifest.Tools, binPath)
 	if err != nil {

--- a/internal/cluster/phase.go
+++ b/internal/cluster/phase.go
@@ -5,6 +5,7 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -23,6 +24,25 @@ const (
 
 	OperationPhaseOptionVPNAutoConnect = "vpnautoconnect"
 )
+
+var errUnsupportedPhase = errors.New("unsupported phase, options are: infrastructure, kubernetes, distribution")
+
+func CheckPhase(phase string) error {
+	switch phase {
+	case OperationPhaseInfrastructure:
+	case OperationPhaseKubernetes:
+	case OperationPhaseDistribution:
+	case OperationPhaseAll:
+		{
+			break
+		}
+
+	default:
+		return errUnsupportedPhase
+	}
+
+	return nil
+}
 
 type OperationPhase struct {
 	Path          string

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -21,6 +21,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+
+	"github.com/sighupio/furyctl/internal/cluster"
 )
 
 func TestE2e(t *testing.T) {
@@ -545,9 +547,9 @@ var (
 				homeDir, err := os.UserHomeDir()
 				Expect(err).To(Not(HaveOccurred()))
 
-				tfPath := path.Join(homeDir, ".furyctl", "furyctl-dev-aws", "infrastructure", "terraform")
+				tfPath := path.Join(homeDir, ".furyctl", "furyctl-dev-aws", cluster.OperationPhaseInfrastructure, "terraform")
 
-				createInfraCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, "infrastructure", true)
+				createInfraCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseInfrastructure, true)
 				session, err := gexec.Start(createInfraCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
 
@@ -574,9 +576,9 @@ var (
 				homeDir, err := os.UserHomeDir()
 				Expect(err).To(Not(HaveOccurred()))
 
-				tfPath := path.Join(homeDir, ".furyctl", "furyctl-dev-aws", "kubernetes", "terraform")
+				tfPath := path.Join(homeDir, ".furyctl", "furyctl-dev-aws", cluster.OperationPhaseKubernetes, "terraform")
 
-				createKubeCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, "kubernetes", true)
+				createKubeCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseKubernetes, true)
 				session, err := gexec.Start(createKubeCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
 

--- a/test/expensive/furyctl_test.go
+++ b/test/expensive/furyctl_test.go
@@ -17,6 +17,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+
+	"github.com/sighupio/furyctl/internal/cluster"
 )
 
 func TestExpensive(t *testing.T) {
@@ -72,7 +74,7 @@ var (
 			w,
 		}
 
-		if phase != "" {
+		if phase != cluster.OperationPhaseAll {
 			args = append(args, "--phase", phase)
 		}
 
@@ -96,11 +98,11 @@ var (
 			w,
 		}
 
-		if phase != "" {
+		if phase != cluster.OperationPhaseAll {
 			args = append(args, "--phase", phase)
 		}
 
-		if phase == "infrastructure" {
+		if phase == cluster.OperationPhaseInfrastructure {
 			args = append(args, "--vpn-auto-connect")
 		}
 
@@ -139,10 +141,10 @@ var (
 				Expect(err).To(Not(HaveOccurred()))
 
 				kubeBinPath := path.Join(homeDir, ".furyctl", "bin", "kubectl", "1.24.7", "kubectl")
-				tfInfraPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws", "infrastructure", "terraform")
-				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws", "kubernetes", "terraform", "secrets", "kubeconfig")
+				tfInfraPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws", cluster.OperationPhaseInfrastructure, "terraform")
+				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws", cluster.OperationPhaseKubernetes, "terraform", "secrets", "kubeconfig")
 
-				createClusterCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, "", "", false, w)
+				createClusterCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseAll, "", false, w)
 
 				session, err := gexec.Start(createClusterCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
@@ -166,7 +168,7 @@ var (
 				homeDir, err := os.UserHomeDir()
 				Expect(err).To(Not(HaveOccurred()))
 
-				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws", "kubernetes", "terraform", "secrets", "kubeconfig")
+				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws", cluster.OperationPhaseKubernetes, "terraform", "secrets", "kubeconfig")
 
 				err = os.Setenv("KUBECONFIG", kcfgPath)
 				Expect(err).To(Not(HaveOccurred()))
@@ -179,7 +181,7 @@ var (
 					Eventually(pkillSession, 10*time.Second).Should(gexec.Exit(0))
 				})
 
-				deleteClusterCmd := FuryctlDeleteCluster(furyctlYamlPath, distroPath, "", false, w)
+				deleteClusterCmd := FuryctlDeleteCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseAll, false, w)
 
 				session, err := gexec.Start(deleteClusterCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
@@ -199,16 +201,16 @@ var (
 				Expect(err).To(Not(HaveOccurred()))
 
 				kubeBinPath := path.Join(homeDir, ".furyctl", "bin", "kubectl", "1.24.7", "kubectl")
-				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws-si", "kubernetes", "terraform", "secrets", "kubeconfig")
+				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws-si", cluster.OperationPhaseKubernetes, "terraform", "secrets", "kubeconfig")
 
-				createClusterInfraCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, "infrastructure", "", false, w)
+				createClusterInfraCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseInfrastructure, "", false, w)
 
 				infraSession, err := gexec.Start(createClusterInfraCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
 
 				Eventually(infraSession, 20*time.Minute).Should(gexec.Exit(0))
 
-				createClusterCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, "", "infrastructure", false, w)
+				createClusterCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseAll, cluster.OperationPhaseInfrastructure, false, w)
 
 				session, err := gexec.Start(createClusterCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
@@ -231,7 +233,7 @@ var (
 				homeDir, err := os.UserHomeDir()
 				Expect(err).To(Not(HaveOccurred()))
 
-				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws-si", "kubernetes", "terraform", "secrets", "kubeconfig")
+				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws-si", cluster.OperationPhaseKubernetes, "terraform", "secrets", "kubeconfig")
 
 				err = os.Setenv("KUBECONFIG", kcfgPath)
 				Expect(err).To(Not(HaveOccurred()))
@@ -244,7 +246,7 @@ var (
 					Eventually(pkillSession, 10*time.Second).Should(gexec.Exit(0))
 				})
 
-				deleteClusterCmd := FuryctlDeleteCluster(furyctlYamlPath, distroPath, "", false, w)
+				deleteClusterCmd := FuryctlDeleteCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseAll, false, w)
 
 				session, err := gexec.Start(deleteClusterCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
@@ -264,9 +266,9 @@ var (
 				Expect(err).To(Not(HaveOccurred()))
 
 				kubeBinPath := path.Join(homeDir, ".furyctl", "bin", "kubectl", "1.24.7", "kubectl")
-				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws-sk", "kubernetes", "terraform", "secrets", "kubeconfig")
+				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws-sk", cluster.OperationPhaseKubernetes, "terraform", "secrets", "kubeconfig")
 
-				createClusterKubeCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, "", "distribution", false, w)
+				createClusterKubeCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseAll, cluster.OperationPhaseDistribution, false, w)
 
 				kubeSession, err := gexec.Start(createClusterKubeCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
@@ -276,7 +278,7 @@ var (
 				err = os.Setenv("KUBECONFIG", kcfgPath)
 				Expect(err).To(Not(HaveOccurred()))
 
-				createClusterCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, "", "kubernetes", false, w)
+				createClusterCmd := FuryctlCreateCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseAll, cluster.OperationPhaseKubernetes, false, w)
 
 				session, err := gexec.Start(createClusterCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
@@ -298,7 +300,7 @@ var (
 				homeDir, err := os.UserHomeDir()
 				Expect(err).To(Not(HaveOccurred()))
 
-				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws-sk", "kubernetes", "terraform", "secrets", "kubeconfig")
+				kcfgPath := path.Join(homeDir, ".furyctl", "furyctl-test-aws-sk", cluster.OperationPhaseKubernetes, "terraform", "secrets", "kubeconfig")
 
 				err = os.Setenv("KUBECONFIG", kcfgPath)
 				Expect(err).To(Not(HaveOccurred()))
@@ -311,7 +313,7 @@ var (
 					Eventually(pkillSession, 10*time.Second).Should(gexec.Exit(0))
 				})
 
-				deleteClusterCmd := FuryctlDeleteCluster(furyctlYamlPath, distroPath, "", false, w)
+				deleteClusterCmd := FuryctlDeleteCluster(furyctlYamlPath, distroPath, cluster.OperationPhaseAll, false, w)
 
 				session, err := gexec.Start(deleteClusterCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
Changelist:

- added an error when trying to use an unsupported phase flag in create/delete cluster command:
`ERRO error while parsing flag: phase: options are: infrastructure, kubernetes, distribution`
- added an error when trying to use an unsupported skip-phase flag in create cluster command:
`ERRO error while parsing flag: skip-phase: unsupported phase, options are: infrastructure, kubernetes, distribution`
- added an error when trying to use phase and skip-phase flag together:
`ERRO error while parsing flag: skip-phase: cannot use together with phase flag`
- refactored "infrastructure", "kubernetes", "distribution" to use enums instead