### PR TITLE
Feat: added json logs to external tools

### DIFF
--- a/internal/x/bytes/transform.go
+++ b/internal/x/bytes/transform.go
@@ -66,6 +66,10 @@ func ToJSONLogFormat(level, action string) TransformFunc {
 	}
 }
 
+func AppendNewLine(p []byte) ([]byte, error) {
+	return append(p, '\n'), nil
+}
+
 func Identity(b []byte) ([]byte, error) {
 	return b, nil
 }

--- a/internal/x/bytes/transform.go
+++ b/internal/x/bytes/transform.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bytesx
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	logrusx "github.com/sighupio/furyctl/internal/x/logrus"
+)
+
+type TransformFunc func([]byte) ([]byte, error)
+
+// This constant was taken from the following public repository:
+// Name: stripansi
+// URL: https://github.com/acarl005/stripansi
+// Commit: 5a71ef0e047df0427e87a79f27009029921f1f9b
+// Author: https://github.com/acarl005
+// License: MIT License.
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))" //nolint:lll // Cannot split regex in multiple lines.
+
+var ErrJSONTransform = errors.New("error while transform to json")
+
+func StripColor(p []byte) ([]byte, error) {
+	reg := regexp.MustCompile(ansi)
+
+	s := string(p)
+
+	strippedS := reg.ReplaceAllString(s, "")
+
+	return []byte(strippedS), nil
+}
+
+func ToJSONLogFormat(level string, action *string) TransformFunc {
+	timestamp := time.Now().Format(time.RFC3339)
+
+	return func(p []byte) ([]byte, error) {
+		msg := string(p)
+
+		lf := logrusx.LogFormat{
+			Level:  level,
+			Action: action,
+			Msg:    msg,
+			Time:   timestamp,
+		}
+
+		out, err := json.Marshal(lf)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrJSONTransform, err)
+		}
+
+		return out, nil
+	}
+}
+
+func Identity(b []byte) ([]byte, error) {
+	return b, nil
+}

--- a/internal/x/bytes/transform_test.go
+++ b/internal/x/bytes/transform_test.go
@@ -113,6 +113,53 @@ func TestToJSONLogFormat(t *testing.T) {
 	}
 }
 
+func TestAppendNewLine(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc    string
+		input   string
+		wantStr string
+		wantErr bool
+	}{
+		{
+			"empty string",
+			"",
+			"\n",
+			false,
+		},
+		{
+			"simple string",
+			"test",
+			"test\n",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte(tc.input)
+
+			gotStr, err := bytesx.AppendNewLine(input)
+			if err != nil && !tc.wantErr {
+				t.Fatalf("expected to not get an error: %v", err)
+			}
+
+			if err == nil && tc.wantErr {
+				t.Fatalf("expected to get an error")
+			}
+
+			if string(gotStr) != tc.wantStr {
+				t.Errorf("want = %s, got = %s", tc.wantStr, gotStr)
+			}
+		})
+	}
+}
+
 func TestIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/x/bytes/transform_test.go
+++ b/internal/x/bytes/transform_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bytesx_test
+
+import (
+	"strings"
+	"testing"
+
+	bytesx "github.com/sighupio/furyctl/internal/x/bytes"
+)
+
+func TestStripColor(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc    string
+		input   string
+		wantStr string
+		wantErr bool
+	}{
+		{
+			"empty string",
+			"",
+			"",
+			false,
+		},
+		{
+			"no color",
+			"test",
+			"test",
+			false,
+		},
+		{
+			"color",
+			"\x1b[31mtest\x1b[0m",
+			"test",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte(tc.input)
+
+			gotStr, err := bytesx.StripColor(input)
+			if err != nil && !tc.wantErr {
+				t.Fatalf("expected to not get an error: %v", err)
+			}
+
+			if err == nil && tc.wantErr {
+				t.Fatalf("expected to get an error")
+			}
+
+			if string(gotStr) != tc.wantStr {
+				t.Errorf("want = %s, got = %s", tc.wantStr, gotStr)
+			}
+		})
+	}
+}
+
+func TestToJSONLogFormat(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc    string
+		setup   func() (string, string, *string)
+		wantStr string
+		wantErr bool
+	}{
+		{
+			"empty string",
+			func() (string, string, *string) {
+				action := "test"
+
+				return "", "debug", &action
+			},
+			"\"level\":\"debug\",\"action\":\"test\",\"msg\":\"\"",
+			false,
+		},
+		{
+			"nil action",
+			func() (string, string, *string) {
+				return "", "debug", nil
+			},
+			"\"level\":\"debug\",\"msg\":\"\"",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			input, level, action := tc.setup()
+
+			gotStr, err := bytesx.ToJSONLogFormat(level, action)([]byte(input))
+			if err != nil && !tc.wantErr {
+				t.Fatalf("expected to not get an error: %v", err)
+			}
+
+			if err == nil && tc.wantErr {
+				t.Fatalf("expected to get an error")
+			}
+
+			if !strings.Contains(string(gotStr), tc.wantStr) {
+				t.Errorf("want = %s, got = %s", tc.wantStr, gotStr)
+			}
+		})
+	}
+}
+
+func TestIdentity(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc    string
+		input   string
+		wantStr string
+		wantErr bool
+	}{
+		{
+			"empty string",
+			"",
+			"",
+			false,
+		},
+		{
+			"simple string",
+			"test",
+			"test",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte(tc.input)
+
+			gotStr, err := bytesx.Identity(input)
+			if err != nil && !tc.wantErr {
+				t.Fatalf("expected to not get an error: %v", err)
+			}
+
+			if err == nil && tc.wantErr {
+				t.Fatalf("expected to get an error")
+			}
+
+			if string(gotStr) != tc.wantStr {
+				t.Errorf("want = %s, got = %s", tc.wantStr, gotStr)
+			}
+		})
+	}
+}

--- a/internal/x/bytes/transform_test.go
+++ b/internal/x/bytes/transform_test.go
@@ -68,24 +68,22 @@ func TestToJSONLogFormat(t *testing.T) {
 
 	testCases := []struct {
 		desc    string
-		setup   func() (string, string, *string)
+		setup   func() (string, string, string)
 		wantStr string
 		wantErr bool
 	}{
 		{
 			"empty string",
-			func() (string, string, *string) {
-				action := "test"
-
-				return "", "debug", &action
+			func() (string, string, string) {
+				return "", "debug", "test"
 			},
 			"\"level\":\"debug\",\"action\":\"test\",\"msg\":\"\"",
 			false,
 		},
 		{
 			"nil action",
-			func() (string, string, *string) {
-				return "", "debug", nil
+			func() (string, string, string) {
+				return "", "debug", ""
 			},
 			"\"level\":\"debug\",\"msg\":\"\"",
 			false,

--- a/internal/x/exec/cmd.go
+++ b/internal/x/exec/cmd.go
@@ -49,6 +49,7 @@ func NewCmd(name string, opts CmdOptions) *Cmd {
 			Transforms: []bytesx.TransformFunc{
 				bytesx.StripColor,
 				bytesx.ToJSONLogFormat("debug", action),
+				bytesx.AppendNewLine,
 			},
 		}
 

--- a/internal/x/exec/cmd.go
+++ b/internal/x/exec/cmd.go
@@ -14,6 +14,9 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	bytesx "github.com/sighupio/furyctl/internal/x/bytes"
+	iox "github.com/sighupio/furyctl/internal/x/io"
 )
 
 var (
@@ -32,12 +35,25 @@ func NewCmd(name string, opts CmdOptions) *Cmd {
 	outLog := bytes.NewBufferString("")
 	errLog := bytes.NewBufferString("")
 
-	outWriters := []io.Writer{outLog}
-	errWriters := []io.Writer{errLog}
+	outWriters := []iox.WriterTransform{{W: outLog}}
+	errWriters := []iox.WriterTransform{{W: errLog}}
 
 	if LogFile != nil {
-		outWriters = append(outWriters, LogFile)
-		errWriters = append(errWriters, LogFile)
+		cmd := strings.Split(name, "/")
+		cmdArgs := strings.Join(opts.Args, " ")
+
+		action := cmd[len(cmd)-1] + " " + cmdArgs
+
+		stripColor := iox.WriterTransform{
+			W: LogFile,
+			Transforms: []bytesx.TransformFunc{
+				bytesx.StripColor,
+				bytesx.ToJSONLogFormat("debug", &action),
+			},
+		}
+
+		outWriters = append(outWriters, stripColor)
+		errWriters = append(errWriters, stripColor)
 	}
 
 	if opts.Executor == nil {
@@ -45,21 +61,21 @@ func NewCmd(name string, opts CmdOptions) *Cmd {
 	}
 
 	if opts.Out != nil {
-		outWriters = append(outWriters, opts.Out)
+		outWriters = append(outWriters, iox.WriterTransform{W: opts.Out})
 	}
 
 	if opts.Err != nil {
-		errWriters = append(errWriters, opts.Err)
+		errWriters = append(errWriters, iox.WriterTransform{W: opts.Err})
 	}
 
 	if Debug || LogFile == nil {
-		outWriters = append(outWriters, os.Stdout)
-		errWriters = append(errWriters, os.Stderr)
+		outWriters = append(outWriters, iox.WriterTransform{W: os.Stdout})
+		errWriters = append(errWriters, iox.WriterTransform{W: os.Stderr})
 	}
 
 	coreCmd := opts.Executor.Command(name, opts.Args...)
-	coreCmd.Stdout = io.MultiWriter(outWriters...)
-	coreCmd.Stderr = io.MultiWriter(errWriters...)
+	coreCmd.Stdout = iox.MultiWriterTransform(outWriters...)
+	coreCmd.Stderr = iox.MultiWriterTransform(errWriters...)
 	coreCmd.Dir = opts.WorkDir
 
 	return &Cmd{

--- a/internal/x/exec/cmd.go
+++ b/internal/x/exec/cmd.go
@@ -48,7 +48,7 @@ func NewCmd(name string, opts CmdOptions) *Cmd {
 			W: LogFile,
 			Transforms: []bytesx.TransformFunc{
 				bytesx.StripColor,
-				bytesx.ToJSONLogFormat("debug", &action),
+				bytesx.ToJSONLogFormat("debug", action),
 			},
 		}
 

--- a/internal/x/io/multiwritertransform.go
+++ b/internal/x/io/multiwritertransform.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package iox
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	bytesx "github.com/sighupio/furyctl/internal/x/bytes"
+)
+
+var ErrWriterTransform = errors.New("writer transform error")
+
+type WriterTransform struct {
+	W          io.Writer
+	Transforms []bytesx.TransformFunc
+}
+
+type multiWriterTransform struct {
+	writers []WriterTransform
+}
+
+func (m *multiWriterTransform) Write(p []byte) (int, error) {
+	var err error
+
+	for _, w := range m.writers {
+		s := p
+
+		for _, transform := range w.Transforms {
+			s, err = transform(s)
+			if err != nil {
+				return 0, fmt.Errorf("%w: %v", ErrWriterTransform, err)
+			}
+		}
+
+		n, err := w.W.Write(s)
+		if err != nil {
+			return n, fmt.Errorf("%w: %v", ErrWriterTransform, err)
+		}
+
+		if n != len(s) {
+			return n, io.ErrShortWrite
+		}
+	}
+
+	return len(p), nil
+}
+
+func MultiWriterTransform(writers ...WriterTransform) io.Writer {
+	return &multiWriterTransform{writers}
+}

--- a/internal/x/io/multiwritertransform_test.go
+++ b/internal/x/io/multiwritertransform_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package iox_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	bytesx "github.com/sighupio/furyctl/internal/x/bytes"
+	iox "github.com/sighupio/furyctl/internal/x/io"
+)
+
+func setup(t *testing.T) (*bytes.Buffer, io.Writer) {
+	t.Helper()
+
+	stringBuffer := bytes.NewBufferString("")
+
+	multiWriter := iox.MultiWriterTransform(iox.WriterTransform{
+		W:          stringBuffer,
+		Transforms: []bytesx.TransformFunc{bytesx.Identity},
+	})
+
+	return stringBuffer, multiWriter
+}
+
+func TestWrite(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc    string
+		input   string
+		wantStr string
+		wantErr bool
+	}{
+		{
+			"empty string",
+			"",
+			"",
+			false,
+		},
+		{
+			"simple string",
+			"test",
+			"test",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			input := tc.input
+
+			buf, multiWriter := setup(t)
+
+			_, err := multiWriter.Write([]byte(input))
+			if err != nil && !tc.wantErr {
+				t.Fatalf("expected to not get an error: %v", err)
+			}
+
+			if err == nil && tc.wantErr {
+				t.Fatalf("expected to get an error")
+			}
+
+			gotStr := buf.String()
+
+			if gotStr != tc.wantStr {
+				t.Errorf("want = %s, got = %s", tc.wantStr, gotStr)
+			}
+		})
+	}
+}

--- a/internal/x/logrus/config.go
+++ b/internal/x/logrus/config.go
@@ -12,6 +12,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type LogFormat struct {
+	Level  string  `json:"level"`
+	Action *string `json:"action,omitempty"`
+	Msg    string  `json:"msg"`
+	Time   string  `json:"time"`
+}
+
 type formatterHook struct {
 	Writer    io.Writer
 	LogLevels []logrus.Level


### PR DESCRIPTION
ChangeList:

-  introduced MultiWriterTransform: adds the capability of changing the input []byte via chained functions before writing to multiple io.Writer instances
- added StripColor, ToJSONLogFormat transform functions to remove colors from buffer strings and encode them to a JSON log format
- refactor cmd to use MultiWriterTransform instead of MultiWriter

log format: `{"level":<log level>, "action":<command executed>, "msg":<command output>, "time":<timestamp>}`

example output:
`{"level":"debug","action":"terraform plan -no-color -out plan/terraform.plan","msg":"\n─────────────────────────────────────────────────────────────────────────────\n\nSaved the plan to: plan/terraform.plan\n\nTo perform exactly these actions, run the following command to apply:\n    terraform apply \"plan/terraform.plan\"\n","time":"2023-01-30T15:53:25+01:00"}`