### PR TITLE
Feat(ingress):upgrade path 1.29 to 1.30

### DIFF
--- a/configs/upgrades/ekscluster/1.29.4-1.30.0/post-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.29.4-1.30.0/post-distribution.sh.tpl
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+set -e
+
+kubectlbin="{{ .paths.kubectl }}"
+
+# Delete old resources after Ingress migration to v3
+{{- if eq .spec.distribution.modules.ingress.nginx.type "single" }}
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-metrics -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-selfsign -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true prometheusrule.monitoring.coreos.com ingress-nginx-k8s-rules -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true servicemonitor.monitoring.coreos.com ingress-nginx -n ingress-nginx
+{{- end }}
+
+{{- if eq .spec.distribution.modules.ingress.nginx.type "dual" }}
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-metrics -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-selfsign -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true prometheusrule.monitoring.coreos.com ingress-nginx-k8s-rules -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true servicemonitor.monitoring.coreos.com ingress-nginx -n ingress-nginx
+{{- end }}

--- a/configs/upgrades/kfddistribution/1.29.4-1.30.0/post-distribution.sh.tpl
+++ b/configs/upgrades/kfddistribution/1.29.4-1.30.0/post-distribution.sh.tpl
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+set -e
+
+kubectlbin="{{ .paths.kubectl }}"
+
+# Delete old resources after Ingress migration to v3
+{{- if eq .spec.distribution.modules.ingress.nginx.type "single" }}
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-metrics -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-selfsign -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true prometheusrule.monitoring.coreos.com ingress-nginx-k8s-rules -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true servicemonitor.monitoring.coreos.com ingress-nginx -n ingress-nginx
+{{- end }}
+
+{{- if eq .spec.distribution.modules.ingress.nginx.type "dual" }}
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-metrics -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-selfsign -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true prometheusrule.monitoring.coreos.com ingress-nginx-k8s-rules -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true servicemonitor.monitoring.coreos.com ingress-nginx -n ingress-nginx
+{{- end }}

--- a/configs/upgrades/onpremises/1.29.4-1.30.0/post-distribution.sh.tpl
+++ b/configs/upgrades/onpremises/1.29.4-1.30.0/post-distribution.sh.tpl
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+set -e
+
+kubectlbin="{{ .paths.kubectl }}"
+
+# Delete old resources after Ingress migration to v3
+{{- if eq .spec.distribution.modules.ingress.nginx.type "single" }}
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-metrics -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-selfsign -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true prometheusrule.monitoring.coreos.com ingress-nginx-k8s-rules -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true servicemonitor.monitoring.coreos.com ingress-nginx -n ingress-nginx
+{{- end }}
+
+{{- if eq .spec.distribution.modules.ingress.nginx.type "dual" }}
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true configmap nginx-configuration-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-admission-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true service ingress-nginx-metrics -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true daemonset.apps nginx-ingress-controller-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls-external -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true certificate.cert-manager.io ingress-nginx-tls-internal -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-ca -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true issuer.cert-manager.io ingress-nginx-selfsign -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true prometheusrule.monitoring.coreos.com ingress-nginx-k8s-rules -n ingress-nginx
+$kubectlbin delete --ignore-not-found=true servicemonitor.monitoring.coreos.com ingress-nginx -n ingress-nginx
+{{- end }}


### PR DESCRIPTION
This PR adds steps to migrate from ingress v2 to ingress v3.

The relevant work for ingress upgrade is:

- https://github.com/sighupio/fury-kubernetes-ingress/pull/136
- https://github.com/sighupio/fury-distribution/pull/287

The upgrade does not need a `pre-apply` phase, because new resources are added to the cluster during the `apply`, while the old ones are still present (to avoid downtime). Also, the patches have already been aligned to be applied on the new resources.

Here we are just removing the old unnecessary resources.
