### PR TITLE
feat: remove snapshot-controller from kapp before upgrade

### DIFF
--- a/configs/upgrades/ekscluster/1.31.0-1.31.1/pre-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.31.0-1.31.1/pre-distribution.sh.tpl
@@ -32,6 +32,7 @@ wait_for_job() {
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+kappbin="{{ .paths.kapp }}"
 
 # Remove some validating webhooks during the upgrade
 {{- if eq .spec.distribution.modules.policy.type "gatekeeper" }}

--- a/configs/upgrades/ekscluster/1.31.0-1.31.1/pre-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.31.0-1.31.1/pre-distribution.sh.tpl
@@ -44,3 +44,22 @@ echo "scaling down kyverno and deleting webhooks"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-scale-to-zero.yaml
 wait_for_job kyverno kyverno-scale-to-zero 60 5
 {{- end }}
+
+
+
+echo "removing old eks snapshot-controller"
+
+$kappbin delete -a kfd -n kube-system \
+  --filter-kind Deployment --filter-name snapshot-controller \
+  --filter-kind ServiceAccount --filter-name snapshot-controller \
+  --filter-kind Role --filter-name snapshot-controller-leaderelection \
+  --filter-kind RoleBinding --filter-name snapshot-controller-leaderelection \
+  --filter-kind ClusterRole --filter-name snapshot-controller-runner \
+  --filter-kind ClusterRoleBinding --filter-name snapshot-controller-role --yes
+
+$kappbin delete -a kfd -n kube-system \
+  --filter-kind \
+  --filter-name volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io \
+  --filter-name volumegroupsnapshots.groupsnapshot.storage.k8s.io \
+  --filter-name volumesnapshots.snapshot.storage.k8s.io \
+  --filter-name volumesnapshotclasses.snapshot.storage.k8s.io --yes


### PR DESCRIPTION
### Summary 💡

Remove snapshot controller before upgrade

Relates:
https://github.com/sighupio/distribution/pull/367

### Description 📝

Remove snapshot-controller before upgrade from kapp so that it will not be deleted once installed via eks addons

### Breaking Changes 💔

None

### Tests performed 🧪

- Created a cluster with v1.31.0
- executed `kubectl get deployment -n kube-system snapshot-controller -o yaml`(and all the other components) to check that it's present
- executed cluster upgrade to 1.31.1
- executed `kubectl get deployment -n kube-system snapshot-controller -o yaml`(and all the other components) to check that it's present 
