### PR TITLE
fix: maxPods value rendering in generated tfvars

### DIFF
--- a/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/eks/create/kubernetes.go
@@ -14,7 +14,6 @@ import (
 	"net"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -774,7 +773,6 @@ func (k *Kubernetes) createTfVars() error {
 				if err := bytesx.SafeWriteToBuffer(
 					&buffer,
 					"max_pods = %v\n",
-					filepath.Dir(k.furyctlConfPath),
 					*np.Instance.MaxPods,
 				); err != nil {
 					return fmt.Errorf(SErrWrapWithStr, ErrWritingTfVars, err)


### PR DESCRIPTION
The value for the maxPods terraform variable was rendered as the path of the directory of the furyctl configuration file causing the execution to fail.