### PR TITLE
feat(cmd): use dot to specify current dir when using --outdir flag

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster"
 	"github.com/sighupio/furyctl/internal/app"
 	"github.com/sighupio/furyctl/internal/cluster"
+	utils "github.com/sighupio/furyctl/internal/cmdutils"
 	"github.com/sighupio/furyctl/internal/config"
 	"github.com/sighupio/furyctl/internal/git"
 	"github.com/sighupio/furyctl/internal/lockfile"
@@ -98,20 +99,14 @@ func NewApplyCmd() *cobra.Command {
 
 			outDir := flags.Outdir
 
-			// Get home dir.
-			logrus.Debug("Getting Home Directory Path...")
-
-			homeDir, err := os.UserHomeDir()
+			outDir, err = utils.ResolveOutputDirectory(outDir)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error while getting user home directory: %w", err)
+				return fmt.Errorf("Error while resolving output dir: %w", err)
 			}
 
-			if outDir == "" {
-				outDir = homeDir
-			}
+			logrus.Debug("Resolved output directory: ", outDir)
 
 			if flags.BinPath == "" {
 				flags.BinPath = filepath.Join(outDir, ".furyctl", "bin")

--- a/cmd/connect/openvpn.go
+++ b/cmd/connect/openvpn.go
@@ -7,7 +7,6 @@ package connect
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -17,6 +16,7 @@ import (
 	"github.com/sighupio/fury-distribution/pkg/apis/config"
 	"github.com/sighupio/furyctl/internal/analytics"
 	"github.com/sighupio/furyctl/internal/app"
+	utils "github.com/sighupio/furyctl/internal/cmdutils"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
 	execx "github.com/sighupio/furyctl/internal/x/exec"
 	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
@@ -64,20 +64,16 @@ func NewOpenVPNCmd() *cobra.Command {
 				return ErrProfileFlagRequired
 			}
 
-			// Get home dir.
-			logrus.Debug("Getting Home Directory Path...")
 			outDir := flags.Outdir
-			homeDir, err := os.UserHomeDir()
+
+			outDir, err := utils.ResolveOutputDirectory(outDir)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("%w: %w", ErrCannotGetHomeDir, err)
+				return fmt.Errorf("Error while resolving output dir: %w", err)
 			}
 
-			if outDir == "" {
-				outDir = homeDir
-			}
+			logrus.Debug("Resolved output directory: ", outDir)
 
 			// Parse furyctl.yaml config.
 			logrus.Debug("Parsing furyctl.yaml file...")

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sighupio/furyctl/internal/analytics"
 	"github.com/sighupio/furyctl/internal/app"
 	"github.com/sighupio/furyctl/internal/cluster"
+	utils "github.com/sighupio/furyctl/internal/cmdutils"
 	"github.com/sighupio/furyctl/internal/config"
 	"github.com/sighupio/furyctl/internal/git"
 	"github.com/sighupio/furyctl/internal/lockfile"
@@ -85,19 +86,14 @@ func NewClusterCmd() *cobra.Command {
 
 			outDir := flags.Outdir
 
-			logrus.Debug("Getting Home Directory Path...")
-
-			homeDir, err := os.UserHomeDir()
+			outDir, err = utils.ResolveOutputDirectory(outDir)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error while getting user home directory: %w", err)
+				return fmt.Errorf("Error while resolving output dir: %w", err)
 			}
 
-			if outDir == "" {
-				outDir = homeDir
-			}
+			logrus.Debug("Resolved output directory: ", outDir)
 
 			if flags.BinPath == "" {
 				flags.BinPath = filepath.Join(outDir, ".furyctl", "bin")

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/r3labs/diff/v3"
@@ -18,6 +17,7 @@ import (
 	"github.com/sighupio/furyctl/internal/analytics"
 	"github.com/sighupio/furyctl/internal/app"
 	"github.com/sighupio/furyctl/internal/cluster"
+	utils "github.com/sighupio/furyctl/internal/cmdutils"
 	"github.com/sighupio/furyctl/internal/git"
 	"github.com/sighupio/furyctl/internal/state"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
@@ -67,20 +67,16 @@ func NewDiffCmd() *cobra.Command {
 
 			execx.Debug = flags.Debug
 
-			logrus.Debug("Getting Home Directory Path...")
 			outDir := flags.Outdir
 
-			homeDir, err := os.UserHomeDir()
+			outDir, err = utils.ResolveOutputDirectory(outDir)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error while getting user home directory: %w", err)
+				return fmt.Errorf("Error while resolving output dir: %w", err)
 			}
 
-			if outDir == "" {
-				outDir = homeDir
-			}
+			logrus.Debug("Resolved output directory: ", outDir)
 
 			if flags.BinPath == "" {
 				flags.BinPath = filepath.Join(outDir, ".furyctl", "bin")

--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -7,7 +7,6 @@ package dump
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/sighupio/furyctl/internal/analytics"
 	"github.com/sighupio/furyctl/internal/app"
+	utils "github.com/sighupio/furyctl/internal/cmdutils"
 	"github.com/sighupio/furyctl/internal/config"
 	"github.com/sighupio/furyctl/internal/distribution"
 	"github.com/sighupio/furyctl/internal/git"
@@ -82,20 +82,14 @@ The generated folder will be created starting from a provided templates folder a
 
 			outDir := flags.Outdir
 
-			// Get home dir.
-			logrus.Debug("Getting Home Directory Path...")
-
-			homeDir, err := os.UserHomeDir()
+			outDir, err = utils.ResolveOutputDirectory(outDir)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error while getting user home directory: %w", err)
+				return fmt.Errorf("Error while resolving output dir: %w", err)
 			}
 
-			if outDir == "" {
-				outDir = homeDir
-			}
+			logrus.Debug("Resolved output directory: ", outDir)
 
 			absDistroPatchesLocation := flags.DistroPatchesLocation
 
@@ -159,20 +153,6 @@ The generated folder will be created starting from a provided templates folder a
 				tracker.Track(cmdEvent)
 
 				return fmt.Errorf("%s - %w", absFuryctlPath, err)
-			}
-
-			outDir = flags.Outdir
-
-			currentDir, err := os.Getwd()
-			if err != nil {
-				cmdEvent.AddErrorMessage(err)
-				tracker.Track(cmdEvent)
-
-				return fmt.Errorf("error while getting current directory: %w", err)
-			}
-
-			if outDir == "" {
-				outDir = currentDir
 			}
 
 			outDir = filepath.Join(outDir, "distribution")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -190,7 +190,7 @@ func NewRootCmd() *RootCommand {
 		"outdir",
 		"o",
 		"",
-		"Change the directory where to create the data directory (.furyctl)",
+		"Change the directory where to create the data directory (.furyctl). Default to $HOME.",
 	)
 
 	rootCmd.PersistentFlags().StringVarP(

--- a/internal/cmdutils/directory.go
+++ b/internal/cmdutils/directory.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ResolveOutputDirectory determines the output directory based on user input.
+// It defaults to the user's home directory if `outDir` is empty.
+func ResolveOutputDirectory(outDir string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("Error while getting user home directory: %w", err)
+	}
+
+	logrus.Debug("Resolved home directory: ", homeDir)
+
+	if outDir == "" {
+		outDir = homeDir
+		logrus.Debug("Empty outdir flag. Set outdir to: ", homeDir)
+	}
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("Error while getting current working directory: %w", err)
+	}
+
+	logrus.Debug("Resolved current directory: ", currentDir)
+
+	if outDir == "." {
+		outDir = currentDir
+		logrus.Debug("Set output dir to current directory: ", currentDir)
+	}
+
+	return outDir, nil
+}


### PR DESCRIPTION
This PR solves the issue #508.

Now is possible to use `.` to specify the current directory when using the `--outdir` flag.

In addition to the `--outdir` flag for the `apply` command, the same behavior has been implement also for the other commands that use it, which are: `delete cluster`, `diff`, `connect openvpn` and `dump template`.

## Tests

- [x]  Result of `furyctl apply`:

```
furyctl apply --outdir . --debug
...
Apply script completed.
```

- [x]  Result of  `furyctl dump template`:
```
furyctl dump template --workdir $(PWD) --outdir . --debug 
...       
INFO Distribution manifests generated successfully 
```
- [x] Result of `furyctl diff` command:
```
furyctl diff --workdir $(PWD) -o .
...
INFO No differences found from previous cluster configuration 
```
- [ ] Check `connect openvpn` command:

`Help needed`

- [x] Result of `furyctl delete cluster` command:
```
furyctl delete cluster --workdir $(PWD) --outdir .
...
INFO Kubernetes Fury Distribution deleted successfully
```