### PR TITLE
Fix: remove duplicates on cidrs

### DIFF
--- a/internal/apis/kfd/v1alpha2/eks/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/infrastructure.go
@@ -402,9 +402,11 @@ func (i *Infrastructure) addVpnDataToTfVars(buffer *bytes.Buffer) error {
 
 func (i *Infrastructure) addVpnSSHDataToTfVars(buffer *bytes.Buffer) error {
 	if len(i.furyctlConf.Spec.Infrastructure.Vpn.Ssh.AllowedFromCidrs) != 0 {
-		allowedCidrs := make([]string, len(i.furyctlConf.Spec.Infrastructure.Vpn.Ssh.AllowedFromCidrs))
+		uniqCidrs := slices.Uniq(i.furyctlConf.Spec.Infrastructure.Vpn.Ssh.AllowedFromCidrs)
 
-		for i, cidr := range i.furyctlConf.Spec.Infrastructure.Vpn.Ssh.AllowedFromCidrs {
+		allowedCidrs := make([]string, len(uniqCidrs))
+
+		for i, cidr := range uniqCidrs {
 			allowedCidrs[i] = fmt.Sprintf("\"%v\"", cidr)
 		}
 

--- a/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
@@ -1122,9 +1122,11 @@ func (*Kubernetes) addCidrBlocksFirewallRules(
 			content += ","
 		}
 
-		dmzCidrRanges := make([]string, len(fwRule.CidrBlocks))
+		uniqCidrBlocks := slices.Uniq(fwRule.CidrBlocks)
 
-		for i, cidr := range fwRule.CidrBlocks {
+		dmzCidrRanges := make([]string, len(uniqCidrBlocks))
+
+		for i, cidr := range uniqCidrBlocks {
 			dmzCidrRanges[i] = fmt.Sprintf("\"%v\"", cidr)
 		}
 

--- a/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
@@ -492,6 +492,8 @@ func (k *Kubernetes) createTfVars() error {
 		}
 	}
 
+	allowedClusterEndpointPrivateAccessCIDRs = slices.Uniq(allowedClusterEndpointPrivateAccessCIDRs)
+
 	err := bytesx.SafeWriteToBuffer(
 		&buffer,
 		"cluster_name = \"%v\"\n",


### PR DESCRIPTION
Changelist:

- added uniq on allowedClusterEndpointPrivateAccessCIDRs slice in order to remove duplicates
- added uniq on ssh AllowedFromCidrs slice
- added uniq on AdditionalFirewallRules CidrBlocks slice
