### PR TITLE
fix: actually execute `post-apply-phases` when `phase` flag is simultaneously set

### DIFF
--- a/internal/apis/kfd/v1alpha2/onpremises/creator.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/creator.go
@@ -337,6 +337,27 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 		return fmt.Errorf("%w: %s", ErrUnsupportedPhase, c.phase)
 	}
 
+	if len(c.postApplyPhases) > 0 {
+		logrus.Info("Executing extra phases...")
+
+		upgradeState := &upgrade.State{
+			Phases: upgrade.Phases{
+				PreDistribution:  &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+				Distribution:     &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+				PostDistribution: &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			},
+		}
+		if err := c.extraPhases(
+			kubernetesPhase,
+			distributionPhase,
+			pluginsPhase,
+			upgr,
+			upgradeState,
+		); err != nil {
+			return fmt.Errorf("error while executing extra phases: %w", err)
+		}
+	}
+
 	if c.dryRun {
 		return nil
 	}
@@ -430,20 +451,6 @@ func (c *ClusterCreator) allPhases(
 	if distribution.HasFeature(c.kfdManifest, distribution.FeaturePlugins) {
 		if err := pluginsPhase.Exec(); err != nil {
 			return fmt.Errorf("error while executing plugins phase: %w", err)
-		}
-	}
-
-	if len(c.postApplyPhases) > 0 {
-		logrus.Info("Executing extra phases...")
-
-		if err := c.extraPhases(
-			kubernetesPhase,
-			distributionPhase,
-			pluginsPhase,
-			upgr,
-			upgradeState,
-		); err != nil {
-			return fmt.Errorf("error while executing extra phases: %w", err)
 		}
 	}
 


### PR DESCRIPTION
### Summary 💡

Run the post-apply-phases always that are set and not only when all phases are ran.
There's no reason to have mutually exclusive the phase and post-apply-phases flags.

> [!NOTE]
> Changes to EKSCluster kind are still to be done.

Closes: #602 


<!-- If this PR is related to changes produced in other repos, like a Module or the distribution, please link them below. -->
Relates:


### Description 📝

<!--
Let us know what you are changing. Share anything that could provide the most context.
Feel free to add screenshots, code examples, the Description could end up in the release notes to help users adopt
the new feature or changes that you are introducing.

Expand on the reasoning behind some decision that you could have made to help reviewers understand the diff in the PR.

-->

### Breaking Changes 💔

<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->

### Tests performed 🧪

- [x] Tested apply without additional flags is working properly
- [x] Tested apply with phase and post-apply-phases flags set is working properly
- [x] Tested apply with start-from and post-apply-phases flags is working properly
- [x] Tested upgrade with post-apply-phases set is working properly (upgrade done and post-apply-phase is run). Tested on `KFDDistribution` only.

### Future work 🔧

<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->
