### PR TITLE
feature: adds containerRuntime parameter to EKS node pools

### DIFF
--- a/data/provisioners/cluster/eks/variables.tf
+++ b/data/provisioners/cluster/eks/variables.tf
@@ -15,7 +15,7 @@ variable "cluster_version" {
 }
 
 variable "cluster_log_retention_days" {
-  type = number
+  type    = number
   default = 90
 }
 variable "network" {
@@ -46,6 +46,7 @@ variable "node_pools" {
     max_size              = number
     instance_type         = string
     spot_instance         = bool
+    container_runtime     = optional(string)
     os                    = optional(string)
     max_pods              = optional(number) # null to use default upstream configuration
     volume_size           = number
@@ -67,7 +68,7 @@ variable "node_pools" {
 }
 
 variable "node_pools_launch_kind" {
-  type = string
+  type        = string
   description = "Choose if the node pools will use launch_configurations, launch_templates or both"
 }
 

--- a/internal/cluster/configuration/eks.go
+++ b/internal/cluster/configuration/eks.go
@@ -40,6 +40,7 @@ type EKSNodePool struct {
 	MinSize                 int                 `yaml:"minSize"`
 	MaxSize                 int                 `yaml:"maxSize"`
 	InstanceType            string              `yaml:"instanceType"`
+	ContainerRuntime        string              `yaml:"containerRuntime"`
 	OS                      string              `yaml:"os"`
 	TargetGroups            []string            `yaml:"targetGroups"`
 	MaxPods                 int                 `yaml:"maxPods"`

--- a/internal/cluster/provisioners/eks/provisioner.go
+++ b/internal/cluster/provisioners/eks/provisioner.go
@@ -181,6 +181,9 @@ func (e EKS) createVarFile() (err error) {
 			} else {
 				buffer.WriteString("version = null\n")
 			}
+			if np.ContainerRuntime != "" {
+				buffer.WriteString(fmt.Sprintf("container_runtime = \"%v\"\n", np.ContainerRuntime))
+			}
 			buffer.WriteString(fmt.Sprintf("spot_instance = %v\n", np.SpotInstance))
 			buffer.WriteString(fmt.Sprintf("min_size = %v\n", np.MinSize))
 			buffer.WriteString(fmt.Sprintf("max_size = %v\n", np.MaxSize))

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -36,12 +36,12 @@ func enabled() bool {
 	return !disable
 }
 
-//Version will set the version of the CLI
+// Version will set the version of the CLI
 func Version(v string) {
 	version = v
 }
 
-//Disable will disable analytics
+// Disable will disable analytics
 func Disable(d bool) {
 	disable = d
 }


### PR DESCRIPTION
Implements the new feature in the fury-eks-installer that allows to specify containerd as container runtime interface for clusters that still default to dockershim

> **Warning**
> Needs a release of the eks-installer with sighupio/fury-eks-installer#50 merged first