### PR TITLE
chore: check github token whitespaces, improve logrus format

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -124,7 +124,7 @@ func downloadProcess(wg *sync.WaitGroup, opts DownloadOpts, data Package, errCha
 			logrus.Infof("downloading '%s' failed, falling back to '%s' and retrying", o, humanReadableSource(pU.getConsumableURL()))
 
 			if resp, err := checkRepository(pU); err != nil || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusNotFound {
-				errChan <- fmt.Errorf("error downloading %s for '%s' version '%s'. Both urls '%s' and '%s' have failed. Please check that the repository exists and that your credentials are correctlly configured. You might want to try using the -H flag", data.Kind, data.Name, data.Version, o, humanReadableSource(pU.getConsumableURL()))
+				errChan <- fmt.Errorf("error downloading %s for '%s' version '%s'. Both urls '%s' and '%s' have failed. Please check that the repository exists and that your credentials are correctlly configured.", data.Kind, data.Name, data.Version, o, humanReadableSource(pU.getConsumableURL()))
 				return
 			}
 

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -5,13 +5,16 @@
 package cmd
 
 import (
+	"os"
+	"strings"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 func init() {
-	vendorCmd.PersistentFlags().BoolVarP(&conf.DownloadOpts.Https, "https", "H", false, "download using HTTPS instead of SSH protocol. Use when SSH traffic is being blocked or when SSH client has not been configured\nset the GITHUB_TOKEN environment variable with your token to use authentication while downloading")
+	vendorCmd.PersistentFlags().BoolVarP(&conf.DownloadOpts.Https, "https", "H", false, "download using HTTPS instead of SSH protocol. Use when SSH traffic is being blocked or when SSH client has not been configured\nset the GITHUB_TOKEN environment variable with your token to use authentication while downloading, for example for private repositories")
 	vendorCmd.PersistentFlags().StringVarP(&conf.Prefix, "prefix", "P", "", "download modules that start with prefix only to reduce download scope. Example:\nfuryctl vendor -P mon\nwill download all modules that start with 'mon', like 'monitoring', and ignore the rest")
 	rootCmd.AddCommand(vendorCmd)
 }
@@ -53,6 +56,10 @@ var vendorCmd = &cobra.Command{
 
 		if err != nil {
 			return err
+		}
+
+		if token := os.Getenv("GITHUB_TOKEN"); token != "" && strings.Contains(token, " ") {
+			logrus.Warn("GITHUB_TOKEN seems to be malformed. Vendoring modules may fail. Please double check its content.\n")
 		}
 
 		for _, p := range list {

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -58,7 +58,7 @@ var vendorCmd = &cobra.Command{
 			return err
 		}
 
-		if token := os.Getenv("GITHUB_TOKEN"); token != "" && strings.Contains(token, " ") {
+		if token := os.Getenv("GITHUB_TOKEN"); strings.Contains(token, " ") {
 			logrus.Warn("GITHUB_TOKEN contains a space character. As a result, vendoring modules may fail. If it's intended, you can ignore this warning.\n")
 		}
 

--- a/cmd/vendor.go
+++ b/cmd/vendor.go
@@ -59,7 +59,7 @@ var vendorCmd = &cobra.Command{
 		}
 
 		if token := os.Getenv("GITHUB_TOKEN"); token != "" && strings.Contains(token, " ") {
-			logrus.Warn("GITHUB_TOKEN seems to be malformed. Vendoring modules may fail. Please double check its content.\n")
+			logrus.Warn("GITHUB_TOKEN contains a space character. As a result, vendoring modules may fail. If it's intended, you can ignore this warning.\n")
 		}
 
 		for _, p := range list {


### PR DESCRIPTION
After https://github.com/sighupio/fury-getting-started/issues/25 (thanks @raclepoulpe) we discovered a bug in the go-getter's library that occurs when the passed URL has whitespaces in it. In this case, the GITHUB_TOKEN erroneously presented a whitespace injected into the OAuth URI to be given to the go-getter's client. This PR is intended to partially mitigate this problem by warning the user with a warning message.