### PR TITLE
chore: improve unsupported version message

### DIFF
--- a/pkg/distribution/download.go
+++ b/pkg/distribution/download.go
@@ -93,8 +93,8 @@ func (d *Downloader) Download(
 	}
 
 	if !compatChecker.IsCompatible() {
-		logrus.Warnf("The specified KFD version %s is not supported by furyctl, "+
-			"please upgrade furyctl to the latest version or use a supported version",
+		logrus.Warnf("The specified KFD version %s is not supported by this version of furyctl, "+
+			"please upgrade furyctl to the latest version or use a supported KFD version",
 			minimalConf.Spec.DistributionVersion)
 	}
 

--- a/pkg/distribution/download.go
+++ b/pkg/distribution/download.go
@@ -94,7 +94,8 @@ func (d *Downloader) Download(
 
 	if !compatChecker.IsCompatible() {
 		logrus.Warnf("The specified KFD version %s is not supported by this version of furyctl, "+
-			"please upgrade furyctl to the latest version or use a supported KFD version",
+			"please upgrade furyctl to the latest version or use a supported KFD version. "+
+			"Run `furyctl get supported-versions` for a compatibility matrix.",
 			minimalConf.Spec.DistributionVersion)
 	}
 


### PR DESCRIPTION

### Summary 💡

Improve the message that gets printed when furyctl does not support the KFD version found in the configuration file.

### Description 📝

Be more specific in the message that gets printed when you use furyctl with an unsupported KFD version.

Before:
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/f772e8a5-458a-4779-b32b-3415b9cc2286" />

After:
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/b6f0d7a2-f422-4e2c-96d8-6efefe850286" />


### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with a kfd.yaml pointing to an non-existent KFD version, so not supported by furyctl.

### Future work 🔧

None