### PR TITLE
fix: missing region from vpc connectivity check

### DIFF
--- a/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
@@ -1150,6 +1150,8 @@ func (k *Kubernetes) checkVPCConnection() error {
 			string(*vpcID),
 			"--query",
 			"Vpcs[0].CidrBlock",
+			"--region",
+			string(k.furyctlConf.Spec.Region),
 			"--output",
 			"text",
 		)

--- a/internal/apis/kfd/v1alpha2/eks/delete/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/delete/kubernetes.go
@@ -159,6 +159,8 @@ func (k *Kubernetes) checkVPCConnection() error {
 			string(*vpcID),
 			"--query",
 			"Vpcs[0].CidrBlock",
+			"--region",
+			string(k.furyctlConf.Spec.Region),
 			"--output",
 			"text",
 		)


### PR DESCRIPTION
Changelist:

- fix bug on vpc connectivity check using env var instead of .spec.region