### PR TITLE
feat!(eks): bump eks installer version

### DIFF
--- a/data/provisioners/bootstrap/aws/main.tf
+++ b/data/provisioners/bootstrap/aws/main.tf
@@ -5,17 +5,17 @@
  */
 
 terraform {
-  required_version = "0.15.4"
+  required_version = ">= 0.15.4"
   required_providers {
     local    = "2.0.0"
     null     = "3.0.0"
-    aws      = "3.37.0"
+    aws      = "3.56.0"
     external = "2.0.0"
   }
 }
 
 module "vpc-and-vpn" {
-  source = "github.com/sighupio/fury-eks-installer//modules/vpc-and-vpn?ref=v1.10.0"
+  source = "github.com/sighupio/fury-eks-installer//modules/vpc-and-vpn?ref=v1.11.0"
 
   name                     = var.name
   network_cidr             = var.network_cidr

--- a/data/provisioners/bootstrap/gcp/main.tf
+++ b/data/provisioners/bootstrap/gcp/main.tf
@@ -16,8 +16,8 @@ terraform {
 }
 
 provider "google" {
-  project     = var.provider_project
-  region      = var.provider_region
+  project = var.provider_project
+  region  = var.provider_region
 }
 
 module "vpc-and-vpn" {

--- a/data/provisioners/cluster/eks/main.tf
+++ b/data/provisioners/cluster/eks/main.tf
@@ -6,9 +6,9 @@
 
 terraform {
   experiments      = [module_variable_optional_attrs]
-  required_version = "0.15.4"
+  required_version = ">= 0.15.4"
   required_providers {
-    aws        = "= 3.37.0"
+    aws        = "= 3.56.0"
     kubernetes = "= 1.13.3"
     local      = "= 1.4.0"
     null       = "= 2.1.0"
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "fury" {
-  source = "github.com/sighupio/fury-eks-installer//modules/eks?ref=v1.10.0"
+  source = "github.com/sighupio/fury-eks-installer//modules/eks?ref=v1.11.0"
 
   cluster_name               = var.cluster_name
   cluster_version            = var.cluster_version


### PR DESCRIPTION
- bump EKS installer version
- bump providers versions to align them with the EKS provider
- relax terraform version constraint so we can update it easily in the future

BREAKING: notice that upgrading terraform provider version requires running some commands for existing clusters.

See PR #221 for instructions.


> **Note**
> Leaving the PR as draft until we have the release of the installer.