### PR TITLE
Feat: support no-tty in external commands

### DIFF
--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -42,6 +42,7 @@ type ClusterCmdFlags struct {
 	DryRun             bool
 	SkipDepsDownload   bool
 	SkipDepsValidation bool
+	NoTTY              bool
 	Kubeconfig         string
 }
 
@@ -98,6 +99,7 @@ func NewClusterCmd(tracker *analytics.Tracker) *cobra.Command {
 
 			// Init packages.
 			execx.Debug = flags.Debug || flags.DryRun
+			execx.NoTTY = flags.NoTTY
 
 			// Download the distribution.
 			logrus.Info("Downloading distribution...")
@@ -267,6 +269,11 @@ func getCreateClusterCmdFlags(cmd *cobra.Command, tracker *analytics.Tracker, cm
 		return ClusterCmdFlags{}, fmt.Errorf("%w: %s", ErrParsingFlag, "dry-run")
 	}
 
+	noTTY, err := cmdutil.BoolFlag(cmd, "no-tty", tracker, cmdEvent)
+	if err != nil {
+		return ClusterCmdFlags{}, fmt.Errorf("%w: %s", ErrParsingFlag, "no-tty")
+	}
+
 	skipDepsDownload, err := cmdutil.BoolFlag(cmd, "skip-deps-download", tracker, cmdEvent)
 	if err != nil {
 		return ClusterCmdFlags{}, fmt.Errorf("%w: %s", ErrParsingFlag, "skip-deps-download")
@@ -293,6 +300,7 @@ func getCreateClusterCmdFlags(cmd *cobra.Command, tracker *analytics.Tracker, cm
 		DryRun:             dryRun,
 		SkipDepsDownload:   skipDepsDownload,
 		SkipDepsValidation: skipDepsValidation,
+		NoTTY:              noTTY,
 		Kubeconfig:         kubeconfig,
 	}, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,11 +89,8 @@ Furyctl is a simple CLI tool to:
 				w := logrus.StandardLogger().Out
 
 				cflag, ok := cobrax.Flag[bool](cmd, "no-tty").(bool)
-				if ok && cflag {
-					w = iox.NewNullWriter()
-					f := new(logrus.TextFormatter)
-					f.DisableColors = true
-					logrus.SetFormatter(f)
+				if !ok {
+					logrus.Fatalf("error while getting no-tty flag")
 				}
 
 				cfg.Spinner = spinner.New(spinner.CharSets[spinnerStyle], timeout, spinner.WithWriter(w))
@@ -120,7 +117,7 @@ Furyctl is a simple CLI tool to:
 				// Set log level.
 				dflag, ok := cobrax.Flag[bool](cmd, "debug").(bool)
 				if ok {
-					logrusx.InitLog(logFile, dflag)
+					logrusx.InitLog(logFile, dflag, cflag)
 				}
 
 				logrus.Debugf("logging to: %s", logPath)

--- a/internal/tool/terraform/runner.go
+++ b/internal/tool/terraform/runner.go
@@ -49,8 +49,14 @@ func (r *Runner) CmdPath() string {
 }
 
 func (r *Runner) Init() error {
+	args := []string{"init"}
+
+	if execx.NoTTY {
+		args = append(args, "-no-color")
+	}
+
 	err := execx.NewCmd(r.paths.Terraform, execx.CmdOptions{
-		Args:     []string{"init"},
+		Args:     args,
 		Executor: r.executor,
 		WorkDir:  r.paths.WorkDir,
 	}).Run()
@@ -139,8 +145,14 @@ func (r *Runner) Apply(timestamp int64) (OutputJSON, error) {
 }
 
 func (r *Runner) Destroy() error {
+	args := []string{"destroy", "-auto-approve"}
+
+	if execx.NoTTY {
+		args = append(args, "-no-color")
+	}
+
 	err := execx.NewCmd(r.paths.Terraform, execx.CmdOptions{
-		Args:     []string{"destroy", "-auto-approve"},
+		Args:     args,
 		Executor: r.executor,
 		WorkDir:  r.paths.WorkDir,
 	}).Run()

--- a/internal/x/exec/cmd.go
+++ b/internal/x/exec/cmd.go
@@ -19,6 +19,7 @@ import (
 var (
 	Debug         = false  //nolint:gochecknoglobals // This variable is shared between all the command instances.
 	LogFile       *os.File //nolint:gochecknoglobals // This variable is shared between all the command instances.
+	NoTTY         = false  //nolint:gochecknoglobals // This variable is shared between all the command instances.
 	ErrCmdFailed  = errors.New("command failed")
 	ErrCmdTimeout = errors.New("command timed out")
 )

--- a/internal/x/logrus/config.go
+++ b/internal/x/logrus/config.go
@@ -44,7 +44,7 @@ func newFormatterHook(writer io.Writer, formatter logrus.Formatter, logLevels []
 	}
 }
 
-func InitLog(logFile *os.File, debug bool) { //nolint:revive // debug is a boolean flag
+func InitLog(logFile *os.File, debug, disableColors bool) { //nolint:revive // debug is a boolean flag
 	logrus.SetOutput(io.Discard)
 
 	stdLevels := []logrus.Level{
@@ -67,7 +67,8 @@ func InitLog(logFile *os.File, debug bool) { //nolint:revive // debug is a boole
 
 		stdOutHook := newFormatterHook(os.Stdout, &logrus.TextFormatter{
 			DisableTimestamp: true,
-			ForceColors:      true,
+			ForceColors:      !disableColors,
+			DisableColors:    disableColors,
 		}, stdLevels)
 
 		logrus.AddHook(stdOutHook)


### PR DESCRIPTION
Changelist:

- refactor cluster delete flags as already done in cluster create
- use no-tty in logrus init function
- add support to terraform init && delete to no-tty (-no-color)

fixes #191 