### PR TITLE
Feat: added support to AWS_PROFILE

### DIFF
--- a/internal/dependencies/envvars/validator.go
+++ b/internal/dependencies/envvars/validator.go
@@ -61,7 +61,7 @@ func (*Validator) checkEKSCluster() ([]string, []error) {
 	}
 
 	if len(missingAwsVars) > 0 {
-		errs = append(errs, fmt.Errorf("%w, either AWS_PROFILE or the following vars must be set: %s",
+		errs = append(errs, fmt.Errorf("%w, either AWS_PROFILE or the following environment variables must be set: %s",
 			ErrMissingEnvVars, strings.Join(missingAwsVars, ", ")))
 
 		return oks, errs

--- a/internal/dependencies/envvars/validator.go
+++ b/internal/dependencies/envvars/validator.go
@@ -34,10 +34,10 @@ func (*Validator) checkEKSCluster() ([]string, []error) {
 	oks := make([]string, 0)
 	errs := make([]error, 0)
 
-	var otherAwsVars []string
+	var missingAwsVars []string
 
 	if os.Getenv("AWS_DEFAULT_REGION") == "" {
-		errs = append(errs, fmt.Errorf("%w AWS_DEFAULT_REGION", ErrMissingRequiredEnvVar))
+		errs = append(errs, fmt.Errorf("%w: AWS_DEFAULT_REGION", ErrMissingRequiredEnvVar))
 	} else {
 		oks = append(oks, "AWS_DEFAULT_REGION")
 	}
@@ -49,20 +49,20 @@ func (*Validator) checkEKSCluster() ([]string, []error) {
 	}
 
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		otherAwsVars = append(otherAwsVars, "AWS_ACCESS_KEY_ID")
+		missingAwsVars = append(missingAwsVars, "AWS_ACCESS_KEY_ID")
 	} else {
 		oks = append(oks, "AWS_ACCESS_KEY_ID")
 	}
 
 	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-		otherAwsVars = append(otherAwsVars, "AWS_SECRET_ACCESS_KEY")
+		missingAwsVars = append(missingAwsVars, "AWS_SECRET_ACCESS_KEY")
 	} else {
 		oks = append(oks, "AWS_SECRET_ACCESS_KEY")
 	}
 
-	if len(otherAwsVars) > 0 {
-		errs = append(errs, fmt.Errorf("%w, either AWS_Profile or the following: %s",
-			ErrMissingEnvVars, strings.Join(otherAwsVars, ", ")))
+	if len(missingAwsVars) > 0 {
+		errs = append(errs, fmt.Errorf("%w, either AWS_PROFILE or the following vars must be set: %s",
+			ErrMissingEnvVars, strings.Join(missingAwsVars, ", ")))
 
 		return oks, errs
 	}

--- a/internal/dependencies/envvars/validator.go
+++ b/internal/dependencies/envvars/validator.go
@@ -8,9 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 )
 
-var ErrMissingEnvVar = errors.New("missing environment variable")
+var (
+	ErrMissingEnvVars        = errors.New("missing environment variables")
+	ErrMissingRequiredEnvVar = errors.New("missing required environment variable")
+)
 
 func NewValidator() *Validator {
 	return &Validator{}
@@ -30,22 +34,37 @@ func (*Validator) checkEKSCluster() ([]string, []error) {
 	oks := make([]string, 0)
 	errs := make([]error, 0)
 
+	var otherAwsVars []string
+
+	if os.Getenv("AWS_DEFAULT_REGION") == "" {
+		errs = append(errs, fmt.Errorf("%w AWS_DEFAULT_REGION", ErrMissingRequiredEnvVar))
+	} else {
+		oks = append(oks, "AWS_DEFAULT_REGION")
+	}
+
+	if os.Getenv("AWS_PROFILE") != "" {
+		oks = append(oks, "AWS_PROFILE")
+
+		return oks, errs
+	}
+
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		errs = append(errs, fmt.Errorf("AWS_ACCESS_KEY_ID: %w", ErrMissingEnvVar))
+		otherAwsVars = append(otherAwsVars, "AWS_ACCESS_KEY_ID")
 	} else {
 		oks = append(oks, "AWS_ACCESS_KEY_ID")
 	}
 
 	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-		errs = append(errs, fmt.Errorf("AWS_SECRET_ACCESS_KEY: %w", ErrMissingEnvVar))
+		otherAwsVars = append(otherAwsVars, "AWS_SECRET_ACCESS_KEY")
 	} else {
 		oks = append(oks, "AWS_SECRET_ACCESS_KEY")
 	}
 
-	if os.Getenv("AWS_DEFAULT_REGION") == "" {
-		errs = append(errs, fmt.Errorf("AWS_DEFAULT_REGION: %w", ErrMissingEnvVar))
-	} else {
-		oks = append(oks, "AWS_DEFAULT_REGION")
+	if len(otherAwsVars) > 0 {
+		errs = append(errs, fmt.Errorf("%w, either AWS_Profile or the following: %s",
+			ErrMissingEnvVars, strings.Join(otherAwsVars, ", ")))
+
+		return oks, errs
 	}
 
 	return oks, errs

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -212,9 +212,9 @@ var (
 				Expect(out).To(ContainSubstring("kubectl:"))
 				Expect(out).To(ContainSubstring("kustomize:"))
 				Expect(out).To(ContainSubstring("furyagent:"))
-				Expect(out).To(ContainSubstring("AWS_ACCESS_KEY_ID:"))
-				Expect(out).To(ContainSubstring("AWS_SECRET_ACCESS_KEY:"))
-				Expect(out).To(ContainSubstring("AWS_DEFAULT_REGION:"))
+				Expect(out).To(ContainSubstring("missing required environment variable AWS_DEFAULT_REGION"))
+				Expect(out).To(ContainSubstring("missing environment variables, either AWS_Profile or the " +
+					"following: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 
 			It("should report an error when dependencies are wrong", Serial, func() {
@@ -250,9 +250,9 @@ var (
 				Expect(out).To(
 					ContainSubstring("terraform: wrong tool version - installed = 0.15.3, expected = 0.15.4"),
 				)
-				Expect(out).To(ContainSubstring("AWS_ACCESS_KEY_ID: missing environment variable"))
-				Expect(out).To(ContainSubstring("AWS_SECRET_ACCESS_KEY: missing environment variable"))
-				Expect(out).To(ContainSubstring("AWS_DEFAULT_REGION: missing environment variable"))
+				Expect(out).To(ContainSubstring("missing required environment variable AWS_DEFAULT_REGION"))
+				Expect(out).To(ContainSubstring("missing environment variables, either AWS_Profile or the " +
+					"following: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 
 			It("should exit without errors when dependencies are correct", Serial, func() {

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -213,7 +213,7 @@ var (
 				Expect(out).To(ContainSubstring("kustomize:"))
 				Expect(out).To(ContainSubstring("furyagent:"))
 				Expect(out).To(ContainSubstring("missing required environment variable AWS_DEFAULT_REGION"))
-				Expect(out).To(ContainSubstring("missing environment variables, either AWS_Profile or the " +
+				Expect(out).To(ContainSubstring("missing environment variables, either AWS_PROFILE or the " +
 					"following: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 
@@ -251,7 +251,7 @@ var (
 					ContainSubstring("terraform: wrong tool version - installed = 0.15.3, expected = 0.15.4"),
 				)
 				Expect(out).To(ContainSubstring("missing required environment variable AWS_DEFAULT_REGION"))
-				Expect(out).To(ContainSubstring("missing environment variables, either AWS_Profile or the " +
+				Expect(out).To(ContainSubstring("missing environment variables, AWS_PROFILE or the following vars must be set: " +
 					"following: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -252,7 +252,7 @@ var (
 				)
 				Expect(out).To(ContainSubstring("missing required environment variable: AWS_DEFAULT_REGION"))
 				Expect(out).To(ContainSubstring("missing environment variables, either AWS_PROFILE or the " +
-					"following vars must be set:  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
+					"following vars must be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 
 			It("should exit without errors when dependencies are correct", Serial, func() {

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -214,7 +214,7 @@ var (
 				Expect(out).To(ContainSubstring("furyagent:"))
 				Expect(out).To(ContainSubstring("missing required environment variable: AWS_DEFAULT_REGION"))
 				Expect(out).To(ContainSubstring("missing environment variables, either AWS_PROFILE or the " +
-					"following vars must be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
+					"following environment variables must be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 
 			It("should report an error when dependencies are wrong", Serial, func() {
@@ -252,7 +252,7 @@ var (
 				)
 				Expect(out).To(ContainSubstring("missing required environment variable: AWS_DEFAULT_REGION"))
 				Expect(out).To(ContainSubstring("missing environment variables, either AWS_PROFILE or the " +
-					"following vars must be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
+					"following environment variables must be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 
 			It("should exit without errors when dependencies are correct", Serial, func() {

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -212,9 +212,9 @@ var (
 				Expect(out).To(ContainSubstring("kubectl:"))
 				Expect(out).To(ContainSubstring("kustomize:"))
 				Expect(out).To(ContainSubstring("furyagent:"))
-				Expect(out).To(ContainSubstring("missing required environment variable AWS_DEFAULT_REGION"))
+				Expect(out).To(ContainSubstring("missing required environment variable: AWS_DEFAULT_REGION"))
 				Expect(out).To(ContainSubstring("missing environment variables, either AWS_PROFILE or the " +
-					"following: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
+					"following vars must be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 
 			It("should report an error when dependencies are wrong", Serial, func() {
@@ -250,9 +250,9 @@ var (
 				Expect(out).To(
 					ContainSubstring("terraform: wrong tool version - installed = 0.15.3, expected = 0.15.4"),
 				)
-				Expect(out).To(ContainSubstring("missing required environment variable AWS_DEFAULT_REGION"))
-				Expect(out).To(ContainSubstring("missing environment variables, AWS_PROFILE or the following vars must be set: " +
-					"following: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
+				Expect(out).To(ContainSubstring("missing required environment variable: AWS_DEFAULT_REGION"))
+				Expect(out).To(ContainSubstring("missing environment variables, either AWS_PROFILE or the " +
+					"following vars must be set:  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
 
 			It("should exit without errors when dependencies are correct", Serial, func() {


### PR DESCRIPTION
Changelist:
- added support to AWS_PROFILE
- modified error message when validating environment variables

missing credentials:
![missing credentials](https://user-images.githubusercontent.com/83355398/220368590-22db349d-fbac-4b24-b4af-32c12763ad95.png)

missing AWS_DEFAULT_REGION ( required https://github.com/hashicorp/terraform-provider-aws/issues/7750 ):
![missing AWS_DEFAULT_REGION](https://user-images.githubusercontent.com/83355398/220368608-60536d2e-3453-466c-9cbe-4b876af24b44.png)



fixes #234 