### PR TITLE
Feat: UX improvement about unsupported KFD version

### DIFF
--- a/internal/x/net/hashicorp.go
+++ b/internal/x/net/hashicorp.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var errDownloadOptionsExausted = errors.New("downloading options exausted")
+var ErrDownloadOptionsExhausted = errors.New("downloading options exhausted")
 
 func NewGoGetterClient() *GoGetterClient {
 	return &GoGetterClient{
@@ -50,7 +50,7 @@ func (g *GoGetterClient) Download(src, dst string) error {
 		logrus.Debug(err)
 	}
 
-	return errDownloadOptionsExausted
+	return ErrDownloadOptionsExhausted
 }
 
 // URLHasForcedProtocol checks if the url has a forced protocol as described in hashicorp/go-getter.

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -164,7 +164,7 @@ var (
 				out, err := FuryctlValidateConfig("../data/e2e/validate/config/nodistro")
 
 				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring("kfd.yaml: no such file or directory"))
+				Expect(out).To(ContainSubstring("unsupported KFD version"))
 			})
 
 			It("should report an error when config validation fails", func() {


### PR DESCRIPTION
Changelist:

- replaced missing `kfd.yaml` message with info about unsupported KFD version when running with or without --distro-location flag


closes #165 