### PR TITLE
fix(compatibility): use the right max130Version for OnPremises

### DIFF
--- a/internal/distribution/compatibility.go
+++ b/internal/distribution/compatibility.go
@@ -306,7 +306,7 @@ func (c *OnPremisesCheck) IsCompatible() bool {
 		return false
 	}
 
-	max130Version, err := semver.NewVersion("v1.30.0")
+	max130Version, err := semver.NewVersion("v1.30.1")
 	if err != nil {
 		return false
 	}

--- a/internal/distribution/compatibility_test.go
+++ b/internal/distribution/compatibility_test.go
@@ -91,6 +91,11 @@ func TestEKSClusterCheckIsCompatible(t *testing.T) {
 			expected:            false,
 		},
 		{
+			name:                "should return true if distribution version is greater than or equals 1.30.0 or 1.30.1",
+			distributionVersion: "v1.30.1",
+			expected:            true,
+		},
+		{
 			name:                "should return false if distribution version is greater than 1.30.1",
 			distributionVersion: "v1.30.2",
 			expected:            false,
@@ -203,6 +208,11 @@ func TestKFDDistributionCheckIsCompatible(t *testing.T) {
 			expected:            false,
 		},
 		{
+			name:                "should return true if distribution version is greater than or equals 1.30.0 or 1.30.1",
+			distributionVersion: "v1.30.1",
+			expected:            true,
+		},
+		{
 			name:                "should return false if distribution version is greater than 1.30.1",
 			distributionVersion: "v1.30.2",
 			expected:            false,
@@ -303,6 +313,11 @@ func TestOnPremisesCheckIsCompatible(t *testing.T) {
 			name:                "should return false if distribution version is greater than 1.29.6",
 			distributionVersion: "v1.29.7",
 			expected:            false,
+		},
+		{
+			name:                "should return true if distribution version is greater than or equals 1.30.0 or 1.30.1",
+			distributionVersion: "v1.30.1",
+			expected:            true,
 		},
 		{
 			name:                "should return false if distribution version is greater than 1.30.1",


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to knwo that you are working on this change, and let's you have a 
place to track your work in progress.

When opening PRs in Draft, don't assign reviewers until the PR is ready for review.  Once you are confortable with the
status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

<!-- Write a short summary of the changes that this PR introduces and the motivations -->

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.
If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->
This PR solves a small bug where `furyctl apply` commands with the OnPremises provider and version 1.30.1  give a warning about v1.30.1 being unsupported, when it's not the case.

This bug appears only with the OnPremises provider, while EKSCluster and KFDDistribution do not show this issue.

Closes: #565 


### Description 📝

<!--
Let us know what you are changing. Share anything that could provide the most context.
Feel free to add screenshots, code examples, the Description could end up in the release notes to help users adopt
the new feature or changes that you are introducing.

Expand on the reasoning behind some decision that you could have made to help reviewers understand the diff in the PR.

-->
The change is a rather small one, adjusting the `max130Version` to the correct one in the code block that does the compatibility checks for the OnPremises provider. I also added relative unit tests to verify this behaviour.

### Breaking Changes 💔

<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->
None.
### Tests performed 🧪

<!--
Create a checklist with all the tests that you performed on your changes, being manual or automated.
If you are opening a Draft PR, you can use the checklist to track the tests that you want to do and mark them once you
have performed them.

-->
- [x] Tested the change with a real KFD OnPremises version 1.30.1 configuration file
- [x] Tested with dedicated unit tests for all providers
### Future work 🔧

<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->
N/A