### PR TITLE
feat: add external kind in furyfile for furyctl legacy vendor

### DIFF
--- a/internal/legacy/download.go
+++ b/internal/legacy/download.go
@@ -22,6 +22,7 @@ const (
 	sshRepoPrefix           = "git@github.com:sighupio/fury-kubernetes"
 	fallbackHTTPSRepoPrefix = "git::https://github.com/sighupio/kubernetes-fury"
 	fallbackSSHRepoPrefix   = "git@github.com:sighupio/kubernetes-fury"
+	externalKind            = "external"
 )
 
 var (
@@ -96,9 +97,10 @@ func (d *Downloader) downloadProcess(wg *sync.WaitGroup, data Package, errChan c
 
 	if d.HTTPS {
 		repoPrefix := httpsRepoPrefix
-		if data.Kind == "external" {
+		if data.Kind == externalKind {
 			repoPrefix = data.URL
 		}
+
 		pU = newPackageURL(
 			repoPrefix,
 			strings.Split(data.Name, "/"),
@@ -168,9 +170,10 @@ func (d *Downloader) downloadProcess(wg *sync.WaitGroup, data Package, errChan c
 
 	if !d.HTTPS {
 		repoPrefix := sshRepoPrefix
-		if data.Kind == "external" {
+		if data.Kind == externalKind {
 			repoPrefix = data.URL
 		}
+
 		pU = newPackageURL(
 			repoPrefix,
 			strings.Split(data.Name, "/"),

--- a/internal/legacy/download.go
+++ b/internal/legacy/download.go
@@ -95,8 +95,12 @@ func (d *Downloader) downloadProcess(wg *sync.WaitGroup, data Package, errChan c
 	logrus.Debugf("worker %d : received data %v", i, data)
 
 	if d.HTTPS {
+		repoPrefix := httpsRepoPrefix
+		if data.Kind == "external" {
+			repoPrefix = data.URL
+		}
 		pU = newPackageURL(
-			httpsRepoPrefix,
+			repoPrefix,
 			strings.Split(data.Name, "/"),
 			data.Kind,
 			data.Version,
@@ -163,8 +167,12 @@ func (d *Downloader) downloadProcess(wg *sync.WaitGroup, data Package, errChan c
 	}
 
 	if !d.HTTPS {
+		repoPrefix := sshRepoPrefix
+		if data.Kind == "external" {
+			repoPrefix = data.URL
+		}
 		pU = newPackageURL(
-			sshRepoPrefix,
+			repoPrefix,
 			strings.Split(data.Name, "/"),
 			data.Kind,
 			data.Version,

--- a/internal/legacy/furyfile.go
+++ b/internal/legacy/furyfile.go
@@ -51,6 +51,7 @@ type FuryFile struct {
 	Roles            []Package       `yaml:"roles"`
 	Modules          []Package       `yaml:"modules"`
 	Bases            []Package       `yaml:"bases"`
+	External         []Package       `yaml:"external"`
 	Provider         ProviderPattern `yaml:"provider"`
 }
 
@@ -101,6 +102,16 @@ func (f *FuryFile) BuildPackages(prefix string) ([]Package, error) {
 			pkgs = append(pkgs, v)
 		} else {
 			logrus.Debugf("katalog '%s' does not match prefix, skipping it", v.Name)
+		}
+	}
+
+	for _, v := range f.External {
+		v.Kind = "external"
+		if strings.HasPrefix(v.Name, prefix) {
+			logrus.Debugf("external '%s' matches prefix, adding it to the download list", v.Name)
+			pkgs = append(pkgs, v)
+		} else {
+			logrus.Debugf("external '%s' does not match prefix, skipping it", v.Name)
 		}
 	}
 

--- a/internal/legacy/package_url.go
+++ b/internal/legacy/package_url.go
@@ -59,6 +59,10 @@ func (n *PackageURL) getURLFromCompanyRepos() string {
 		dG = ".git"
 	}
 
+	if n.Kind == "external" {
+		return fmt.Sprintf("%s/?ref=%s", n.Prefix, n.Version)
+	}
+
 	if len(n.Blocks) == 1 {
 		return fmt.Sprintf("%s-%s%s//%s?ref=%s", n.Prefix, n.Blocks[0], dG, n.Kind, n.Version)
 	}


### PR DESCRIPTION
### Summary 💡

add new kind in furyfile.yaml so that we can specify external dependencies to download with `furyctl legacy vendor`

Closes:
N/A

Relates:
https://github.com/sighupio/installer-eks/pull/84

### Description 📝

add new kind in furyfile.yaml so that we can specify external dependencies to download with `furyctl legacy vendor`

in the `furyfile.yaml` specify external repos like this:
```yaml
versions:
...

bases:
...

external:
  - name: terraform-aws-eks
    url: git@github.com:terraform-aws-modules/terraform-aws-eks.git
    version: v17.24.0
```

### Breaking Changes 💔

none

### Tests performed 🧪

with this `furyfile.yaml`
```yaml

external:
  - name: terraform-aws-eks
    url: git@github.com:terraform-aws-modules/terraform-aws-eks.git
    version: v17.24.0
```
ran `furyctl legacy vendor`
output:
```
go run main.go legacy vendor --furyfile /Users/filipporavaglia/work/installer-eks/furyfile.yaml
INFO using version 'v17.24.0' for package 'terraform-aws-eks' 
INFO downloading 'terraform-aws-modules/terraform-aws-eks.git/?ref=v17.24.0' into 'vendor/external/terraform-aws-eks' 
INFO removing git subfolder: vendor/external/terraform-aws-eks/.git 
```

verified that `./vendor/external/terraform-aws-eks` is present with the selected repository 

### Future work 🔧

N/A
