### PR TITLE
Bugfix/303 spec region is not being used

### DIFF
--- a/configs/provisioners/bootstrap/aws/main.tf.tpl
+++ b/configs/provisioners/bootstrap/aws/main.tf.tpl
@@ -10,6 +10,21 @@ terraform {
     key    = "{{ .terraform.backend.s3.keyPrefix }}/infrastructure.json"
     region = "{{ .terraform.backend.s3.region }}"
   }
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = "{{ .global.region }}"
+  default_tags = {
+    tags = {
+      {{range $k, $v := .global.tags}}$k = $v{{end}}
+    }
+  }
 }
 
 module "vpc-and-vpn" {

--- a/configs/provisioners/bootstrap/aws/main.tf.tpl
+++ b/configs/provisioners/bootstrap/aws/main.tf.tpl
@@ -19,10 +19,12 @@ terraform {
 }
 
 provider "aws" {
-  region = "{{ .global.region }}"
-  default_tags = {
+  region = "{{ .spec.region }}"
+  default_tags {
     tags = {
-      {{range $k, $v := .global.tags}}$k = $v{{end}}
+      {{- range $k, $v := .spec.tags }}
+      {{ $k }} = "{{ $v }}"
+      {{- end}}
     }
   }
 }

--- a/configs/provisioners/cluster/eks/data.tf
+++ b/configs/provisioners/cluster/eks/data.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+data "aws_eks_cluster" "fury" {
+  name = var.cluster_name
+  depends_on = [
+    module.fury
+  ]
+}
+
+data "aws_eks_cluster_auth" "fury" {
+  name = var.cluster_name
+  depends_on = [
+    module.fury
+  ]
+}

--- a/configs/provisioners/cluster/eks/main.tf.tpl
+++ b/configs/provisioners/cluster/eks/main.tf.tpl
@@ -16,6 +16,33 @@ terraform {
     key    = "{{ .terraform.backend.s3.keyPrefix }}/cluster.json"
     region = "{{ .terraform.backend.s3.region }}"
   }
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}
+
+provider "aws" {
+  region = "{{ .spec.region }}"
+  default_tags {
+    tags = {
+      {{- range $k, $v := .spec.tags }}
+      {{ $k }} = "{{ $v }}"
+      {{- end}}
+    }
+  }
+}
+
+provider "kubernetes" {
+   host                   = data.aws_eks_cluster.fury.endpoint
+   cluster_ca_certificate = base64decode(data.aws_eks_cluster.fury.certificate_authority[0].data)
+   token                  = data.aws_eks_cluster_auth.fury.token
+   load_config_file       = false
 }
 
 module "fury" {

--- a/configs/provisioners/cluster/eks/variables.tf
+++ b/configs/provisioners/cluster/eks/variables.tf
@@ -15,7 +15,7 @@ variable "cluster_version" {
 }
 
 variable "cluster_log_retention_days" {
-  type = number
+  type    = number
   default = 90
 }
 variable "network" {
@@ -67,7 +67,7 @@ variable "node_pools" {
 }
 
 variable "node_pools_launch_kind" {
-  type = string
+  type        = string
   description = "Choose if the node pools will use launch_configurations, launch_templates or both"
 }
 

--- a/internal/apis/kfd/v1alpha2/eks/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/infrastructure.go
@@ -228,6 +228,10 @@ func (i *Infrastructure) copyFromTemplate() error {
 	eksInstallerPath := path.Join(i.Path, "..", "vendor", "installers", "eks", "modules", "vpc-and-vpn")
 
 	cfg.Data = map[string]map[any]any{
+		"spec": {
+			"region": i.furyctlConf.Spec.Region,
+			"tags":   i.furyctlConf.Spec.Tags,
+		},
 		"kubernetes": {
 			"installerPath": eksInstallerPath,
 		},

--- a/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
@@ -212,6 +212,10 @@ func (k *Kubernetes) copyFromTemplate() error {
 	eksInstallerPath := path.Join(k.Path, "..", "vendor", "installers", "eks", "modules", "eks")
 
 	tfConfVars := map[string]map[any]any{
+		"spec": {
+			"region": k.furyctlConf.Spec.Region,
+			"tags":   k.furyctlConf.Spec.Tags,
+		},
 		"kubernetes": {
 			"installerPath": eksInstallerPath,
 			"tfVersion":     k.kfdManifest.Tools.Common.Terraform.Version,

--- a/internal/dependencies/envvars/validator.go
+++ b/internal/dependencies/envvars/validator.go
@@ -5,10 +5,10 @@
 package envvars
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"strings"
+  "errors"
+  "fmt"
+  "os"
+  "strings"
 )
 
 var (
@@ -35,12 +35,6 @@ func (*Validator) checkEKSCluster() ([]string, []error) {
 	errs := make([]error, 0)
 
 	var missingAwsVars []string
-
-	if os.Getenv("AWS_DEFAULT_REGION") == "" {
-		errs = append(errs, fmt.Errorf("%w: AWS_DEFAULT_REGION", ErrMissingRequiredEnvVar))
-	} else {
-		oks = append(oks, "AWS_DEFAULT_REGION")
-	}
 
 	if os.Getenv("AWS_PROFILE") != "" {
 		oks = append(oks, "AWS_PROFILE")

--- a/internal/dependencies/envvars/validator.go
+++ b/internal/dependencies/envvars/validator.go
@@ -5,10 +5,10 @@
 package envvars
 
 import (
-  "errors"
-  "fmt"
-  "os"
-  "strings"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
 )
 
 var (

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -197,12 +197,13 @@ var (
 			}
 
 			It("should report an error when dependencies are missing", func() {
-				RestoreEnvVars := BackupEnvVars("PATH", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION")
+				RestoreEnvVars := BackupEnvVars("PATH", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
 				defer RestoreEnvVars()
 
 				os.Unsetenv("AWS_ACCESS_KEY_ID")
 				os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 				os.Unsetenv("AWS_DEFAULT_REGION")
+				os.Unsetenv("AWS_REGION")
 
 				out, err := FuryctlValidateDependencies("../data/e2e/validate/dependencies/missing", "/tmp")
 
@@ -211,7 +212,6 @@ var (
 				Expect(out).To(ContainSubstring("kubectl:"))
 				Expect(out).To(ContainSubstring("kustomize:"))
 				Expect(out).To(ContainSubstring("furyagent:"))
-				Expect(out).To(ContainSubstring("missing required environment variable: AWS_DEFAULT_REGION"))
 				Expect(out).To(ContainSubstring("missing environment variables, either AWS_PROFILE or the " +
 					"following environment variables must be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
@@ -221,7 +221,6 @@ var (
 					"PATH",
 					"AWS_ACCESS_KEY_ID",
 					"AWS_SECRET_ACCESS_KEY",
-					"AWS_DEFAULT_REGION",
 					"FURYCTL_MIXPANEL_TOKEN",
 				)
 				defer RestoreEnvVars()
@@ -232,6 +231,7 @@ var (
 				os.Unsetenv("AWS_ACCESS_KEY_ID")
 				os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 				os.Unsetenv("AWS_DEFAULT_REGION")
+				os.Unsetenv("AWS_REGION")
 				os.Unsetenv("FURYCTL_MIXPANEL_TOKEN")
 
 				out, err := FuryctlValidateDependencies(bp, bp)
@@ -249,7 +249,6 @@ var (
 				Expect(out).To(
 					ContainSubstring("terraform: wrong tool version - installed = 0.15.3, expected = 0.15.4"),
 				)
-				Expect(out).To(ContainSubstring("missing required environment variable: AWS_DEFAULT_REGION"))
 				Expect(out).To(ContainSubstring("missing environment variables, either AWS_PROFILE or the " +
 					"following environment variables must be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"))
 			})
@@ -259,7 +258,6 @@ var (
 					"PATH",
 					"AWS_ACCESS_KEY_ID",
 					"AWS_SECRET_ACCESS_KEY",
-					"AWS_DEFAULT_REGION",
 					"FURYCTL_MIXPANEL_TOKEN",
 				)
 				defer RestoreEnvVars()
@@ -267,7 +265,6 @@ var (
 				bp := Abs("../data/e2e/validate/dependencies/correct")
 
 				os.Setenv("PATH", bp+":"+os.Getenv("PATH"))
-				os.Setenv("AWS_DEFAULT_REGION", "eu-west-1")
 				os.Setenv("FURYCTL_MIXPANEL_TOKEN", "test")
 
 				out, err := FuryctlValidateDependencies(bp, bp)


### PR DESCRIPTION
- updated infrastructure phase terraform templates
- updated kubernetes phase terraform templates
- remove AWS_DEFAULT_REGION env var validation when use resource of kind EKSCluster
