### PR TITLE
feat: rework furyctl dump template cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ needed to create a Kubernetes Fury cluster.
 
 > 🔥 **Advanced Tip**
 >
-> Using the command `furyctl dump template` with the flag `-w` pointing to the local location of the repository `fury-distribution`,
+> Using the command `furyctl dump template` with the flag `--distro-location` pointing to the local location of the repository `fury-distribution`,
 > will run the template engine on the modules and generate the final manifests that will be applied to the cluster.
 
 #### Cluster creation

--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -36,9 +36,9 @@ func NewTemplateCmd(tracker *analytics.Tracker) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "template",
-		Short: "Renders the distribution's manifests from a template and a configuration file",
-		Long: `Generates a folder with the Kustomization project for deploying Kubernetes Fury Distribution into a cluster.
-The generated folder will be created starting from a provided template and the parameters set in a configuration file that is merged with default values.`,
+		Short: "Renders the distribution's infrastructure code from template files and a configuration file",
+		Long: `Generates a folder with the Terraform and Kustomization code for deploying the Kubernetes Fury Distribution into a cluster.
+The generated folder will be created starting from a provided templates folder and the parameters set in a configuration file that is merged with default values.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRun: func(cmd *cobra.Command, _ []string) {
@@ -86,7 +86,7 @@ The generated folder will be created starting from a provided template and the p
 
 			logrus.Info("Generating distribution manifests...")
 
-			distroManBuilder := distribution.NewManifestBuilder(
+			distroManBuilder := distribution.NewIACBuilder(
 				furyctlFile,
 				res.RepoPath,
 				flags.OutDir,

--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -7,8 +7,6 @@ package dump
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -17,23 +15,12 @@ import (
 	"github.com/sighupio/furyctl/internal/cmd/cmdutil"
 	"github.com/sighupio/furyctl/internal/config"
 	"github.com/sighupio/furyctl/internal/distribution"
-	"github.com/sighupio/furyctl/internal/merge"
-	"github.com/sighupio/furyctl/internal/template"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
 	netx "github.com/sighupio/furyctl/internal/x/net"
 	yamlx "github.com/sighupio/furyctl/internal/x/yaml"
 )
 
-const (
-	source           = "templates/distribution"
-	suffix           = ".tpl"
-	defaultsFileName = "furyctl-defaults.yaml"
-)
-
-var (
-	ErrSourceDirDoesNotExist = errors.New("source directory does not exist")
-	ErrParsingFlag           = errors.New("error while parsing flag")
-)
+var ErrParsingFlag = errors.New("error while parsing flag")
 
 type TemplateCmdFlags struct {
 	DryRun         bool
@@ -86,16 +73,6 @@ The generated folder will be created starting from a provided template and the p
 				return fmt.Errorf("error while validating configuration file: %w", err)
 			}
 
-			defaultsFilePath := filepath.Join(res.RepoPath, defaultsFileName)
-
-			distributionFile, err := yamlx.FromFileV2[map[any]any](defaultsFilePath)
-			if err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("%s - %w", defaultsFilePath, err)
-			}
-
 			furyctlFile, err := yamlx.FromFileV2[map[any]any](flags.FuryctlPath)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
@@ -104,110 +81,26 @@ The generated folder will be created starting from a provided template and the p
 				return fmt.Errorf("%s - %w", flags.FuryctlPath, err)
 			}
 
-			sourcePath := filepath.Join(res.RepoPath, source)
+			logrus.Info("Generating distribution manifests...")
 
-			if _, err := os.Stat(sourcePath); os.IsNotExist(err) {
-				cmdEvent.AddErrorMessage(ErrSourceDirDoesNotExist)
-				tracker.Track(cmdEvent)
-
-				return ErrSourceDirDoesNotExist
-			}
-
-			merger := merge.NewMerger(
-				merge.NewDefaultModel(distributionFile, ".data"),
-				merge.NewDefaultModel(furyctlFile, ".spec.distribution"),
-			)
-
-			_, err = merger.Merge()
-			if err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error merging files: %w", err)
-			}
-
-			reverseMerger := merge.NewMerger(
-				*merger.GetCustom(),
-				*merger.GetBase(),
-			)
-
-			_, err = reverseMerger.Merge()
-			if err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error merging files: %w", err)
-			}
-
-			tmplCfg, err := template.NewConfig(reverseMerger, reverseMerger, []string{})
-			if err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error creating template config: %w", err)
-			}
-
-			outYaml, err := yamlx.MarshalV2(tmplCfg)
-			if err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error marshaling template config: %w", err)
-			}
-
-			outDirPath, err := os.MkdirTemp("", "furyctl-dist-")
-			if err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error creating temporary directory: %w", err)
-			}
-
-			confPath := filepath.Join(outDirPath, "config.yaml")
-
-			logrus.Debugf("config path = %s", confPath)
-
-			if err = os.WriteFile(confPath, outYaml, os.ModePerm); err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error writing config file: %w", err)
-			}
-
-			if !flags.NoOverwrite {
-				if err = os.RemoveAll(flags.OutDir); err != nil {
-					cmdEvent.AddErrorMessage(err)
-					tracker.Track(cmdEvent)
-
-					return fmt.Errorf("error removing target directory: %w", err)
-				}
-			}
-
-			templateModel, err := template.NewTemplateModel(
-				sourcePath,
+			distroManBuilder := distribution.NewManifestBuilder(
+				furyctlFile,
+				res.RepoPath,
 				flags.OutDir,
-				confPath,
-				outDirPath,
-				suffix,
 				flags.NoOverwrite,
 				flags.DryRun,
 			)
-			if err != nil {
+
+			if err := distroManBuilder.Build(); err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("error creating template model: %w", err)
+				return fmt.Errorf("error while generating distribution manifests: %w", err)
 			}
 
-			err = templateModel.Generate()
-			if err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
+			logrus.Info("Distribution manifests generated successfully")
 
-				return fmt.Errorf("error generating from template: %w", err)
-			}
-
-			cmdEvent.AddSuccessMessage("Distribution template generated successfully")
+			cmdEvent.AddSuccessMessage("Distribution manifests generated successfully")
 			tracker.Track(cmdEvent)
 
 			return nil

--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -7,13 +7,13 @@ package dump
 import (
 	"errors"
 	"fmt"
-	"github.com/sighupio/furyctl/internal/config"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/sighupio/furyctl/internal/analytics"
 	"github.com/sighupio/furyctl/internal/cmd/cmdutil"
+	"github.com/sighupio/furyctl/internal/config"
 	"github.com/sighupio/furyctl/internal/distribution"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
 	netx "github.com/sighupio/furyctl/internal/x/net"

--- a/internal/distribution/iac.go
+++ b/internal/distribution/iac.go
@@ -25,7 +25,7 @@ const (
 
 var ErrSourceDirDoesNotExist = errors.New("source directory does not exist")
 
-type ManifestBuilder struct {
+type IACBuilder struct {
 	furyctlFile map[any]any
 	distroPath  string
 	outDir      string
@@ -33,14 +33,14 @@ type ManifestBuilder struct {
 	dryRun      bool
 }
 
-func NewManifestBuilder(
+func NewIACBuilder(
 	furyctlFile map[any]any,
 	distroPath,
 	outDir string,
 	noOverwrite,
 	dryRun bool,
-) *ManifestBuilder {
-	return &ManifestBuilder{
+) *IACBuilder {
+	return &IACBuilder{
 		furyctlFile: furyctlFile,
 		distroPath:  distroPath,
 		outDir:      outDir,
@@ -49,7 +49,7 @@ func NewManifestBuilder(
 	}
 }
 
-func (m *ManifestBuilder) Build() error {
+func (m *IACBuilder) Build() error {
 	defaultsFile, err := m.defaultsFile()
 	if err != nil {
 		return fmt.Errorf("error getting defaults file: %w", err)
@@ -130,7 +130,7 @@ func (m *ManifestBuilder) Build() error {
 	return nil
 }
 
-func (m *ManifestBuilder) defaultsFile() (map[any]any, error) {
+func (m *IACBuilder) defaultsFile() (map[any]any, error) {
 	defaultsFilePath := filepath.Join(m.distroPath, defaultsFileName)
 
 	defaultsFile, err := yamlx.FromFileV2[map[any]any](defaultsFilePath)
@@ -141,7 +141,7 @@ func (m *ManifestBuilder) defaultsFile() (map[any]any, error) {
 	return defaultsFile, nil
 }
 
-func (m *ManifestBuilder) sourcePath() (string, error) {
+func (m *IACBuilder) sourcePath() (string, error) {
 	sourcePath := filepath.Join(m.distroPath, source)
 
 	if _, err := os.Stat(sourcePath); os.IsNotExist(err) {

--- a/internal/distribution/manifest.go
+++ b/internal/distribution/manifest.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package distribution
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/sighupio/furyctl/internal/merge"
+	"github.com/sighupio/furyctl/internal/template"
+	yamlx "github.com/sighupio/furyctl/internal/x/yaml"
+)
+
+const (
+	source           = "templates/distribution"
+	defaultsFileName = "furyctl-defaults.yaml"
+	suffix           = ".tpl"
+)
+
+var ErrSourceDirDoesNotExist = errors.New("source directory does not exist")
+
+type ManifestBuilder struct {
+	furyctlFile map[any]any
+	distroPath  string
+	outDir      string
+	noOverwrite bool
+	dryRun      bool
+}
+
+func NewManifestBuilder(
+	furyctlFile map[any]any,
+	distroPath,
+	outDir string,
+	noOverwrite,
+	dryRun bool,
+) *ManifestBuilder {
+	return &ManifestBuilder{
+		furyctlFile: furyctlFile,
+		distroPath:  distroPath,
+		outDir:      outDir,
+		noOverwrite: noOverwrite,
+		dryRun:      dryRun,
+	}
+}
+
+func (m *ManifestBuilder) Build() error {
+	defaultsFile, err := m.defaultsFile()
+	if err != nil {
+		return fmt.Errorf("error getting defaults file: %w", err)
+	}
+
+	sourcePath, err := m.sourcePath()
+	if err != nil {
+		return fmt.Errorf("error getting source path: %w", err)
+	}
+
+	merger := merge.NewMerger(
+		merge.NewDefaultModel(defaultsFile, ".data"),
+		merge.NewDefaultModel(m.furyctlFile, ".spec.distribution"),
+	)
+
+	_, err = merger.Merge()
+	if err != nil {
+		return fmt.Errorf("error merging files: %w", err)
+	}
+
+	reverseMerger := merge.NewMerger(
+		*merger.GetCustom(),
+		*merger.GetBase(),
+	)
+
+	_, err = reverseMerger.Merge()
+	if err != nil {
+		return fmt.Errorf("error merging files: %w", err)
+	}
+
+	tmplCfg, err := template.NewConfig(reverseMerger, reverseMerger, []string{"source/terraform", ".gitignore"})
+	if err != nil {
+		return fmt.Errorf("error creating template config: %w", err)
+	}
+
+	outYaml, err := yamlx.MarshalV2(tmplCfg)
+	if err != nil {
+		return fmt.Errorf("error marshaling template config: %w", err)
+	}
+
+	outDirPath, err := os.MkdirTemp("", "furyctl-dist-")
+	if err != nil {
+		return fmt.Errorf("error creating temporary directory: %w", err)
+	}
+
+	confPath := filepath.Join(outDirPath, "config.yaml")
+
+	logrus.Debugf("config path = %s", confPath)
+
+	if err = os.WriteFile(confPath, outYaml, os.ModePerm); err != nil {
+		return fmt.Errorf("error writing config file: %w", err)
+	}
+
+	if !m.noOverwrite {
+		if err = os.RemoveAll(m.outDir); err != nil {
+			return fmt.Errorf("error removing target directory: %w", err)
+		}
+	}
+
+	templateModel, err := template.NewTemplateModel(
+		sourcePath,
+		m.outDir,
+		confPath,
+		outDirPath,
+		suffix,
+		m.noOverwrite,
+		m.dryRun,
+	)
+	if err != nil {
+		return fmt.Errorf("error creating template model: %w", err)
+	}
+
+	err = templateModel.Generate()
+	if err != nil {
+		return fmt.Errorf("error generating from template: %w", err)
+	}
+
+	return nil
+}
+
+func (m *ManifestBuilder) defaultsFile() (map[any]any, error) {
+	defaultsFilePath := filepath.Join(m.distroPath, defaultsFileName)
+
+	defaultsFile, err := yamlx.FromFileV2[map[any]any](defaultsFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("%s - %w", defaultsFilePath, err)
+	}
+
+	return defaultsFile, nil
+}
+
+func (m *ManifestBuilder) sourcePath() (string, error) {
+	sourcePath := filepath.Join(m.distroPath, source)
+
+	if _, err := os.Stat(sourcePath); os.IsNotExist(err) {
+		return "", ErrSourceDirDoesNotExist
+	}
+
+	return sourcePath, nil
+}

--- a/test/data/e2e/dump/template/complex-dry-run/kfd.yaml
+++ b/test/data/e2e/dump/template/complex-dry-run/kfd.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+version: v1.24.1
+modules:
+  auth: v0.0.1
+  aws: v2.0.0
+  dr: v1.9.3
+  ingress: v1.12.2
+  logging: v2.0.3
+  monitoring: v1.14.2
+  opa: v1.7.0
+  networking: v1.10.0
+kubernetes:
+  eks:
+    version: 1.24
+    installer: v1.10.0
+furyctlSchemas:
+  eks:
+    - apiVersion: kfd.sighup.io/v1alpha2
+      kind: EKSCluster
+tools:
+  common:
+    furyagent:
+      version: 0.3.0
+    kubectl:
+      version: 1.24.9
+    kustomize:
+      version: 3.5.3
+    terraform:
+      version: 0.15.4
+  eks:
+    awscli:
+      version: "*"

--- a/test/data/e2e/dump/template/complex/kfd.yaml
+++ b/test/data/e2e/dump/template/complex/kfd.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+version: v1.24.1
+modules:
+  auth: v0.0.1
+  aws: v2.0.0
+  dr: v1.9.3
+  ingress: v1.12.2
+  logging: v2.0.3
+  monitoring: v1.14.2
+  opa: v1.7.0
+  networking: v1.10.0
+kubernetes:
+  eks:
+    version: 1.24
+    installer: v1.10.0
+furyctlSchemas:
+  eks:
+    - apiVersion: kfd.sighup.io/v1alpha2
+      kind: EKSCluster
+tools:
+  common:
+    furyagent:
+      version: 0.3.0
+    kubectl:
+      version: 1.24.9
+    kustomize:
+      version: 3.5.3
+    terraform:
+      version: 0.15.4
+  eks:
+    awscli:
+      version: "*"

--- a/test/data/e2e/dump/template/distribution-yaml-no-data-property/kfd.yaml
+++ b/test/data/e2e/dump/template/distribution-yaml-no-data-property/kfd.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+version: v1.24.1
+modules:
+  auth: v0.0.1
+  aws: v2.0.0
+  dr: v1.9.3
+  ingress: v1.12.2
+  logging: v2.0.3
+  monitoring: v1.14.2
+  opa: v1.7.0
+  networking: v1.10.0
+kubernetes:
+  eks:
+    version: 1.24
+    installer: v1.10.0
+furyctlSchemas:
+  eks:
+    - apiVersion: kfd.sighup.io/v1alpha2
+      kind: EKSCluster
+tools:
+  common:
+    furyagent:
+      version: 0.3.0
+    kubectl:
+      version: 1.24.9
+    kustomize:
+      version: 3.5.3
+    terraform:
+      version: 0.15.4
+  eks:
+    awscli:
+      version: "*"

--- a/test/data/e2e/dump/template/no-distribution-yaml/furyctl.yaml
+++ b/test/data/e2e/dump/template/no-distribution-yaml/furyctl.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  distribution:
+    test:
+      hello: testValue

--- a/test/data/e2e/dump/template/no-furyctl-yaml/kfd.yaml
+++ b/test/data/e2e/dump/template/no-furyctl-yaml/kfd.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+version: v1.24.1
+modules:
+  auth: v0.0.1
+  aws: v2.0.0
+  dr: v1.9.3
+  ingress: v1.12.2
+  logging: v2.0.3
+  monitoring: v1.14.2
+  opa: v1.7.0
+  networking: v1.10.0
+kubernetes:
+  eks:
+    version: 1.24
+    installer: v1.10.0
+furyctlSchemas:
+  eks:
+    - apiVersion: kfd.sighup.io/v1alpha2
+      kind: EKSCluster
+tools:
+  common:
+    furyagent:
+      version: 0.3.0
+    kubectl:
+      version: 1.24.9
+    kustomize:
+      version: 3.5.3
+    terraform:
+      version: 0.15.4
+  eks:
+    awscli:
+      version: "*"

--- a/test/data/e2e/dump/template/simple-dry-run/kfd.yaml
+++ b/test/data/e2e/dump/template/simple-dry-run/kfd.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+version: v1.24.1
+modules:
+  auth: v0.0.1
+  aws: v2.0.0
+  dr: v1.9.3
+  ingress: v1.12.2
+  logging: v2.0.3
+  monitoring: v1.14.2
+  opa: v1.7.0
+  networking: v1.10.0
+kubernetes:
+  eks:
+    version: 1.24
+    installer: v1.10.0
+furyctlSchemas:
+  eks:
+    - apiVersion: kfd.sighup.io/v1alpha2
+      kind: EKSCluster
+tools:
+  common:
+    furyagent:
+      version: 0.3.0
+    kubectl:
+      version: 1.24.9
+    kustomize:
+      version: 3.5.3
+    terraform:
+      version: 0.15.4
+  eks:
+    awscli:
+      version: "*"

--- a/test/data/e2e/dump/template/simple/kfd.yaml
+++ b/test/data/e2e/dump/template/simple/kfd.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+version: v1.24.1
+modules:
+  auth: v0.0.1
+  aws: v2.0.0
+  dr: v1.9.3
+  ingress: v1.12.2
+  logging: v2.0.3
+  monitoring: v1.14.2
+  opa: v1.7.0
+  networking: v1.10.0
+kubernetes:
+  eks:
+    version: 1.24
+    installer: v1.10.0
+furyctlSchemas:
+  eks:
+    - apiVersion: kfd.sighup.io/v1alpha2
+      kind: EKSCluster
+tools:
+  common:
+    furyagent:
+      version: 0.3.0
+    kubectl:
+      version: 1.24.9
+    kustomize:
+      version: 3.5.3
+    terraform:
+      version: 0.15.4
+  eks:
+    awscli:
+      version: "*"

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -337,9 +337,11 @@ var (
 					"dump", "template",
 					"--debug",
 					"--workdir", workdir,
-					"--distro-location", workdir,
+					"--distro-location", ".",
+					"--out-dir", "target",
 					"--disable-analytics",
 					"--log", "stdout",
+					"--skip-validation",
 				}
 				if dryRun {
 					args = append(args, "--dry-run")
@@ -362,7 +364,7 @@ var (
 				out, err := FuryctlDumpTemplate(bp, false)
 
 				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring("furyctl-defaults.yaml: no such file or directory"))
+				Expect(out).To(ContainSubstring("unsupported KFD version"))
 			})
 
 			It("fails if no furyctl.yaml file is found", func() {

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -337,6 +337,7 @@ var (
 					"dump", "template",
 					"--debug",
 					"--workdir", workdir,
+					"--distro-location", workdir,
 					"--disable-analytics",
 					"--log", "stdout",
 				}


### PR DESCRIPTION
Changelist:

- added --distro-location --config --out-dir --skip-validation flag to dump template cmd
- moved cmd logic to the distribution package

fixes #270 