### PR TITLE
Feat: add depth=1 to go-getter urls

### DIFF
--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -327,7 +327,7 @@ func setupCreateClusterCmdFlags(cmd *cobra.Command) {
 		"",
 		"Location where to download schemas, defaults and the distribution manifest. "+
 			"It can either be a local path(eg: /path/to/fury/distribution) or "+
-			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME). "+
+			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME&depth=1). "+
 			"Any format supported by hashicorp/go-getter can be used.",
 	)
 

--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -140,7 +140,7 @@ func NewConfigCmd(tracker *analytics.Tracker) *cobra.Command {
 		"",
 		"Base URL used to download schemas, defaults and the distribution manifest. "+
 			"It can either be a local path(eg: /path/to/fury/distribution) or "+
-			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME)."+
+			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME&depth=1)."+
 			"Any format supported by hashicorp/go-getter can be used.",
 	)
 

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -203,7 +203,7 @@ func NewClusterCmd(tracker *analytics.Tracker) *cobra.Command {
 		"",
 		"Base URL used to download schemas, defaults and the distribution manifest. "+
 			"It can either be a local path(eg: /path/to/fury/distribution) or "+
-			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME)."+
+			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME&depth=1)."+
 			"Any format supported by hashicorp/go-getter can be used.",
 	)
 

--- a/cmd/download/dependencies.go
+++ b/cmd/download/dependencies.go
@@ -130,7 +130,7 @@ func NewDependenciesCmd(tracker *analytics.Tracker) *cobra.Command {
 		"",
 		"Base URL used to download schemas, defaults and the distribution manifest. "+
 			"It can either be a local path(eg: /path/to/fury/distribution) or "+
-			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME)."+
+			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME&depth=1)."+
 			"Any format supported by hashicorp/go-getter can be used.",
 	)
 

--- a/cmd/validate/config.go
+++ b/cmd/validate/config.go
@@ -93,7 +93,7 @@ func NewConfigCmd(tracker *analytics.Tracker) *cobra.Command {
 		"",
 		"Base URL used to download schemas, defaults and the distribution manifest. "+
 			"It can either be a local path(eg: /path/to/fury/distribution) or "+
-			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME)."+
+			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME&depth=1)."+
 			"Any format supported by hashicorp/go-getter can be used.",
 	)
 

--- a/cmd/validate/dependencies.go
+++ b/cmd/validate/dependencies.go
@@ -133,7 +133,7 @@ func NewDependenciesCmd(tracker *analytics.Tracker) *cobra.Command {
 		"",
 		"Base URL used to download schemas, defaults and the distribution manifest. "+
 			"It can either be a local path(eg: /path/to/fury/distribution) or "+
-			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME)."+
+			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?ref=BRANCH_NAME&depth=1)."+
 			"Any format supported by hashicorp/go-getter can be used.",
 	)
 

--- a/internal/dependencies/download.go
+++ b/internal/dependencies/download.go
@@ -106,7 +106,7 @@ func (dd *Downloader) DownloadModules(modules config.KFDModules) error {
 		dst := filepath.Join(dd.basePath, "vendor", "modules", name)
 
 		for _, prefix := range []string{oldPrefix, newPrefix} {
-			src := fmt.Sprintf("git::git@github.com:sighupio/%s-%s.git?ref=%s&depth=1", prefix, name, version)
+			src := fmt.Sprintf("git::git@github.com:sighupio/%s-%s?ref=%s&depth=1", prefix, name, version)
 
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, createURL(prefix, name, version), nil)
 			if err != nil {

--- a/internal/dependencies/download.go
+++ b/internal/dependencies/download.go
@@ -106,7 +106,7 @@ func (dd *Downloader) DownloadModules(modules config.KFDModules) error {
 		dst := filepath.Join(dd.basePath, "vendor", "modules", name)
 
 		for _, prefix := range []string{oldPrefix, newPrefix} {
-			src := fmt.Sprintf("git::git@github.com:sighupio/%s-%s.git?ref=%s", prefix, name, version)
+			src := fmt.Sprintf("git::git@github.com:sighupio/%s-%s.git?ref=%s&depth=1", prefix, name, version)
 
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, createURL(prefix, name, version), nil)
 			if err != nil {
@@ -175,7 +175,7 @@ func (dd *Downloader) DownloadInstallers(installers config.KFDKubernetes) error 
 
 		version := v.Installer
 
-		src := fmt.Sprintf("git::git@github.com:sighupio/fury-%s-installer?ref=%s", name, version)
+		src := fmt.Sprintf("git::git@github.com:sighupio/fury-%s-installer?ref=%s&depth=1", name, version)
 
 		if err := dd.client.Download(src, dst); err != nil {
 			return fmt.Errorf("%w '%s': %v", distribution.ErrDownloadingFolder, src, err)

--- a/internal/distribution/download.go
+++ b/internal/distribution/download.go
@@ -19,7 +19,7 @@ import (
 	yamlx "github.com/sighupio/furyctl/internal/x/yaml"
 )
 
-const DefaultBaseURL = "git::git@github.com:sighupio/fury-distribution?ref=%s"
+const DefaultBaseURL = "git::git@github.com:sighupio/fury-distribution?ref=%s&depth=1"
 
 var (
 	ErrChangingFilePermissions = errors.New("error changing file permissions")


### PR DESCRIPTION
Changelist:

- added depth=1 to every go-getter url

⚠️ needs #171 to be merged

NOTE: this is possibly breaking, now it's not possible to specify a commit hash as a ref
![Screenshot 2023-01-20 at 12 02 31](https://user-images.githubusercontent.com/83355398/213680236-f835d5dd-709b-4f9a-bfcc-1e1284ea40ca.png)


closes #169 