### PR TITLE
fix(tools): handle nil tools in validator

### DIFF
--- a/internal/dependencies/tools/validator.go
+++ b/internal/dependencies/tools/validator.go
@@ -17,7 +17,10 @@ import (
 	execx "github.com/sighupio/furyctl/internal/x/exec"
 )
 
-var ErrWrongToolVersion = errors.New("wrong tool version")
+var (
+	ErrWrongToolVersion = errors.New("wrong tool version")
+	ErrToolNotFound     = errors.New("tool not found in the toolFactory, possible fury-distribution version mismatch")
+)
 
 func NewValidator(executor execx.Executor, binPath, furyctlPath string, autoConnect bool) *Validator {
 	return &Validator{
@@ -130,7 +133,11 @@ func (tv *Validator) validateTools(i any, kfdManifest config.KFD) ([]string, []e
 		tool := tv.toolFactory.Create(itool.Name(toolName), toolCfg.Version)
 
 		if tool == nil {
-			errs = append(errs, fmt.Errorf("%s not found in the toolFactory, possible fury-distribution version mismatch", toolName))
+			errs = append(
+				errs,
+				fmt.Errorf("%w: %s", ErrToolNotFound, toolName),
+			)
+
 			continue
 		}
 

--- a/internal/dependencies/tools/validator.go
+++ b/internal/dependencies/tools/validator.go
@@ -6,6 +6,7 @@ package tools
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -127,6 +128,12 @@ func (tv *Validator) validateTools(i any, kfdManifest config.KFD) ([]string, []e
 		}
 
 		tool := tv.toolFactory.Create(itool.Name(toolName), toolCfg.Version)
+
+		if tool == nil {
+			errs = append(errs, fmt.Errorf("%s not found in the toolFactory, possible fury-distribution version mismatch", toolName))
+			continue
+		}
+
 		if err := tool.CheckBinVersion(); err != nil {
 			errs = append(errs, err)
 

--- a/internal/x/http/file_test.go
+++ b/internal/x/http/file_test.go
@@ -17,7 +17,7 @@ import (
 func TestDownloadFile(t *testing.T) {
 	t.Parallel()
 
-	fpath, err := httpx.DownloadFile("https://sighup.io")
+	fpath, err := httpx.DownloadFile("https://example.com")
 
 	assert.NotNil(t, fpath)
 	assert.FileExists(t, fpath)


### PR DESCRIPTION

### Summary 💡

<!-- Write a short summary of the changes that this PR introduces and the motivations -->

This PR introduces a fix to handle cases where a tool returned by the `toolFactory` is `nil` in the `Validator` implementation. 
The change prevents a potential panic in case of a non-existing or non-supported tool.

Closes: [551](https://github.com/sighupio/furyctl/issues/551)

### Description 📝

The potential issue occurred because `Validator.validateTools` did not check if `toolFactory.Create` returned `nil`. 

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with tools returning `nil` to verify the error handling
- [x] Ran locally integration tests

### Future work 🔧

None
