### PR TITLE
fix: diff checker error when force flag is set

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -130,7 +130,7 @@ func NewDiffCmd() *cobra.Command {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("error while creating diff checker: %w", err)
+				return fmt.Errorf("error while creating configuration diff checker: %w", err)
 			}
 
 			phasePath, err := getPhasePath(

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
@@ -225,13 +225,13 @@ func (p *PreFlight) Exec(renderedConfig map[string]any) (*Status, error) {
 	if err != nil {
 		if !cluster.IsForceEnabledForFeature(p.force, cluster.ForceFeatureMigrations) {
 			return status, fmt.Errorf(
-				"error creating diff checker: %w; "+
+				"error creating configuration diff checker: %w; "+
 					"if this happened after a failed attempt at creating a cluster, retry using the \"--force migrations\" flag",
 				err,
 			)
 		}
 
-		logrus.Error("error creating diff checker, skipping: %w", err)
+		logrus.WithError(err).Warn("error creating configuration diff checker but force flag was used. Continuing")
 	} else {
 		d, err := diffChecker.GenerateDiff()
 		if err != nil {

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
@@ -147,13 +147,13 @@ func (p *PreFlight) Exec(renderedConfig map[string]any) (*Status, error) {
 	if err != nil {
 		if !cluster.IsForceEnabledForFeature(p.force, cluster.ForceFeatureMigrations) {
 			return status, fmt.Errorf(
-				"error creating diff checker: %w; "+
+				"error creating configuration diff checker: %w; "+
 					"if this happened after a failed attempt at creating a cluster, retry using the \"--force migrations\" flag",
 				err,
 			)
 		}
 
-		logrus.Error("error creating diff checker, skipping: %w", err)
+		logrus.WithError(err).Warn("error creating configuration diff checker but force flag was used. Continuing")
 	} else {
 		d, err := diffChecker.GenerateDiff()
 		if err != nil {

--- a/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
@@ -168,13 +168,13 @@ func (p *PreFlight) Exec(renderedConfig map[string]any) (*Status, error) {
 	if err != nil {
 		if !cluster.IsForceEnabledForFeature(p.force, cluster.ForceFeatureMigrations) {
 			return status, fmt.Errorf(
-				"error creating diff checker: %w; "+
+				"error creating configuration diff checker: %w; "+
 					"if this happened after a failed attempt at creating a cluster, retry using the \"--force migrations\" flag",
 				err,
 			)
 		}
 
-		logrus.Error("error creating diff checker, skipping: %w", err)
+		logrus.WithError(err).Warn("error creating configuration diff checker but force flag was used. Continuing")
 	} else {
 		d, err := diffChecker.GenerateDiff()
 		if err != nil {


### PR DESCRIPTION
### Summary 💡

Lower message severity to WARN when diff checker fails but force flag is set.

Fix error message formatting

Fixes #588

### Description 📝

Before:
![image](https://github.com/user-attachments/assets/71ac292d-272e-485c-9885-7ed345bb06d1)


After:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/012b02c5-1502-4dea-bd86-23087fd759bf" />

Note: I changed `Skipping` for `Continuing` afterwards taking the screenshot.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested forcing the diff checker error by aborting a cluster creation, following the reproduce steps in the linked issue.

### Future work 🔧

None