### PR TITLE
feat: added --distro-patches flag

### DIFF
--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -94,6 +94,11 @@ func NewConfigCommand(tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("%w: %w", ErrParsingFlag, err)
 			}
 
+			distroPatchesLocation, err := cmdutil.StringFlag(cmd, "distro-patches", tracker, cmdEvent)
+			if err != nil {
+				return fmt.Errorf("%w: %s", ErrParsingFlag, "distro-patches")
+			}
+
 			minimalConf := distroconf.Furyctl{
 				APIVersion: apiVersion,
 				Kind:       kind,
@@ -130,9 +135,9 @@ func NewConfigCommand(tracker *analytics.Tracker) *cobra.Command {
 			depsvl := dependencies.NewValidator(executor, "", "", false)
 
 			if distroLocation == "" {
-				distrodl = distribution.NewCachingDownloader(client, outDir, typedGitProtocol)
+				distrodl = distribution.NewCachingDownloader(client, outDir, typedGitProtocol, distroPatchesLocation)
 			} else {
-				distrodl = distribution.NewDownloader(client, typedGitProtocol)
+				distrodl = distribution.NewDownloader(client, typedGitProtocol, distroPatchesLocation)
 			}
 
 			// Init packages.
@@ -215,6 +220,13 @@ func NewConfigCommand(tracker *analytics.Tracker) *cobra.Command {
 			"It can either be a local path(eg: /path/to/fury/distribution) or "+
 			"a remote URL(eg: git::git@github.com:sighupio/fury-distribution?depth=1&ref=BRANCH_NAME)."+
 			"Any format supported by hashicorp/go-getter can be used.",
+	)
+
+	cmd.Flags().String(
+		"distro-patches",
+		"",
+		"Location where to download distribution's user-made patches from. "+
+			cmdutil.AnyGoGetterFormatStr,
 	)
 
 	cmd.Flags().StringP(

--- a/cmd/download/dependencies.go
+++ b/cmd/download/dependencies.go
@@ -58,6 +58,11 @@ func NewDependenciesCmd(tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("%w: %w", ErrParsingFlag, err)
 			}
 
+			distroPatchesLocation, err := cmdutil.StringFlag(cmd, "distro-patches", tracker, cmdEvent)
+			if err != nil {
+				return fmt.Errorf("%w: %s", ErrParsingFlag, "distro-patches")
+			}
+
 			binPath := cmdutil.StringFlagOptional(cmd, "bin-path")
 
 			// Init paths.
@@ -92,9 +97,9 @@ func NewDependenciesCmd(tracker *analytics.Tracker) *cobra.Command {
 			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath, false)
 
 			if distroLocation == "" {
-				distrodl = distribution.NewCachingDownloader(client, outDir, typedGitProtocol)
+				distrodl = distribution.NewCachingDownloader(client, outDir, typedGitProtocol, distroPatchesLocation)
 			} else {
-				distrodl = distribution.NewDownloader(client, typedGitProtocol)
+				distrodl = distribution.NewDownloader(client, typedGitProtocol, distroPatchesLocation)
 			}
 
 			// Validate base requirements.
@@ -174,6 +179,13 @@ func NewDependenciesCmd(tracker *analytics.Tracker) *cobra.Command {
 			"It can either be a local path (eg: /path/to/fury/distribution) or "+
 			"a remote URL (eg: git::git@github.com:sighupio/fury-distribution?depth=1&ref=BRANCH_NAME). "+
 			"Any format supported by hashicorp/go-getter can be used.",
+	)
+
+	cmd.Flags().String(
+		"distro-patches",
+		"",
+		"Location where to download distribution's user-made patches from. "+
+			cmdutil.AnyGoGetterFormatStr,
 	)
 
 	return cmd

--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -28,13 +28,14 @@ import (
 var ErrParsingFlag = errors.New("error while parsing flag")
 
 type TemplateCmdFlags struct {
-	DryRun         bool
-	NoOverwrite    bool
-	SkipValidation bool
-	GitProtocol    git.Protocol
-	Outdir         string
-	FuryctlPath    string
-	DistroLocation string
+	DryRun                bool
+	NoOverwrite           bool
+	SkipValidation        bool
+	GitProtocol           git.Protocol
+	Outdir                string
+	FuryctlPath           string
+	DistroLocation        string
+	DistroPatchesLocation string
 }
 
 func NewTemplateCmd(tracker *analytics.Tracker) *cobra.Command {
@@ -88,9 +89,9 @@ The generated folder will be created starting from a provided templates folder a
 			depsvl := dependencies.NewValidator(executor, "", absFuryctlPath, false)
 
 			if flags.DistroLocation == "" {
-				distrodl = distribution.NewCachingDownloader(client, outDir, flags.GitProtocol)
+				distrodl = distribution.NewCachingDownloader(client, outDir, flags.GitProtocol, flags.DistroPatchesLocation)
 			} else {
-				distrodl = distribution.NewDownloader(client, flags.GitProtocol)
+				distrodl = distribution.NewDownloader(client, flags.GitProtocol, flags.DistroPatchesLocation)
 			}
 
 			if err := depsvl.ValidateBaseReqs(); err != nil {
@@ -216,6 +217,13 @@ The generated folder will be created starting from a provided templates folder a
 		"Skip validation of the configuration file",
 	)
 
+	cmd.Flags().String(
+		"distro-patches",
+		"",
+		"Location where to download distribution's user-made patches from. "+
+			cmdutil.AnyGoGetterFormatStr,
+	)
+
 	return cmd
 }
 
@@ -260,13 +268,19 @@ func getDumpTemplateCmdFlags(cmd *cobra.Command, tracker *analytics.Tracker, cmd
 		return TemplateCmdFlags{}, fmt.Errorf("%w: %w", ErrParsingFlag, err)
 	}
 
+	distroPatchesLocation, err := cmdutil.StringFlag(cmd, "distro-patches", tracker, cmdEvent)
+	if err != nil {
+		return TemplateCmdFlags{}, fmt.Errorf("%w: %s", ErrParsingFlag, "distro-patches")
+	}
+
 	return TemplateCmdFlags{
-		DryRun:         dryRun,
-		NoOverwrite:    noOverwrite,
-		SkipValidation: skipValidation,
-		Outdir:         outdir,
-		DistroLocation: distroLocation,
-		FuryctlPath:    furyctlPath,
-		GitProtocol:    typedGitProtocol,
+		DryRun:                dryRun,
+		NoOverwrite:           noOverwrite,
+		SkipValidation:        skipValidation,
+		Outdir:                outdir,
+		DistroLocation:        distroLocation,
+		FuryctlPath:           furyctlPath,
+		GitProtocol:           typedGitProtocol,
+		DistroPatchesLocation: distroPatchesLocation,
 	}, nil
 }

--- a/cmd/validate/config.go
+++ b/cmd/validate/config.go
@@ -63,6 +63,11 @@ func NewConfigCmd(tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("%w: %w", ErrParsingFlag, err)
 			}
 
+			distroPatchesLocation, err := cmdutil.StringFlag(cmd, "distro-patches", tracker, cmdEvent)
+			if err != nil {
+				return fmt.Errorf("%w: %s", ErrParsingFlag, "distro-patches")
+			}
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
@@ -82,9 +87,9 @@ func NewConfigCmd(tracker *analytics.Tracker) *cobra.Command {
 			depsvl := dependencies.NewValidator(executor, "", furyctlPath, false)
 
 			if distroLocation == "" {
-				distrodl = distribution.NewCachingDownloader(client, outDir, typedGitProtocol)
+				distrodl = distribution.NewCachingDownloader(client, outDir, typedGitProtocol, distroPatchesLocation)
 			} else {
-				distrodl = distribution.NewDownloader(client, typedGitProtocol)
+				distrodl = distribution.NewDownloader(client, typedGitProtocol, distroPatchesLocation)
 			}
 
 			// Validate base requirements.
@@ -145,6 +150,13 @@ func NewConfigCmd(tracker *analytics.Tracker) *cobra.Command {
 			"It can either be a local path (eg: /path/to/fury/distribution) or "+
 			"a remote URL (eg: git::git@github.com:sighupio/fury-distribution?depth=1&ref=BRANCH_NAME). "+
 			"Any format supported by hashicorp/go-getter can be used.",
+	)
+
+	cmd.Flags().String(
+		"distro-patches",
+		"",
+		"Location where to download distribution's user-made patches from. "+
+			cmdutil.AnyGoGetterFormatStr,
 	)
 
 	return cmd

--- a/cmd/validate/dependencies.go
+++ b/cmd/validate/dependencies.go
@@ -46,6 +46,11 @@ func NewDependenciesCmd(tracker *analytics.Tracker) *cobra.Command {
 				return fmt.Errorf("%w: distro-location", ErrParsingFlag)
 			}
 
+			distroPatchesLocation, err := cmdutil.StringFlag(cmd, "distro-patches", tracker, cmdEvent)
+			if err != nil {
+				return fmt.Errorf("%w: %s", ErrParsingFlag, "distro-patches")
+			}
+
 			// Init paths.
 			logrus.Debug("Getting Home Directory Path...")
 			outDir, err := cmdutil.StringFlag(cmd, "outdir", tracker, cmdEvent)
@@ -87,9 +92,9 @@ func NewDependenciesCmd(tracker *analytics.Tracker) *cobra.Command {
 			depsvl := dependencies.NewValidator(executor, "", furyctlPath, false)
 
 			if distroLocation == "" {
-				distrodl = distribution.NewCachingDownloader(client, outDir, typedGitProtocol)
+				distrodl = distribution.NewCachingDownloader(client, outDir, typedGitProtocol, distroPatchesLocation)
 			} else {
-				distrodl = distribution.NewDownloader(client, typedGitProtocol)
+				distrodl = distribution.NewDownloader(client, typedGitProtocol, distroPatchesLocation)
 			}
 
 			// Validate base requirements.
@@ -192,6 +197,13 @@ func NewDependenciesCmd(tracker *analytics.Tracker) *cobra.Command {
 			"It can either be a local path (eg: /path/to/fury/distribution) or "+
 			"a remote URL (eg: git::git@github.com:sighupio/fury-distribution?depth=1&ref=BRANCH_NAME). "+
 			"Any format supported by hashicorp/go-getter can be used.",
+	)
+
+	cmd.Flags().String(
+		"distro-patches",
+		"",
+		"Location where to download distribution's user-made patches from. "+
+			cmdutil.AnyGoGetterFormatStr,
 	)
 
 	return cmd

--- a/internal/cmd/cmdutil/flag.go
+++ b/internal/cmd/cmdutil/flag.go
@@ -15,6 +15,8 @@ import (
 
 var ErrParsingFlag = errors.New("error while parsing flag")
 
+const AnyGoGetterFormatStr = "Any format supported by hashicorp/go-getter can be used."
+
 func BoolFlag(cmd *cobra.Command, flagName string, tracker *analytics.Tracker, event analytics.Event) (bool, error) {
 	value, err := cmd.Flags().GetBool(flagName)
 	if err != nil {

--- a/internal/distribution/download.go
+++ b/internal/distribution/download.go
@@ -226,8 +226,15 @@ func (d *Downloader) applyCustomCompatibilityPatches(kfdManifest config.KFD, dst
 	info, err := os.Stat(patchesPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("custom distro patches not found: %w", err)
+			logrus.Warnf("Cannot find a custom distribution patches directory for version %s in %s, skipping...",
+				kfdManifest.Version,
+				d.customDistroPatchesPath,
+			)
+
+			return nil
 		}
+
+		return fmt.Errorf("error getting custom distro patches info: %w", err)
 	}
 
 	if !info.IsDir() {

--- a/internal/distribution/download_test.go
+++ b/internal/distribution/download_test.go
@@ -52,7 +52,7 @@ func Test_Downloader_Download(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			d := distribution.NewDownloader(netx.NewGoGetterClient(), git.ProtocolSSH)
+			d := distribution.NewDownloader(netx.NewGoGetterClient(), git.ProtocolSSH, "")
 
 			res, err := d.Download(
 				absDistroPath,

--- a/test/utils/testutils.go
+++ b/test/utils/testutils.go
@@ -149,7 +149,7 @@ func CompileFuryctl(outputPath string) func() {
 }
 
 func DownloadFuryDistribution(outDir, furyctlConfPath string) distribution.DownloadResult {
-	distrodl := distribution.NewCachingDownloader(netx.NewGoGetterClient(), outDir, git.ProtocolSSH)
+	distrodl := distribution.NewCachingDownloader(netx.NewGoGetterClient(), outDir, git.ProtocolSSH, "")
 
 	return Must1(distrodl.Download("", furyctlConfPath))
 }


### PR DESCRIPTION
usage: `--distro-patches go-getter/compatible/path`

Within the location, the folders must have the target KFD version as name (e.g. v1.29.0) and the contents should be compatible with those from the https://github.com/sighupio/fury-distribution repository.

closes #503 