### PR TITLE
Feat: Warn the user about connectivity when running kubernetes phase

### DIFF
--- a/internal/apis/kfd/v1alpha2/eks/creator.go
+++ b/internal/apis/kfd/v1alpha2/eks/creator.go
@@ -137,6 +137,9 @@ func (v *ClusterCreator) Create(skipPhase string) error {
 		return nil
 
 	case cluster.OperationPhaseKubernetes:
+		logrus.Info("Please make sure that the Kubernetes API is reachable before continuing" +
+			" (e.g. check VPN connection is active`), otherwise the installation will fail.")
+
 		if err = kube.Exec(); err != nil {
 			return fmt.Errorf("error while executing kubernetes phase: %w", err)
 		}

--- a/internal/apis/kfd/v1alpha2/eks/creator.go
+++ b/internal/apis/kfd/v1alpha2/eks/creator.go
@@ -137,7 +137,7 @@ func (v *ClusterCreator) Create(skipPhase string) error {
 		return nil
 
 	case cluster.OperationPhaseKubernetes:
-		logrus.Info("Please make sure that the Kubernetes API is reachable before continuing" +
+		logrus.Warn("Please make sure that the Kubernetes API is reachable before continuing" +
 			" (e.g. check VPN connection is active`), otherwise the installation will fail.")
 
 		if err = kube.Exec(); err != nil {


### PR DESCRIPTION
Changelist:

- added warn message to tell the user to make sure the cluster is reachable when running phase kubernetes

closes #166 