### PR TITLE
chore(cmd): fix create config example command

### DIFF
--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -39,7 +39,7 @@ func NewConfigCmd() *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:     "config",
 		Short:   "Scaffolds a new furyctl configuration file for a specific version and kind",
-		Example: "furyctl create config --kind OnPremises --version 1.30.0 --name test-cluster",
+		Example: "furyctl create config --kind OnPremises --version v1.30.0 --name test-cluster",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			cmdEvent = analytics.NewCommandEvent(cobrax.GetFullname(cmd))
 


### PR DESCRIPTION

### Summary 💡

<!-- Write a short summary of the changes that this PR introduces and the motivations -->
Fix example in `furyctl create config` command help, the version needs to start with `v`. Otherwise you'll get an error.

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.
If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->
Closes: #573


### Description 📝

See Summary and linked issue.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Fixed help message, ran `furyctl create config --help`, copy&pasted the example command and verified that it generated a configuration file.

### Future work 🔧

None