### PR TITLE
feat: add support to kustomize version 5.6.0

### DIFF
--- a/internal/dependencies/tools/kustomize.go
+++ b/internal/dependencies/tools/kustomize.go
@@ -20,7 +20,7 @@ func NewKustomize(runner *kustomize.Runner, version string) *Kustomize {
 		os:      runtime.GOOS,
 		version: version,
 		checker: &checker{
-			regex:  regexp.MustCompile(`kustomize/v(\S*)`),
+			regex:  regexp.MustCompile(`v(\S*)`),
 			runner: runner,
 			trimFn: func(tokens []string) string {
 				return strings.TrimLeft(tokens[len(tokens)-1], "v")

--- a/internal/tool/kustomize/runner.go
+++ b/internal/tool/kustomize/runner.go
@@ -53,7 +53,7 @@ func (r *Runner) deleteCmd(id string) {
 }
 
 func (r *Runner) Version() (string, error) {
-	args := []string{"version", "--short"}
+	args := []string{"version"}
 
 	cmd, id := r.newCmd(args)
 	defer r.deleteCmd(id)
@@ -67,7 +67,7 @@ func (r *Runner) Version() (string, error) {
 }
 
 func (r *Runner) Build() (string, error) {
-	args := []string{"build", "--load_restrictor", "none", "."}
+	args := []string{"build", "--load-restrictor", "none", "."}
 
 	cmd, id := r.newCmd(args)
 	defer r.deleteCmd(id)

--- a/internal/tool/kustomize/runner.go
+++ b/internal/tool/kustomize/runner.go
@@ -66,20 +66,6 @@ func (r *Runner) Version() (string, error) {
 	return out, nil
 }
 
-func (r *Runner) Build() (string, error) {
-	args := []string{"build", "--load-restrictor", "none", "."}
-
-	cmd, id := r.newCmd(args)
-	defer r.deleteCmd(id)
-
-	out, err := execx.CombinedOutput(cmd)
-	if err != nil {
-		return "", fmt.Errorf("error while running kustomize build: %w", err)
-	}
-
-	return out, nil
-}
-
 func (r *Runner) Stop() error {
 	for _, cmd := range r.cmds {
 		if err := cmd.Stop(); err != nil {


### PR DESCRIPTION
### Summary 💡
This follows the PR on fury-distribution to allow to update `kustomize` to version 5.6.0.

Relates: https://github.com/sighupio/product-management/issues/630

### Description 📝
New versions of kustomize deprecate the kustomize version option `--short`. The output of that command is also changed. To allow both version to be handled correctly by `furyctl` we now relax the regular expression used to get the tool version to match both outputs.

### Breaking Changes 💔
Nothing.

### Tests performed 🧪
- [x] Create a cluster with a "new" fury-distribution, that uses the new `kustomize` version (5.6.0).
- [x] Create a cluster with an "old" furydistribution, that uses the old `kustomize` version (3.10.0).

### Future work 🔧
Nothing.
