### PR TITLE
bugfix: cache preserve file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <!-- FIXME: UPDATE THE BUILD BADGE WITH THE RIGHT BRANCH -->
 
 [![Build Status](https://ci.sighup.io/api/badges/sighupio/furyctl/status.svg)](https://ci.sighup.io/sighupio/furyctl)
-![Release](https://img.shields.io/badge/furyctl-v0.27.3-blue)
+![Release](https://img.shields.io/badge/furyctl-v0.27.4-blue)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack)
 ![License](https://img.shields.io/github/license/sighupio/furyctl)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sighupio/furyctl)](https://goreportcard.com/report/github.com/sighupio/furyctl)
@@ -80,7 +80,7 @@ $ furyctl version
 ...
 goVersion: go1.22
 osArch: amd64
-version: 0.27.3
+version: 0.27.4
 ```
 
 ### Installing from source

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -4,6 +4,7 @@ Note: Always use the latest `furyctl` version, we make sure that is compatible w
 
 | Furyctl / KFD | 1.27.3             | 1.27.2             | 1.27.1             | 1.27.0             | 1.26.5             | 1.26.4             | 1.26.3             | 1.25.10            | 1.25.9             | 1.25.8             |
 | ------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| 0.27.4        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 0.27.3        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 0.27.2        |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: | :white_check_mark: |
 | 0.27.1        |                    |                    | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: | :white_check_mark: |
@@ -13,6 +14,7 @@ Note: Always use the latest `furyctl` version, we make sure that is compatible w
 
 | Furyctl / Providers | EKSCluster         | KFDDistribution    | OnPremises         |
 | ------------------- | ------------------ | ------------------ | ------------------ |
+| 0.27.4              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 0.27.3              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 0.27.2              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 0.27.1              | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/internal/x/io/fs.go
+++ b/internal/x/io/fs.go
@@ -164,6 +164,16 @@ func CopyRecursive(src fs.FS, dest string) error {
 		if err := os.WriteFile(path.Join(dest, file.Name()), fileContent, RWPermAccess); err != nil {
 			return fmt.Errorf("error while writing file %s: %w", file.Name(), err)
 		}
+
+		si, err := fs.Stat(src, file.Name())
+		if err != nil {
+			return fmt.Errorf("error while getting file info %s: %w", file.Name(), err)
+		}
+
+		err = os.Chmod(path.Join(dest, file.Name()), si.Mode())
+		if err != nil {
+			return fmt.Errorf("error while changing file mode %s: %w", file.Name(), err)
+		}
 	}
 
 	return nil

--- a/internal/x/io/fs.go
+++ b/internal/x/io/fs.go
@@ -170,8 +170,7 @@ func CopyRecursive(src fs.FS, dest string) error {
 			return fmt.Errorf("error while getting file info %s: %w", file.Name(), err)
 		}
 
-		err = os.Chmod(path.Join(dest, file.Name()), si.Mode())
-		if err != nil {
+		if err := os.Chmod(path.Join(dest, file.Name()), si.Mode()); err != nil {
 			return fmt.Errorf("error while changing file mode %s: %w", file.Name(), err)
 		}
 	}


### PR DESCRIPTION
## Bug

### Error
Given an eks cluster with vpn enabled, terraform gives this error when running `--phase infrastructure`

```
Error: External Program Lookup Failed

  with module.vpn[0].data.external.os,
  on .terraform/modules/vpn/data.tf line 6, in data "external" "os":
   6:   program = ["${path.module}/bin/os.sh"]
```

### Causes
Files downloaded to the cache folder do not preserve permissions

downloaded files:
```
drwxr-xr-x   7 x  x   224B Feb 21 14:23 .
drwxr-xr-x  11 x  x   352B Feb 21 14:23 ..
-rwxr-xr-x   1 x  x    38M Feb 21 14:23 furyagent-darwin-amd64
-rwxr-xr-x   1 x  x    38M Feb 21 14:23 furyagent-darwin-arm64
-rwxr-xr-x   1 x  x    34M Feb 21 14:23 furyagent-linux-amd64
-rwxr-xr-x   1 x  x    33M Feb 21 14:23 furyagent-linux-arm64
-rwxr-xr-x   1 x  x   144B Feb 21 14:23 os.sh
```

cached files:
```
drwxr-xr-x   7 x  x   224B Feb 21 13:55 .
drwxr-xr-x  11 x  x   352B Feb 21 13:55 ..
-rw-r--r--   1 x  x    38M Feb 21 13:55 furyagent-darwin-amd64
-rw-r--r--   1 x  x    38M Feb 21 13:55 furyagent-darwin-arm64
-rw-r--r--   1 x  x    34M Feb 21 13:55 furyagent-linux-amd64
-rw-r--r--   1 x  x    33M Feb 21 13:55 furyagent-linux-arm64
-rw-r--r--   1 x  x   144B Feb 21 13:55 os.sh
```

### Actions
- [x] copy permissions when caching dependencies
- [x] add unit tests to cover this scenario