### PR TITLE
chore(lockfile): improve error message

### DIFF
--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -11,7 +11,9 @@ import (
 	"path/filepath"
 )
 
-var ErrLockFileExists = errors.New("lock file exists")
+var ErrLockFileExists = errors.New(
+	"lock file exists. This usually means that there is another instance of furyctl running",
+)
 
 type LockFile struct {
 	Path string


### PR DESCRIPTION
make the error message when the lock file exists more user friendly. Explaining what does it mean when the file already exists.

Before:
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/36292ee9-e2c4-4e5b-8074-6f7926dcd8e7">

After:
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/879a5034-afba-40e9-bb7c-ba80b5f11cbf">

