### PR TITLE
feat: print lock file path

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -184,7 +184,7 @@ func NewApplyCmd() *cobra.Command {
 					logrus.Debugf("Removing lock file %s", lockFileHandler.Path)
 
 					if err := lockFileHandler.Remove(); err != nil {
-						logrus.Errorf("error while removing lock file: %v", err)
+						logrus.Errorf("error while removing lock file %s: %v", lockFileHandler.Path, err)
 					}
 				}
 
@@ -198,7 +198,7 @@ func NewApplyCmd() *cobra.Command {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("error while verifying lock file: %w", err)
+				return fmt.Errorf("error while verifying lock file %s: %w", lockFileHandler.Path, err)
 			}
 
 			err = lockFileHandler.Create()
@@ -206,7 +206,7 @@ func NewApplyCmd() *cobra.Command {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("error while creating lock file: %w", err)
+				return fmt.Errorf("error while creating lock file %s: %w", lockFileHandler.Path, err)
 			}
 			defer lockFileHandler.Remove() //nolint:errcheck // ignore error
 

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -171,7 +171,7 @@ func NewClusterCmd() *cobra.Command {
 					logrus.Debugf("Removing lock file %s", lockFileHandler.Path)
 
 					if err := lockFileHandler.Remove(); err != nil {
-						logrus.Errorf("error while removing lock file: %v", err)
+						logrus.Errorf("error while removing lock file %s: %v", lockFileHandler.Path, err)
 					}
 				}
 
@@ -185,7 +185,7 @@ func NewClusterCmd() *cobra.Command {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("error while verifying lock file: %w", err)
+				return fmt.Errorf("error while verifying lock file %s: %w", lockFileHandler.Path, err)
 			}
 
 			err = lockFileHandler.Create()
@@ -193,7 +193,7 @@ func NewClusterCmd() *cobra.Command {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("error while creating lock file: %w", err)
+				return fmt.Errorf("error while creating lock file %s: %w", lockFileHandler.Path, err)
 			}
 			defer lockFileHandler.Remove() //nolint:errcheck // ignore error
 


### PR DESCRIPTION
### Summary 💡

Print also the path to the lock file in the messages shown to the user.

So, if your furyctl execution is blocked by the lock file by mistake (a dead process that did not clean up the lock, for example) the user knows which file to delete.

### Description 📝

See summary.

Example output:

```
❯ furyctl apply
INFO Downloading distribution...
INFO Compatibility patches applied for v1.31.1
ERRO error while verifying lock file /var/folders/lb/zscvwt_s6fx6qdrfv4g51dsc0000gn/T/furyctl-multipass: lock file exists. This usually means that there is another instance of furyctl running
```

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested to run 2 furyctl instances in parallel and verified that the path is added to the error message.

### Future work 🔧

It would be nice if the lock file had the PID inside.