### PR TITLE
Add support to relative paths with {path://} dynamic value

### DIFF
--- a/internal/parser/config.go
+++ b/internal/parser/config.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	Path  = "path"
 	Env   = "env"
 	File  = "file"
 	HTTP  = "http"
@@ -46,6 +47,9 @@ func (p *ConfigParser) ParseDynamicValue(val any) (string, error) {
 		sourceValue := strings.TrimSuffix(spl[1], "}")
 
 		switch source {
+		case Path:
+			return filepath.Join(p.baseDir, filepath.Clean(sourceValue)), nil
+
 		case Env:
 			envVar := os.Getenv(sourceValue)
 

--- a/internal/template/mapper/mapper.go
+++ b/internal/template/mapper/mapper.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	EnvRegexp          = regexp.MustCompile(`{(.*?)}`)
+	DynamicRegexp      = regexp.MustCompile(`{(.*?)}`)
 	RelativePathRegexp = regexp.MustCompile(`^\.{1,}\/`)
 )
 
@@ -127,7 +127,7 @@ func (m *Mapper) injectDynamicValuesAndPathsString(value string) (string, error)
 	cfgParser := parser.NewConfigParser(m.furyctlConfDir)
 
 	// If the value contains dynamic values, we need to parse them.
-	dynamicValues := EnvRegexp.FindAllString(value, -1)
+	dynamicValues := DynamicRegexp.FindAllString(value, -1)
 	for _, dynamicValue := range dynamicValues {
 		parsedDynamicValue, err := cfgParser.ParseDynamicValue(dynamicValue)
 		if err != nil {


### PR DESCRIPTION
This feature ad a new "dynamic value" for string interpolation the name `path` that converts a relative path to absolute.

NOTE: This feature can replace the string regex replacer that converts any string that starts with `./` as absolute.

## Usage example
Secret generator with files:

```yaml
customPatches:
  secretGenerator:
    - name: my-secret
      namespace: default
      type: kubernetes.io/tls
      files:
        - tls.crt={path://./certs/tls.crt}
        - tls.key={path://./certs/tls.key}
```