### PR TITLE
feat: added dry run to cluster delete

### DIFF
--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -87,13 +87,17 @@ func NewClusterCmd(tracker *analytics.Tracker) *cobra.Command {
 				flags.BinPath = filepath.Join(homeDir, ".furyctl", "bin")
 			}
 
+			if flags.DryRun {
+				logrus.Info("Dry run mode enabled, no changes will be applied")
+			}
+
 			// Init first half of collaborators.
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
 			distrodl := distribution.NewDownloader(client)
 
 			// Init packages.
-			execx.Debug = flags.Debug
+			execx.Debug = flags.Debug || flags.DryRun
 
 			// Download the distribution.
 			logrus.Info("Downloading distribution...")

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -109,7 +109,7 @@ func NewClusterCmd(tracker *analytics.Tracker) *cobra.Command {
 			executor := execx.NewStdExecutor()
 			distrodl := distribution.NewDownloader(client)
 
-			execx.Debug = debug
+			execx.Debug = debug || dryRun
 
 			// Download the distribution.
 			logrus.Info("Downloading distribution...")
@@ -179,7 +179,9 @@ func NewClusterCmd(tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("error while deleting cluster: %w", err)
 			}
 
-			logrus.Info("Cluster deleted successfully!")
+			if !dryRun && phase == cluster.OperationPhaseAll {
+				logrus.Info("Cluster deleted successfully!")
+			}
 
 			cmdEvent.AddSuccessMessage("Cluster deleted successfully!")
 			tracker.Track(cmdEvent)

--- a/internal/apis/kfd/v1alpha2/eks/delete/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/infrastructure.go
@@ -7,6 +7,7 @@ package del
 import (
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -50,10 +51,20 @@ func NewInfrastructure(dryRun bool, workDir, binPath string, kfdManifest config.
 func (i *Infrastructure) Exec() error {
 	logrus.Info("Deleting infrastructure phase...")
 
+	timestamp := time.Now().Unix()
+
 	err := iox.CheckDirIsEmpty(i.OperationPhase.Path)
 	if err == nil {
 		logrus.Infof("infrastructure phase already executed, skipping...")
 
+		return nil
+	}
+
+	if err := i.tfRunner.Plan(timestamp, "-destroy"); err != nil {
+		return fmt.Errorf("error running terraform plan: %w", err)
+	}
+
+	if i.dryRun {
 		return nil
 	}
 

--- a/internal/tool/kubectl/runner.go
+++ b/internal/tool/kubectl/runner.go
@@ -118,7 +118,7 @@ func (r *Runner) DeleteAllResources(res, ns string) (string, error) {
 	return out, nil
 }
 
-func (r *Runner) Delete(manifestPath string) error {
+func (r *Runner) Delete(manifestPath string, params ...string) error {
 	args := []string{"delete"}
 
 	if r.paths.Kubeconfig != "" {
@@ -127,6 +127,10 @@ func (r *Runner) Delete(manifestPath string) error {
 
 	if r.skipNotFound {
 		args = append(args, "--ignore-not-found=true")
+	}
+
+	if len(params) > 0 {
+		args = append(args, params...)
 	}
 
 	args = append(args, "-f", manifestPath)

--- a/internal/tool/terraform/runner.go
+++ b/internal/tool/terraform/runner.go
@@ -61,9 +61,17 @@ func (r *Runner) Init() error {
 	return nil
 }
 
-func (r *Runner) Plan(timestamp int64) error {
+func (r *Runner) Plan(timestamp int64, params ...string) error {
+	args := []string{"plan"}
+
+	if len(params) > 0 {
+		args = append(args, params...)
+	}
+
+	args = append(args, "-no-color", "-out", "plan/terraform.plan")
+
 	cmd := execx.NewCmd(r.paths.Terraform, execx.CmdOptions{
-		Args:     []string{"plan", "--out=plan/terraform.plan", "-no-color"},
+		Args:     args,
 		Executor: r.executor,
 		WorkDir:  r.paths.WorkDir,
 	})


### PR DESCRIPTION
Changelist:

- added --dry-run to cluster delete phases

infrastructure(dry-run): output plan -destroy
kubernetes(dry-run): output plan -destroy
distribution(dry-run): output plan -destroy and kubectl delete --dry-run, plus a list of resources deleted from the cluster, regardless of the manifests built from the template

example output of distribution(dry-run):
![Screenshot 2023-01-11 at 19 15 14](https://user-images.githubusercontent.com/83355398/212084181-36622261-e6b3-4596-b563-590f4cbe5563.png)

