### PR TITLE
feat: add new `furyctl get distro-versions` command

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -18,6 +18,6 @@ func NewGetCmd() *cobra.Command {
 
 	getCmd.AddCommand(get.NewKubeconfigCmd())
 	getCmd.AddCommand(get.NewUpgradePathsCmd())
-
+	getCmd.AddCommand(get.NewDistroVersionCmd())
 	return getCmd
 }

--- a/cmd/get/distro-versions.go
+++ b/cmd/get/distro-versions.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package get
+
+import (
+	"fmt"
+
+	"github.com/sighupio/furyctl/internal/analytics"
+	"github.com/sighupio/furyctl/internal/app"
+	"github.com/sighupio/furyctl/internal/git"
+	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const DateFmt = "2006-01-02"
+
+func NewDistroVersionCmd() *cobra.Command {
+	var cmdEvent analytics.Event
+
+	distroVersionCmd := &cobra.Command{
+		Use:   "distro-versions",
+		Short: "Get the supported distro versions and shows compatibilities with the current furyctl version used to invoke this command with the different distribution's kind.",
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			cmdEvent = analytics.NewCommandEvent(cobrax.GetFullname(cmd))
+
+			if err := viper.BindPFlags(cmd.Flags()); err != nil {
+				logrus.Fatalf("error while binding flags: %v", err)
+			}
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctn := app.GetContainerInstance()
+
+			tracker := ctn.Tracker()
+			tracker.Flush()
+			releases, err := app.GetSupportedDistroVersions(git.NewGitHubClient())
+			if err != nil {
+				cmdEvent.AddErrorMessage(err)
+				tracker.Track(cmdEvent)
+				return fmt.Errorf("error getting supported distro versions: %w", err)
+			}
+			logrus.Info(formatDistroVersions(releases))
+
+			cmdEvent.AddSuccessMessage("upgrade paths successfully retrieved")
+			tracker.Track(cmdEvent)
+
+			return nil
+		},
+	}
+
+	return distroVersionCmd
+}
+
+func formatDistroVersions(releases []app.DistroRelease) string {
+	fmtDistroVersions := ""
+	fmtDistroVersions += "AVAILABLE KUBERNETES FURY DISTRIBUTION VERSIONS\n"
+	fmtDistroVersions += "-----------------------------------------------\n"
+	fmtDistroVersions += "VERSION\tRELEASE DATE\tEKS\tKFD\tON PREMISE\n"
+	for _, r := range releases {
+		supported := func(s bool) string {
+			if s {
+				return "X"
+			}
+			return ""
+		}
+
+		fmtDistroVersions += fmt.Sprintf(
+			"v%s\t%s\t%s\t%s\t%s\n",
+			r.Version.String(),
+			r.Date.Format(DateFmt),
+			supported(r.FuryctlSupport.EKSCluster),
+			supported(r.FuryctlSupport.KFDDistribution),
+			supported(r.FuryctlSupport.OnPremises),
+		)
+	}
+	return fmtDistroVersions
+}

--- a/cmd/get/distro-versions_test.go
+++ b/cmd/get/distro-versions_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package get
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sighupio/furyctl/internal/app"
+	"github.com/sighupio/furyctl/internal/git"
+	"github.com/sighupio/furyctl/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatDistroVersions(t *testing.T) {
+	mockGhClient := mocks.NewMockGitHubClient(
+		[]git.Tag{{
+			Ref:    "v1.20.0",
+			Object: git.TagCommit{SHA: "20", URL: "https://..."},
+		}, {
+			Ref:    "v1.22.0",
+			Object: git.TagCommit{SHA: "22", URL: "https://..."},
+		}, {
+			Ref:    "v1.23.0",
+			Object: git.TagCommit{SHA: "23", URL: "https://..."},
+		}, {
+			Ref:    "v1.24.0",
+			Object: git.TagCommit{SHA: "27", URL: "https://..."},
+		}, {
+			Ref:    "v1.28.0",
+			Object: git.TagCommit{SHA: "28", URL: "https://..."},
+		}, {
+			Ref:    "v1.29.0",
+			Object: git.TagCommit{SHA: "29", URL: "https://..."},
+		}, {
+			Ref:    "v1.30.0",
+			Object: git.TagCommit{SHA: "30", URL: "https://..."},
+		}, {
+			Ref:    "v1.31.0",
+			Object: git.TagCommit{SHA: "31", URL: "https://..."},
+		}},
+		map[string]git.Commit{
+			"31": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2024-10-06T14:16:00Z"}},
+			"30": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"29": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2022-10-06T14:16:00Z"}},
+			"28": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2020-10-06T14:16:00Z"}},
+			"27": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2019-10-06T14:16:00Z"}},
+			"23": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2018-10-06T14:16:00Z"}},
+			"22": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"20": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+		},
+	)
+	releases, err := app.GetSupportedDistroVersions(mockGhClient)
+	assert.NoError(t, err)
+	fmtString := formatDistroVersions(releases)
+	lines := strings.Split(fmtString, "\n")
+	assert.Equal(t, lines[0], "AVAILABLE KUBERNETES FURY DISTRIBUTION VERSIONS")
+	assert.Equal(t, lines[1], "-----------------------------------------------")
+	assert.Equal(t, lines[2], "VERSION\tRELEASE DATE\tEKS\tKFD\tON PREM")
+	assert.Contains(t, lines[3], "v1.29.0\t2022-10-06")
+	assert.Contains(t, lines[4], "v1.30.0\t2023-10-06")
+	assert.Contains(t, lines[5], "v1.31.0\t2024-10-06")
+}

--- a/cmd/get/distro-versions_test.go
+++ b/cmd/get/distro-versions_test.go
@@ -42,14 +42,14 @@ func TestFormatDistroVersions(t *testing.T) {
 			Object: git.TagCommit{SHA: "31", URL: "https://..."},
 		}},
 		map[string]git.Commit{
-			"31": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2024-10-06T14:16:00Z"}},
-			"30": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"29": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2022-10-06T14:16:00Z"}},
-			"28": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2020-10-06T14:16:00Z"}},
-			"27": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2019-10-06T14:16:00Z"}},
-			"23": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2018-10-06T14:16:00Z"}},
-			"22": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"20": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"31": {Tagger: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2024-10-06T14:16:00Z"}},
+			"30": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"29": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2022-10-06T14:16:00Z"}},
+			"28": {Tagger: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2020-10-06T14:16:00Z"}},
+			"27": {Tagger: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2019-10-06T14:16:00Z"}},
+			"23": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2018-10-06T14:16:00Z"}},
+			"22": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"20": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
 		},
 	)
 	releases, err := app.GetSupportedDistroVersions(mockGhClient)
@@ -58,8 +58,8 @@ func TestFormatDistroVersions(t *testing.T) {
 	lines := strings.Split(fmtString, "\n")
 	assert.Equal(t, lines[0], "AVAILABLE KUBERNETES FURY DISTRIBUTION VERSIONS")
 	assert.Equal(t, lines[1], "-----------------------------------------------")
-	assert.Equal(t, lines[2], "VERSION\tRELEASE DATE\tEKS\tKFD\tON PREM")
-	assert.Contains(t, lines[3], "v1.29.0\t2022-10-06")
+	assert.Equal(t, lines[2], "VERSION\tRELEASE DATE\tEKS\tKFD\tON PREMISE")
+	assert.Contains(t, lines[3], "v1.31.0\t2024-10-06")
 	assert.Contains(t, lines[4], "v1.30.0\t2023-10-06")
-	assert.Contains(t, lines[5], "v1.31.0\t2024-10-06")
+	assert.Contains(t, lines[5], "v1.29.0\t2022-10-06")
 }

--- a/internal/app/distro_versions.go
+++ b/internal/app/distro_versions.go
@@ -1,0 +1,156 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"slices"
+
+	"github.com/Al-Pragliola/go-version"
+	"github.com/sighupio/furyctl/internal/distribution"
+	"github.com/sighupio/furyctl/internal/git"
+	"github.com/sirupsen/logrus"
+)
+
+// DistroRelease holds information about a distribution release.
+type DistroRelease struct {
+	Version        version.Version
+	Sha            string
+	Date           time.Time
+	FuryctlSupport FuryctlSupported
+}
+
+// FuryctlSupported holds boolean flags for supported distributions.
+type FuryctlSupported struct {
+	EKSCluster      bool
+	KFDDistribution bool
+	OnPremises      bool
+}
+
+// GetSupportedDistroVersions retrieves distro releases filtering out unsupported versions.
+func GetSupportedDistroVersions(ghClient git.RepoClient) ([]DistroRelease, error) {
+	var releases []DistroRelease
+
+	// Fetch all tags from the GitHub API.
+	tags, err := ghClient.GetTags()
+	if err != nil {
+		return releases, fmt.Errorf("error getting tags from github: %w", err)
+	}
+
+	// Get the latest distro version from the tag list.
+	latestRelease, err := getLatestDistroVersion(ghClient, tags)
+	if err != nil {
+		return releases, fmt.Errorf("error getting latest distro version: %w", err)
+	}
+
+	// Calculate the latest supported version based on the latest release.
+	latestSupportedVersion := GetLatestSupportedVersion(latestRelease.Version)
+
+	// Loop over all tags except the final element and only keep supported ones.
+	for _, tag := range tags {
+		v, err := VersionFromRef(tag.Ref)
+		if err != nil || v.LessThan(&latestSupportedVersion) {
+			continue
+		}
+		release, err := newDistroRelease(ghClient, tag)
+		if err != nil {
+			// Skip tags that cannot be parsed or processed.
+			continue
+		}
+		releases = append(releases, release)
+	}
+	return releases, nil
+}
+
+// GetLatestSupportedVersion returns the supported version based on the second segment of the version.
+func GetLatestSupportedVersion(v version.Version) version.Version {
+	// Generate a version string using the second segment from the provided version.
+	versionStr := fmt.Sprintf("1.%d.0", v.Segments()[1]-2)
+	supportedVersion, _ := version.NewSemver(versionStr)
+	return *supportedVersion
+}
+
+// GetLatestDistroVersion iterates backward over tags to return the latest valid distro release.
+func getLatestDistroVersion(ghClient git.RepoClient, tags []git.Tag) (DistroRelease, error) {
+	// Iterate from last to first using slices.Backward
+	for _, tag := range slices.Backward(tags) {
+		version, err := VersionFromRef(tag.Ref)
+		if err != nil {
+			continue
+		}
+		// Skip prerelease versions.
+		if version.Prerelease() != "" {
+			continue
+		}
+		return newDistroRelease(ghClient, tag)
+	}
+	return DistroRelease{}, fmt.Errorf("latest distro not found")
+}
+
+// NewDistroRelease creates a DistroRelease from a Tag, fetching its commit details.
+func newDistroRelease(ghClient git.RepoClient, tag git.Tag) (DistroRelease, error) {
+	var release DistroRelease
+
+	// Parse version from tag reference.
+	version, err := VersionFromRef(tag.Ref)
+	if err != nil {
+		logrus.Debug(err)
+		return release, fmt.Errorf("invalid version: %w", err)
+	}
+
+	// Fetch the commit information using the SHA.
+	commit, err := ghClient.GetCommit(tag.Object.SHA)
+	if err != nil {
+		logrus.Error(err)
+		return release, fmt.Errorf("error getting commit: %w", err)
+	}
+
+	// Parse the commit date.
+	commitDate, _ := time.Parse(time.RFC3339, commit.Author.Date)
+
+	// Build the release struct.
+	release = DistroRelease{
+		Version:        version,
+		Sha:            tag.Object.SHA,
+		Date:           commitDate,
+		FuryctlSupport: GetFuryctlSupport(version),
+	}
+	return release, nil
+}
+
+// GetFuryctlSupport checks for compatibility with various distributions.
+func GetFuryctlSupport(version version.Version) FuryctlSupported {
+	eks, errEKS := distribution.NewCompatibilityChecker(version.String(), distribution.EKSClusterKind)
+	kfd, errKFD := distribution.NewCompatibilityChecker(version.String(), distribution.KFDDistributionKind)
+	onprem, errOnPrem := distribution.NewCompatibilityChecker(version.String(), distribution.OnPremisesKind)
+
+	// Helper function to interpret compatibility result.
+	isCompatible := func(checker distribution.CompatibilityChecker, err error) bool {
+		if err != nil {
+			return false
+		}
+		return checker.IsCompatible()
+	}
+
+	return FuryctlSupported{
+		EKSCluster:      isCompatible(eks, errEKS),
+		KFDDistribution: isCompatible(kfd, errKFD),
+		OnPremises:      isCompatible(onprem, errOnPrem),
+	}
+}
+
+// VersionFromRef converts a tag ref string to a semver version.
+// Expected format: "refs/tags/v1.2.3"
+func VersionFromRef(ref string) (version.Version, error) {
+	var v version.Version
+	// Remove the "refs/tags/" prefix.
+	versionStr := strings.ReplaceAll(ref, "refs/tags/", "")
+	if !strings.HasPrefix(versionStr, "v") {
+		return v, fmt.Errorf("invalid version: %s", versionStr)
+	}
+	// Remove the "v" prefix to isolate the version number.
+	versionStr = versionStr[1:]
+	ver, err := version.NewSemver(versionStr)
+	return *ver, err
+}

--- a/internal/app/distro_versions_test.go
+++ b/internal/app/distro_versions_test.go
@@ -38,14 +38,14 @@ func TestGetSupportedDistroVersions(t *testing.T) {
 			Object: git.TagCommit{SHA: "31", URL: "https://..."},
 		}},
 		map[string]git.Commit{
-			"31": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"30": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"29": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"28": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"27": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"23": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"22": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
-			"20": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"31": {Tagger: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"30": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"29": {Tagger: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"28": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"27": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"23": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"22": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"20": {Author: &git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
 		},
 	)
 

--- a/internal/app/distro_versions_test.go
+++ b/internal/app/distro_versions_test.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/Al-Pragliola/go-version"
+	"github.com/sighupio/furyctl/internal/git"
+	"github.com/sighupio/furyctl/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSupportedDistroVersions(t *testing.T) {
+	// Mock GitHub client
+	mockGhClient := mocks.NewMockGitHubClient(
+		[]git.Tag{{
+			Ref:    "v1.20.0",
+			Object: git.TagCommit{SHA: "20", URL: "https://..."},
+		}, {
+			Ref:    "v1.22.0",
+			Object: git.TagCommit{SHA: "22", URL: "https://..."},
+		}, {
+			Ref:    "v1.23.0",
+			Object: git.TagCommit{SHA: "23", URL: "https://..."},
+		}, {
+			Ref:    "v1.24.0",
+			Object: git.TagCommit{SHA: "27", URL: "https://..."},
+		}, {
+			Ref:    "v1.28.0",
+			Object: git.TagCommit{SHA: "28", URL: "https://..."},
+		}, {
+			Ref:    "v1.29.0",
+			Object: git.TagCommit{SHA: "29", URL: "https://..."},
+		}, {
+			Ref:    "v1.30.0",
+			Object: git.TagCommit{SHA: "30", URL: "https://..."},
+		}, {
+			Ref:    "v1.31.0",
+			Object: git.TagCommit{SHA: "31", URL: "https://..."},
+		}},
+		map[string]git.Commit{
+			"31": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"30": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"29": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"28": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"27": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"23": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"22": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+			"20": {Author: git.CommitAuthor{Name: "John Doe", Email: "john@example.com", Date: "2023-10-06T14:16:00Z"}},
+		},
+	)
+
+	// Call the function being tested
+	releases, err := GetSupportedDistroVersions(mockGhClient)
+
+	// Assert results
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(releases))
+	assert.Equal(t, "1.29.0", releases[0].Version.String())
+}
+
+func TestGetLatestSupportedVersion(t *testing.T) {
+	// Test case for GetLatestSupportedVersion
+	v, _ := version.NewSemver("1.31.0")
+	supportedV := GetLatestSupportedVersion(*v)
+	assert.Equal(t, "1.29.0", supportedV.String())
+}
+
+func TestVersionFromRef(t *testing.T) {
+	// Test case for VersionFromRef
+	ref := "refs/tags/v1.2.3-abcXXX"
+	v, err := VersionFromRef(ref)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3-abcXXX", v.String())
+}

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -1,0 +1,148 @@
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// HTTPClient is an interface for making HTTP requests
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// ClientConfig holds the configuration for the GitHub API client
+type ClientConfig struct {
+	TagsAPI   string
+	CommitAPI string
+	Timeout   time.Duration
+}
+
+type RepoClient interface {
+	GetTags() ([]Tag, error)
+	GetCommit(sha string) (Commit, error)
+}
+
+// GitHubClient provides methods for interacting with the GitHub API
+type GitHubClient struct {
+	client HTTPClient
+	config ClientConfig
+}
+
+// Tag represents the Git tag structure from the GitHub API.
+type Tag struct {
+	Ref    string    `json:"ref"`
+	Object TagCommit `json:"object"`
+}
+
+// TagCommit represents the commit object within a tag.
+type TagCommit struct {
+	SHA string `json:"sha"`
+	URL string `json:"url"`
+}
+
+// Commit represents the commit details retrieved from GitHub.
+type Commit struct {
+	Author CommitAuthor `json:"author"`
+}
+
+// CommitAuthor holds the commit author’s details.
+type CommitAuthor struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+	Date  string `json:"date"`
+}
+
+type GithubMessage struct {
+	Message string `json:"message"`
+}
+
+// GetTags retrieves Git tags from the GitHub API
+func (gc GitHubClient) GetTags() ([]Tag, error) {
+	var tags []Tag
+	ctx, cancel := context.WithTimeout(context.Background(), gc.config.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gc.config.TagsAPI, nil)
+	if err != nil {
+		return tags, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := gc.client.Do(req)
+	if err != nil {
+		return tags, fmt.Errorf("error performing request: %w", err)
+	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			if err := resp.Body.Close(); err != nil {
+				logrus.Error(err)
+			}
+		}
+	}()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if err := json.Unmarshal(respBody, &tags); err != nil {
+		var ghMessage GithubMessage
+
+		if err := json.Unmarshal(respBody, &ghMessage); err == nil {
+			return tags, fmt.Errorf("error from github api: %s", ghMessage.Message)
+		}
+		return tags, fmt.Errorf("error decoding response: %w", err)
+	}
+
+	return tags, nil
+}
+
+// GetCommit fetches commit details for a given SHA
+func (gc GitHubClient) GetCommit(sha string) (Commit, error) {
+	var commit Commit
+	ctx, cancel := context.WithTimeout(context.Background(), gc.config.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gc.config.CommitAPI+sha, nil)
+	if err != nil {
+		return commit, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := gc.client.Do(req)
+	if err != nil {
+		return commit, fmt.Errorf("error performing request: %w", err)
+	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			if err := resp.Body.Close(); err != nil {
+				logrus.Error(err)
+			}
+		}
+	}()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if err := json.Unmarshal(respBody, &commit); err != nil {
+		var ghMessage GithubMessage
+
+		if err := json.Unmarshal(respBody, &ghMessage); err == nil {
+			return commit, fmt.Errorf("error from github api: %s", ghMessage.Message)
+		}
+		return commit, fmt.Errorf("error decoding response: %w", err)
+	}
+	return commit, nil
+}
+
+// NewGitHubClient creates a new GitHub client with the given configuration
+func NewGitHubClient() *GitHubClient {
+	return &GitHubClient{
+		client: http.DefaultClient,
+		config: ClientConfig{
+			TagsAPI:   "https://api.github.com/repos/sighupio/fury-distribution/git/refs/tags",
+			CommitAPI: "https://api.github.com/repos/sighupio/fury-distribution/git/commits/",
+			Timeout:   5 * time.Second,
+		},
+	}
+}

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -48,7 +48,8 @@ type TagCommit struct {
 
 // Commit represents the commit details retrieved from GitHub.
 type Commit struct {
-	Author CommitAuthor `json:"author"`
+	Author *CommitAuthor `json:"author"`
+	Tagger *CommitAuthor `json:"tagger"`
 }
 
 // CommitAuthor holds the commit author’s details.

--- a/mocks/mock_github.go
+++ b/mocks/mock_github.go
@@ -1,0 +1,34 @@
+package mocks
+
+import (
+	"fmt"
+
+	"github.com/sighupio/furyctl/internal/git"
+)
+
+// MockGitHubClient is a mocked version of GitHubClient
+type MockGitHubClient struct {
+	tagsResponse   []git.Tag
+	commitResponse map[string]git.Commit
+}
+
+// GetTags mocks the GetTags method of GitHubClient
+func (m MockGitHubClient) GetTags() ([]git.Tag, error) {
+	return m.tagsResponse, nil
+}
+
+// GetCommit mocks the GetCommit method of GitHubClient
+func (m MockGitHubClient) GetCommit(sha string) (git.Commit, error) {
+	if commit, ok := m.commitResponse[sha]; ok {
+		return commit, nil
+	}
+	return git.Commit{}, fmt.Errorf("commit not found")
+}
+
+// NewMockGitHubClient creates a new MockGitHubClient with predefined responses
+func NewMockGitHubClient(tags []git.Tag, commits map[string]git.Commit) git.RepoClient {
+	return MockGitHubClient{
+		tagsResponse:   tags,
+		commitResponse: commits,
+	}
+}


### PR DESCRIPTION
### Summary 💡

Created new subcommand `furyctl get distro-versions` to show available supported versions for the fury-distribution. The command only shows supported versions and if the various distribution kinds are compatible with the furyctl cli

Closes: #210 

### Description 📝

- Added new command `furyctl get distro-versions`
- Added a way to query directly the public github api to retrieve sighupio/kubernetes-fury tags and commit info
- Added logic to check 

### Breaking Changes 💔

None

### Tests performed 🧪

- Unit tests (`cmd/get/distro-versions_test.go`, `internal/app/distro_versions_test.go`)
- run `furyctl get distro-versions`
Output:
```
INFO AVAILABLE KUBERNETES FURY DISTRIBUTION VERSIONS
-----------------------------------------------
VERSION	RELEASE DATE	EKS	KFD	ON PREMISE
v1.29.0	2024-04-24	X	X	X
v1.29.1	0001-01-01	X	X	X
v1.29.2	2024-08-09	X	X	X
v1.29.3	2024-08-27	X	X	X
v1.29.4	2024-09-20	X	X	X
v1.29.5	0001-01-01	X	X	X
v1.29.6	0001-01-01	X	X	X
v1.30.0	0001-01-01	X	X	X
v1.30.1	0001-01-01	X	X	X
v1.31.0	0001-01-01	X	X	X 
```

### Future work 🔧

- The way it checks for compatibility for various distribution's kinds the should be more customisable to be able to be tested properly
- The logic to get the last supported version is very basic (latest version minor and the 2 previous, for example 1.31.0 minus 2 minor versions = 1.29.0) which would probably break in case of a major version bump