### PR TITLE
feat: cluster upgrade preparations

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package create
+package cmd
 
 import (
 	"errors"
@@ -51,12 +51,12 @@ type ClusterCmdFlags struct {
 	Outdir             string
 }
 
-func NewClusterCmd(tracker *analytics.Tracker) *cobra.Command {
+func NewApplyCommand(tracker *analytics.Tracker) *cobra.Command {
 	var cmdEvent analytics.Event
 
 	cmd := &cobra.Command{
-		Use:   "cluster",
-		Short: "Creates a battle-tested Kubernetes Fury cluster",
+		Use:   "apply",
+		Short: "Apply the configuration to create or upgrade a battle-tested Kubernetes Fury cluster",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			cmdEvent = analytics.NewCommandEvent(cobrax.GetFullname(cmd))
 		},

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -23,7 +23,7 @@ var (
 	ErrPowershellCompletion = errors.New("error generating powershell completion")
 )
 
-func NewCompletionCmd(tracker *analytics.Tracker) *cobra.Command {
+func NewCompletionCommand(tracker *analytics.Tracker) *cobra.Command {
 	var cmdEvent analytics.Event
 
 	return &cobra.Command{

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -14,10 +14,24 @@ import (
 func NewCreateCommand(tracker *analytics.Tracker) *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a sample configuration file",
+		Short: "Create a cluster or a sample configuration file",
 	}
 
 	createCmd.AddCommand(create.NewConfigCommand(tracker))
+
+	// Configure create cluster command as alias of apply command.
+	applyCmd := NewApplyCommand(tracker)
+
+	clusterCmd := &cobra.Command{
+		Use:    "cluster",
+		Short:  "Apply the configuration to create or upgrade a battle-tested Kubernetes Fury cluster",
+		PreRun: applyCmd.PreRun,
+		RunE:   applyCmd.RunE,
+	}
+
+	clusterCmd.Flags().AddFlagSet(applyCmd.Flags())
+
+	createCmd.AddCommand(clusterCmd)
 
 	return createCmd
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -14,11 +14,10 @@ import (
 func NewCreateCommand(tracker *analytics.Tracker) *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a cluster or a sample configuration file",
+		Short: "Create a sample configuration file",
 	}
 
-	createCmd.AddCommand(create.NewClusterCmd(tracker))
-	createCmd.AddCommand(create.NewConfigCmd(tracker))
+	createCmd.AddCommand(create.NewConfigCommand(tracker))
 
 	return createCmd
 }

--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -26,11 +26,12 @@ import (
 )
 
 var (
+	ErrParsingFlag          = errors.New("error while parsing flag")
 	ErrMandatoryFlag        = errors.New("flag must be specified")
 	ErrConfigCreationFailed = fmt.Errorf("config creation failed")
 )
 
-func NewConfigCmd(tracker *analytics.Tracker) *cobra.Command {
+func NewConfigCommand(tracker *analytics.Tracker) *cobra.Command {
 	var cmdEvent analytics.Event
 
 	cmd := &cobra.Command{

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sighupio/furyctl/internal/analytics"
 )
 
-func NewDownloadCmd(tracker *analytics.Tracker) *cobra.Command {
+func NewDownloadCommand(tracker *analytics.Tracker) *cobra.Command {
 	dumpCmd := &cobra.Command{
 		Use:   "download",
 		Short: "Download all dependencies for the Kubernetes Fury Distribution version specified in the configuration file",

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sighupio/furyctl/internal/analytics"
 )
 
-func NewDumpCmd(tracker *analytics.Tracker) *cobra.Command {
+func NewDumpCommand(tracker *analytics.Tracker) *cobra.Command {
 	dumpCmd := &cobra.Command{
 		Use:   "dump",
 		Short: "Dump manifests templates and other useful KFD objects",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,15 +204,16 @@ furyctl is a command line interface tool to manage the full lifecycle of a Kuber
 			"authentication while downloading, for example for private repositories",
 	)
 
-	rootCmd.AddCommand(NewCompletionCmd(tracker))
+	rootCmd.AddCommand(NewCompletionCommand(tracker))
 	rootCmd.AddCommand(NewCreateCommand(tracker))
-	rootCmd.AddCommand(NewDownloadCmd(tracker))
-	rootCmd.AddCommand(NewDumpCmd(tracker))
+	rootCmd.AddCommand(NewDownloadCommand(tracker))
+	rootCmd.AddCommand(NewDumpCommand(tracker))
 	rootCmd.AddCommand(NewValidateCommand(tracker))
 	rootCmd.AddCommand(NewVersionCmd(versions, tracker))
 	rootCmd.AddCommand(NewDeleteCommand(tracker))
 	rootCmd.AddCommand(NewLegacyCommand(tracker))
 	rootCmd.AddCommand(NewConnectCommand(tracker))
+	rootCmd.AddCommand(NewApplyCommand(tracker))
 
 	return rootCmd
 }

--- a/internal/tool/furyagent/runner.go
+++ b/internal/tool/furyagent/runner.go
@@ -53,12 +53,16 @@ func (r *Runner) deleteCmd(id string) {
 	delete(r.cmds, id)
 }
 
-func (r *Runner) ConfigOpenvpnClient(name string, _ ...string) (*bytes.Buffer, error) {
+func (r *Runner) ConfigOpenvpnClient(name string, params ...string) (*bytes.Buffer, error) {
 	args := []string{
 		"configure",
 		"openvpn-client",
 		fmt.Sprintf("--client-name=%s", name),
 		"--config=furyagent.yml",
+	}
+
+	if len(params) > 0 {
+		args = append(args, params...)
 	}
 
 	cmd, id := r.newCmd(args)


### PR DESCRIPTION
The goal of this PR is to prepare the ground for the actual cluster upgrade feature by making sure we treat the cluster folder as fully ephemeral and by creating the `cluster create` command alias `apply`

Closes https://github.com/sighupio/furyctl/issues/438.
Closes https://github.com/sighupio/furyctl/issues/437.