### PR TITLE
fix: fix outdir and workdir on commands

### DIFF
--- a/cmd/get/kubeconfig.go
+++ b/cmd/get/kubeconfig.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sighupio/furyctl/internal/git"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
 	execx "github.com/sighupio/furyctl/internal/x/exec"
-	iox "github.com/sighupio/furyctl/internal/x/io"
 	"github.com/sighupio/furyctl/pkg/dependencies"
 	dist "github.com/sighupio/furyctl/pkg/distribution"
 	netx "github.com/sighupio/furyctl/pkg/x/net"
@@ -175,7 +174,7 @@ func NewKubeconfigCmd() *cobra.Command {
 				}
 			}
 
-			getter, err := cluster.NewKubeconfigGetter(res.MinimalConf, res.DistroManifest, res.RepoPath, absFuryctlPath, outDir)
+			getter, err := cluster.NewKubeconfigGetter(res.MinimalConf, res.DistroManifest, res.RepoPath, absFuryctlPath, currentDir)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
@@ -188,13 +187,6 @@ func NewKubeconfigCmd() *cobra.Command {
 				tracker.Track(cmdEvent)
 
 				return fmt.Errorf("error while getting the kubeconfig, please check that the cluster is up and running and is reachable: %w", err)
-			}
-
-			if err := iox.CopyFile(path.Join(outDir, "kubeconfig"), path.Join(currentDir, "kubeconfig")); err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error while copying the kubeconfig: %w", err)
 			}
 
 			logrus.Infof("Kubeconfig successfully retrieved, you can find it at: %s", path.Join(currentDir, "kubeconfig"))

--- a/cmd/get/kubeconfig.go
+++ b/cmd/get/kubeconfig.go
@@ -73,7 +73,7 @@ func NewKubeconfigCmd() *cobra.Command {
 			}
 
 			// Get absolute path to the config file.
-			absFuryctlPath, err := filepath.Abs(furyctlPath)
+			furyctlPath, err = filepath.Abs(furyctlPath)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
@@ -108,7 +108,7 @@ func NewKubeconfigCmd() *cobra.Command {
 			executor := execx.NewStdExecutor()
 
 			distrodl := &dist.Downloader{}
-			depsvl := dependencies.NewValidator(executor, binPath, absFuryctlPath, false)
+			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath, false)
 
 			// Init first half of collaborators.
 			client := netx.NewGoGetterClient()
@@ -130,7 +130,7 @@ func NewKubeconfigCmd() *cobra.Command {
 			// Download the distribution.
 			logrus.Info("Downloading distribution...")
 
-			res, err := distrodl.Download(distroLocation, absFuryctlPath)
+			res, err := distrodl.Download(distroLocation, furyctlPath)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
@@ -145,7 +145,7 @@ func NewKubeconfigCmd() *cobra.Command {
 
 			// Validate the furyctl.yaml file.
 			logrus.Info("Validating configuration file...")
-			if err := config.Validate(absFuryctlPath, res.RepoPath); err != nil {
+			if err := config.Validate(furyctlPath, res.RepoPath); err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
@@ -174,7 +174,7 @@ func NewKubeconfigCmd() *cobra.Command {
 				}
 			}
 
-			getter, err := cluster.NewKubeconfigGetter(res.MinimalConf, res.DistroManifest, res.RepoPath, absFuryctlPath, currentDir)
+			getter, err := cluster.NewKubeconfigGetter(res.MinimalConf, res.DistroManifest, res.RepoPath, furyctlPath, currentDir)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)

--- a/cmd/get/upgrade-paths.go
+++ b/cmd/get/upgrade-paths.go
@@ -68,19 +68,20 @@ func NewUpgradePathsCmd() *cobra.Command {
 			skipDepsValidation := viper.GetBool("skip-deps-validation")
 			fromVersion := viper.GetString("from")
 			kind := viper.GetString("kind")
-			// Get Current dir.
-			logrus.Debug("Getting current directory path...")
 
-			currentDir, err := os.Getwd()
+			// Get absolute path to the config file.
+			var err error
+			furyctlPath, err = filepath.Abs(furyctlPath)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("error while getting current directory: %w", err)
+				return fmt.Errorf("error while getting config directory: %w", err)
 			}
 
 			// Get home dir.
 			logrus.Debug("Getting Home directory path...")
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
@@ -89,15 +90,15 @@ func NewUpgradePathsCmd() *cobra.Command {
 				return fmt.Errorf("error while getting user home directory: %w", err)
 			}
 
+			if outDir == "" {
+				outDir = homeDir
+			}
+
 			if binPath == "" {
-				binPath = path.Join(homeDir, ".furyctl", "bin")
+				binPath = path.Join(outDir, ".furyctl", "bin")
 			}
 
 			parsedGitProtocol := (git.Protocol)(gitProtocol)
-
-			if outDir == "" {
-				outDir = currentDir
-			}
 
 			// Init packages.
 			execx.Debug = debug

--- a/cmd/renew/certificates.go
+++ b/cmd/renew/certificates.go
@@ -160,7 +160,7 @@ func NewCertificatesCmd() *cobra.Command {
 				}
 			}
 
-			renewer, err := cluster.NewCertificatesRenewer(res.MinimalConf, res.DistroManifest, res.RepoPath, furyctlPath, outDir)
+			renewer, err := cluster.NewCertificatesRenewer(res.MinimalConf, res.DistroManifest, res.RepoPath, furyctlPath)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)

--- a/cmd/renew/certificates.go
+++ b/cmd/renew/certificates.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -57,19 +58,19 @@ func NewCertificatesCmd() *cobra.Command {
 			skipDepsDownload := viper.GetBool("skip-deps-download")
 			skipDepsValidation := viper.GetBool("skip-deps-validation")
 
-			// Get Current dir.
-			logrus.Debug("Getting current directory path...")
-
-			currentDir, err := os.Getwd()
+			// Get absolute path to the config file.
+			var err error
+			furyctlPath, err = filepath.Abs(furyctlPath)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("error while getting current directory: %w", err)
+				return fmt.Errorf("error while getting config directory: %w", err)
 			}
 
 			// Get home dir.
 			logrus.Debug("Getting Home directory path...")
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
@@ -78,15 +79,15 @@ func NewCertificatesCmd() *cobra.Command {
 				return fmt.Errorf("error while getting user home directory: %w", err)
 			}
 
+			if outDir == "" {
+				outDir = homeDir
+			}
+
 			if binPath == "" {
-				binPath = path.Join(homeDir, ".furyctl", "bin")
+				binPath = path.Join(outDir, ".furyctl", "bin")
 			}
 
 			parsedGitProtocol := (git.Protocol)(gitProtocol)
-
-			if outDir == "" {
-				outDir = currentDir
-			}
 
 			// Init packages.
 			execx.Debug = debug
@@ -127,7 +128,7 @@ func NewCertificatesCmd() *cobra.Command {
 			basePath := path.Join(outDir, ".furyctl", res.MinimalConf.Metadata.Name)
 
 			// Init second half of collaborators.
-			depsdl := dependencies.NewCachingDownloader(client, homeDir, basePath, binPath, parsedGitProtocol)
+			depsdl := dependencies.NewCachingDownloader(client, outDir, basePath, binPath, parsedGitProtocol)
 
 			// Validate the furyctl.yaml file.
 			logrus.Info("Validating configuration file...")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -190,7 +190,7 @@ func NewRootCmd() *RootCommand {
 		"outdir",
 		"o",
 		"",
-		"Switch to a different working directory before executing the given subcommand",
+		"Change the directory where to create the data directory (.furyctl)",
 	)
 
 	rootCmd.PersistentFlags().StringVarP(

--- a/internal/apis/kfd/v1alpha2/ekscluster/kubeconfig_getter.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/kubeconfig_getter.go
@@ -20,7 +20,7 @@ import (
 type KubeconfigGetter struct {
 	furyctlConf private.EksclusterKfdV1Alpha2
 	configPath  string
-	outDir      string
+	workDir     string
 }
 
 func (k *KubeconfigGetter) SetProperties(props []cluster.KubeconfigProperty) {
@@ -43,9 +43,9 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 			k.configPath = s
 		}
 
-	case cluster.KubeconfigPropertyOutdir:
+	case cluster.KubeconfigPropertyWorkDir:
 		if s, ok := value.(string); ok {
-			k.outDir = s
+			k.workDir = s
 		}
 	}
 }
@@ -53,13 +53,13 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 func (k *KubeconfigGetter) Get() error {
 	logrus.Info("Getting kubeconfig...")
 
-	kubeconfigPath := path.Join(k.outDir, "kubeconfig")
+	kubeconfigPath := path.Join(k.workDir, "kubeconfig")
 
 	awsRunner := awscli.NewRunner(
 		execx.NewStdExecutor(),
 		awscli.Paths{
 			Awscli:  "aws",
-			WorkDir: k.outDir,
+			WorkDir: k.workDir,
 		},
 	)
 

--- a/internal/apis/kfd/v1alpha2/kfddistribution/kubeconfig_getter.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/kubeconfig_getter.go
@@ -27,7 +27,7 @@ type KubeconfigGetter struct {
 	furyctlConf public.KfddistributionKfdV1Alpha2
 	kfdManifest config.KFD
 	configPath  string
-	outDir      string
+	workDir     string
 }
 
 func (k *KubeconfigGetter) SetProperties(props []cluster.KubeconfigProperty) {
@@ -50,9 +50,9 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 			k.configPath = s
 		}
 
-	case cluster.KubeconfigPropertyOutdir:
+	case cluster.KubeconfigPropertyWorkDir:
 		if s, ok := value.(string); ok {
-			k.outDir = s
+			k.workDir = s
 		}
 
 	case cluster.KubeconfigPropertyKfdManifest:
@@ -85,7 +85,7 @@ func (k *KubeconfigGetter) Get() error {
 		return fmt.Errorf("error reading kubeconfig file: %w", err)
 	}
 
-	kubeconfigPath = path.Join(k.outDir, "kubeconfig")
+	kubeconfigPath = path.Join(k.workDir, "kubeconfig")
 
 	if err := os.WriteFile(kubeconfigPath, kubeconfig, iox.FullRWPermAccess); err != nil {
 		return fmt.Errorf("error writing kubeconfig file: %w", err)

--- a/internal/apis/kfd/v1alpha2/onpremises/certificates_renewer.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/certificates_renewer.go
@@ -26,7 +26,6 @@ type CertificatesRenewer struct {
 	kfdManifest config.KFD
 	distroPath  string
 	configPath  string
-	outDir      string
 }
 
 func (k *CertificatesRenewer) SetProperties(props []cluster.CertificatesRenewerProperty) {
@@ -41,27 +40,22 @@ func (k *CertificatesRenewer) SetProperty(name string, value any) {
 	lcName := strings.ToLower(name)
 
 	switch lcName {
-	case cluster.KubeconfigPropertyFuryctlConf:
+	case cluster.CertificatesRenewerPropertyFuryctlConf:
 		if s, ok := value.(public.OnpremisesKfdV1Alpha2); ok {
 			k.furyctlConf = s
 		}
 
-	case cluster.KubeconfigPropertyConfigPath:
+	case cluster.CertificatesRenewerPropertyConfigPath:
 		if s, ok := value.(string); ok {
 			k.configPath = s
 		}
 
-	case cluster.KubeconfigPropertyOutdir:
-		if s, ok := value.(string); ok {
-			k.outDir = s
-		}
-
-	case cluster.KubeconfigPropertyKfdManifest:
+	case cluster.CertificatesRenewerPropertyKfdManifest:
 		if s, ok := value.(config.KFD); ok {
 			k.kfdManifest = s
 		}
 
-	case cluster.KubeconfigPropertyDistroPath:
+	case cluster.CertificatesRenewerPropertyDistroPath:
 		if s, ok := value.(string); ok {
 			k.distroPath = s
 		}

--- a/internal/apis/kfd/v1alpha2/onpremises/kubeconfig_getter.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/kubeconfig_getter.go
@@ -27,7 +27,7 @@ type KubeconfigGetter struct {
 	kfdManifest config.KFD
 	distroPath  string
 	configPath  string
-	outDir      string
+	workDir     string
 }
 
 func (k *KubeconfigGetter) SetProperties(props []cluster.KubeconfigProperty) {
@@ -52,9 +52,9 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 			k.configPath = s
 		}
 
-	case cluster.KubeconfigPropertyOutdir:
+	case cluster.KubeconfigPropertyWorkDir:
 		if s, ok := value.(string); ok {
-			k.outDir = s
+			k.workDir = s
 		}
 
 	case cluster.KubeconfigPropertyKfdManifest:
@@ -72,7 +72,7 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 func (k *KubeconfigGetter) Get() error {
 	logrus.Info("Getting kubeconfig...")
 
-	kubeconfigPath := path.Join(k.outDir, "kubeconfig")
+	kubeconfigPath := path.Join(k.workDir, "kubeconfig")
 
 	tmpDir, err := os.MkdirTemp("", "fury-kubeconfig-*")
 	if err != nil {

--- a/internal/cluster/certificates_renewer.go
+++ b/internal/cluster/certificates_renewer.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//nolint:dupl // ignoring duplication linting error
 package cluster
 
 import (

--- a/internal/cluster/certificates_renewer.go
+++ b/internal/cluster/certificates_renewer.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	CertificatesRenewerPropertyOutdir      = "outdir"
 	CertificatesRenewerPropertyFuryctlConf = "furyctlconf"
 	CertificatesRenewerPropertyConfigPath  = "configpath"
 	CertificatesRenewerPropertyKfdManifest = "kfdmanifest"
@@ -41,7 +40,6 @@ func NewCertificatesRenewer(
 	kfdManifest config.KFD,
 	distroPath string,
 	configPath string,
-	outDir string,
 ) (CertificatesRenewer, error) {
 	lcAPIVersion := strings.ToLower(minimalConf.APIVersion)
 	lcResourceType := strings.ToLower(minimalConf.Kind)
@@ -51,10 +49,6 @@ func NewCertificatesRenewer(
 			{
 				Name:  CertificatesRenewerPropertyKfdManifest,
 				Value: kfdManifest,
-			},
-			{
-				Name:  CertificatesRenewerPropertyOutdir,
-				Value: outDir,
 			},
 			{
 				Name:  CertificatesRenewerPropertyDistroPath,

--- a/internal/cluster/kubeconfig_getter.go
+++ b/internal/cluster/kubeconfig_getter.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//nolint:dupl // ignoring duplication linting error
 package cluster
 
 import (

--- a/internal/cluster/kubeconfig_getter.go
+++ b/internal/cluster/kubeconfig_getter.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	KubeconfigPropertyOutdir      = "outdir"
+	KubeconfigPropertyWorkDir     = "workdir"
 	KubeconfigPropertyFuryctlConf = "furyctlconf"
 	KubeconfigPropertyConfigPath  = "configpath"
 	KubeconfigPropertyKfdManifest = "kfdmanifest"
@@ -42,7 +42,7 @@ func NewKubeconfigGetter(
 	kfdManifest config.KFD,
 	distroPath string,
 	configPath string,
-	outDir string,
+	workDir string,
 ) (KubeconfigGetter, error) {
 	lcAPIVersion := strings.ToLower(minimalConf.APIVersion)
 	lcResourceType := strings.ToLower(minimalConf.Kind)
@@ -54,8 +54,8 @@ func NewKubeconfigGetter(
 				Value: kfdManifest,
 			},
 			{
-				Name:  KubeconfigPropertyOutdir,
-				Value: outDir,
+				Name:  KubeconfigPropertyWorkDir,
+				Value: workDir,
 			},
 			{
 				Name:  KubeconfigPropertyDistroPath,


### PR DESCRIPTION
Fixed `get kubeconfig`, `get upgrade-paths` and `renew certificates` commands.