### PR TITLE
Chore: removed warning about cluster reachability when in dry-run

### DIFF
--- a/internal/apis/kfd/v1alpha2/eks/creator.go
+++ b/internal/apis/kfd/v1alpha2/eks/creator.go
@@ -242,6 +242,12 @@ func (v *ClusterCreator) allPhases(
 		}
 	}
 
+	if v.dryRun {
+		logrus.Info("Kubernetes Fury cluster created successfully (dry-run mode)")
+
+		return nil
+	}
+
 	logrus.Info("Kubernetes Fury cluster created successfully")
 
 	if v.furyctlConf.Spec.Infrastructure != nil {
@@ -281,6 +287,7 @@ func (v *ClusterCreator) setupPhases() (*create.Infrastructure, *create.Kubernet
 		v.kfdManifest,
 		infra.OutputsPath,
 		v.dryRun,
+		v.phase,
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error while initiating distribution phase: %w", err)


### PR DESCRIPTION
Changelist:

- removed cluster reachability warning when running --dry-run without --phase
- phase distribution will not return an error when terraform plan fails in --dry-run
 
closes #237 