### PR TITLE
fix(upgrade-paths): delete old loki resources

### DIFF
--- a/configs/upgrades/ekscluster/1.29.6-1.29.7/post-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.29.6-1.29.7/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/ekscluster/1.29.6-1.30.2/post-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.29.6-1.30.2/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/ekscluster/1.30.1-1.30.2/post-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.30.1-1.30.2/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/ekscluster/1.30.1-1.31.1/post-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.30.1-1.31.1/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/kfddistribution/1.29.6-1.29.7/post-distribution.sh.tpl
+++ b/configs/upgrades/kfddistribution/1.29.6-1.29.7/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/kfddistribution/1.29.6-1.30.2/post-distribution.sh.tpl
+++ b/configs/upgrades/kfddistribution/1.29.6-1.30.2/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/kfddistribution/1.30.1-1.30.2/post-distribution.sh.tpl
+++ b/configs/upgrades/kfddistribution/1.30.1-1.30.2/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/kfddistribution/1.30.1-1.31.1/post-distribution.sh.tpl
+++ b/configs/upgrades/kfddistribution/1.30.1-1.31.1/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/onpremises/1.29.6-1.29.7/post-distribution.sh.tpl
+++ b/configs/upgrades/onpremises/1.29.6-1.29.7/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/onpremises/1.29.6-1.30.2/post-distribution.sh.tpl
+++ b/configs/upgrades/onpremises/1.29.6-1.30.2/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/onpremises/1.30.1-1.30.2/post-distribution.sh.tpl
+++ b/configs/upgrades/onpremises/1.30.1-1.30.2/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}

--- a/configs/upgrades/onpremises/1.30.1-1.31.1/post-distribution.sh.tpl
+++ b/configs/upgrades/onpremises/1.30.1-1.31.1/post-distribution.sh.tpl
@@ -4,6 +4,7 @@ set -e
 
 vendorPath="{{ .paths.vendorPath }}"
 kubectlbin="{{ .paths.kubectl }}"
+yqbin="{{ .paths.yq }}"
 
 # Upgrade Kyverno steps
 {{- if eq .spec.distribution.modules.policy.type "kyverno" }}
@@ -14,4 +15,16 @@ $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgra
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-migrate-resources-job.yaml
 echo "cleaning policy reports"
 $kubectlbin apply --server-side -f $vendorPath/modules/opa/katalog/kyverno/upgrade-paths/v1.12.6-v1.13.4/kyverno-clean-reports.yaml
+{{- end }}
+
+# Logging v5 / Loki cleanup
+{{- if eq .spec.distribution.modules.logging.type "loki" }}
+echo "cleaning logging resources..."
+# Delete `loki-distributed-querier` statefulset that has been migrated to a deployment
+$kubectlbin delete statefulset --namespace logging loki-distributed-querier --ignore-not-found
+# Delete `loki-distributed-compactor` deployment that has been migrated to a statefulset
+$kubectlbin delete deployment --namespace logging loki-distributed-compactor --ignore-not-found
+# Delete old `loki-distributed-*` configuration secrets (they have been replaced by `loki-*`)
+$kubectlbin get secrets --namespace logging --output yaml | $yqbin eval '.items[] | select(.metadata.name | test("^loki-distributed")) | .metadata.name' - | xargs -I {} $kubectlbin delete secret --namespace logging --ignore-not-found {}
+echo "finished cleaning logging resources"
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to knwo that you are working on this change, and let's you have a 
place to track your work in progress.

When opening PRs in Draft, don't assign reviewers until the PR is ready for review.  Once you are confortable with the
status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

<!-- Write a short summary of the changes that this PR introduces and the motivations -->

Delete resources that are not needed anymore after upgading to logging v5, that updates and deprecates some Loki components.

<!-- If this PR is related to changes produced in other repos, like a Module or the distribution, please link them below. -->
Relates: https://github.com/sighupio/module-logging/pull/185


### Description 📝

In logging v5 some components of Loki have changed kind or name. We need to do some clean up after the upgrade when we are coming from versions that were not using `kapp`.

In versions that were previously using `kapp` this was not needed.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the 1.30.1 -> 1.30.2 upgrade path in an on-premises cluster with Loki enabled. Clean up was successful.

### Future work 🔧

None
