### PR TITLE
feat: add tab-completion for known flags

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
+	"strings"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -426,15 +428,28 @@ func setupCreateClusterCmdFlags(cmd *cobra.Command) {
 		"phase",
 		"p",
 		"",
-		"Limit the execution to a specific phase. Options are: infrastructure, kubernetes, distribution, plugins",
+		"Limit the execution to a specific phase. Options are: "+strings.Join(cluster.GetMainPhases(), ", "),
 	)
+
+	// Tab-completion for the "phase" flag.
+	if err := cmd.RegisterFlagCompletionFunc("phase", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return cluster.GetMainPhases(), cobra.ShellCompDirectiveDefault
+	}); err != nil {
+		logrus.Fatalf("error while registering flag completion: %v", err)
+	}
 
 	cmd.Flags().String(
 		"start-from",
 		"",
-		"Start the execution from a specific phase and continue with the following phases. Options are: pre-infrastructure, infrastructure, post-infrastructure, pre-kubernetes, "+
-			"kubernetes, post-kubernetes, pre-distribution, distribution, post-distribution, plugins",
-	)
+		"Start the execution from a specific phase and continue with the following phases. "+
+			"Options are: "+strings.Join(slices.Concat(cluster.GetMainPhases(), cluster.GetOperationPhases()), ", "))
+
+	// Tab-completion for the "start-from" flag.
+	if err := cmd.RegisterFlagCompletionFunc("start-from", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return slices.Concat(cluster.GetMainPhases(), cluster.GetOperationPhases()), cobra.ShellCompDirectiveDefault
+	}); err != nil {
+		logrus.Fatalf("error while registering flag completion: %v", err)
+	}
 
 	cmd.Flags().StringP(
 		"distro-location",
@@ -507,11 +522,42 @@ func setupCreateClusterCmdFlags(cmd *cobra.Command) {
 		"WARNING: furyctl won't ask for confirmation and will proceed applying upgrades and migrations. Options are: all, upgrades, migrations, pods-running-check",
 	)
 
+	if err := cmd.RegisterFlagCompletionFunc("force", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+			cluster.ForceFeatureAll,
+			cluster.ForceFeatureMigrations,
+			cluster.ForceFeaturePodsRunningCheck,
+			cluster.ForceFeatureUpgrades,
+		}, cobra.ShellCompDirectiveDefault
+	}); err != nil {
+		logrus.Fatalf("error while registering flag completion: %v", err)
+	}
+
 	cmd.Flags().StringSlice(
 		"post-apply-phases",
 		[]string{},
-		"Phases to run after the apply command. Options are: infrastructure, kubernetes, distribution, plugins",
+		"Comma separated list of phases to run after the apply command. Options are: infrastructure, kubernetes, distribution, plugins",
 	)
+
+	// Tab-autocomplete for post-apply-phases.
+	if err := cmd.RegisterFlagCompletionFunc("post-apply-phases", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// The post-apply-phases flag accepts a comma separated list of phases, so we need to take the passed list and add a new valid option at the end of it.
+		phases := cluster.GetMainPhases()
+		toCompleteList := strings.Split(toComplete, ",")
+		toCompleteLast := toCompleteList[len(toCompleteList)-1]
+		completion := []string{}
+
+		for p := range phases {
+			if strings.HasPrefix(phases[p], toCompleteLast) {
+				toCompleteList[len(toCompleteList)-1] = phases[p]
+				completion = append(completion, strings.Join(toCompleteList, ","))
+			}
+		}
+
+		return completion, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	}); err != nil {
+		logrus.Fatalf("error while registering flag completion: %v", err)
+	}
 
 	cmd.Flags().Int(
 		"timeout",

--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sighupio/furyctl/internal/analytics"
 	"github.com/sighupio/furyctl/internal/app"
 	"github.com/sighupio/furyctl/internal/config"
+	"github.com/sighupio/furyctl/internal/distribution"
 	"github.com/sighupio/furyctl/internal/git"
 	"github.com/sighupio/furyctl/internal/semver"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
@@ -70,8 +71,11 @@ func NewConfigCmd() *cobra.Command {
 
 			kind := viper.GetString("kind")
 
-			if kind == "" {
-				return fmt.Errorf("%w: kind", ErrMandatoryFlag)
+			if _, err := distribution.NewCompatibilityChecker(version, kind); err != nil {
+				cmdEvent.AddErrorMessage(err)
+				tracker.Track(cmdEvent)
+
+				return fmt.Errorf("error while checking compatibility: %w", err)
 			}
 
 			gitProtocol := viper.GetString("git-protocol")
@@ -240,6 +244,12 @@ func NewConfigCmd() *cobra.Command {
 		"",
 		"Type of cluster to create (eg: EKSCluster, KFDDistribution, OnPremises)",
 	)
+
+	if err := configCmd.RegisterFlagCompletionFunc("kind", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return distribution.GetConfigKinds(), cobra.ShellCompDirectiveDefault
+	}); err != nil {
+		logrus.Fatalf("error while registering flag completion: %v", err)
+	}
 
 	configCmd.Flags().StringP(
 		"api-version",

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -350,6 +350,17 @@ func NewClusterCmd() *cobra.Command {
 		"Limit execution to the specified phase. Options are: infrastructure, kubernetes, distribution",
 	)
 
+	if err := clusterCmd.RegisterFlagCompletionFunc("phase", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+				cluster.OperationPhaseInfrastructure,
+				cluster.OperationPhaseKubernetes,
+				cluster.OperationPhaseDistribution,
+			},
+			cobra.ShellCompDirectiveDefault
+	}); err != nil {
+		logrus.Fatalf("error while registering flag completion: %v", err)
+	}
+
 	clusterCmd.Flags().Bool(
 		"dry-run",
 		false,

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/r3labs/diff/v3"
 	"github.com/sirupsen/logrus"
@@ -185,8 +186,23 @@ func NewDiffCmd() *cobra.Command {
 		"phase",
 		"p",
 		"",
-		"Limit the execution to a specific phase. Options are: infrastructure, kubernetes, distribution",
+		"Limit the execution to a specific phase. Options are: "+strings.Join([]string{
+			cluster.OperationPhaseInfrastructure,
+			cluster.OperationPhaseKubernetes,
+			cluster.OperationPhaseDistribution,
+		}, ", "),
 	)
+
+	// Add completion for the phase flag.
+	if err := diffCmd.RegisterFlagCompletionFunc("phase", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+			cluster.OperationPhaseInfrastructure,
+			cluster.OperationPhaseKubernetes,
+			cluster.OperationPhaseDistribution,
+		}, cobra.ShellCompDirectiveDefault
+	}); err != nil {
+		logrus.Fatalf("error while registering flag completion: %v", err)
+	}
 
 	diffCmd.Flags().StringP(
 		"distro-location",

--- a/cmd/get/upgrade-paths.go
+++ b/cmd/get/upgrade-paths.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sighupio/furyctl/internal/analytics"
 	"github.com/sighupio/furyctl/internal/app"
 	"github.com/sighupio/furyctl/internal/config"
+	"github.com/sighupio/furyctl/internal/distribution"
 	"github.com/sighupio/furyctl/internal/git"
 	"github.com/sighupio/furyctl/internal/semver"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
@@ -205,6 +206,13 @@ func NewUpgradePathsCmd() *cobra.Command {
 			// We don't need the starting v in the version. Drop it if the user passes it.
 			fromVersion, _ = strings.CutPrefix(fromVersion, "v")
 
+			// Validate the kind. We don't need the normalised kind because we are checking against the folder names.
+			if _, err := distribution.ValidateConfigKind(kind); err != nil {
+				cmdEvent.AddErrorMessage(err)
+				tracker.Track(cmdEvent)
+
+				return fmt.Errorf("error while validating kind: %w", err)
+			}
 			globPattern := fmt.Sprintf("%s/%s/%s-*", "upgrades", strings.ToLower(kind), fromVersion)
 			availablePaths, err := fs.Glob(configs.Tpl, globPattern)
 			logrus.Debug("found folders: ", availablePaths)
@@ -290,6 +298,12 @@ func NewUpgradePathsCmd() *cobra.Command {
 		"",
 		"Show upgrade paths for the kind of cluster specified (eg: EKSCluster, KFDDistribution, OnPremises) instead of the kind defined in the configuration file.",
 	)
+
+	if err := upgradePathsCmd.RegisterFlagCompletionFunc("kind", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return distribution.GetConfigKinds(), cobra.ShellCompDirectiveDefault
+	}); err != nil {
+		logrus.Fatalf("error while registering flag completion: %v", err)
+	}
 
 	return upgradePathsCmd
 }

--- a/internal/cluster/phase.go
+++ b/internal/cluster/phase.go
@@ -50,55 +50,67 @@ var (
 		"unsupported operation phase, options are: pre-infrastructure, infrastructure, post-infrastructure, " +
 			"pre-kubernetes, kubernetes, post-kubernetes, pre-distribution, distribution, post-distribution, plugins",
 	)
-	ErrChangesToOtherPhases = errors.New("changes to other phases detected")
+	ErrChangesToOtherPhases = errors.New("changes to other phases detected. When using the --phase flag, changes " +
+		"only to the section corresponding to the selected phase are accepted. ",
+	)
 )
 
 func CheckPhase(phase string) error {
-	switch phase {
-	case OperationPhasePreFlight,
+	phases := slices.Concat(
+		GetMainPhases(),
+		[]string{
+			OperationPhasePreFlight,
+			OperationPhaseAll,
+		})
+	if slices.Contains(phases, phase) {
+		return nil
+	}
+
+	return ErrUnsupportedPhase
+}
+
+// GetMainPhases returns all the main phases that can be used in the operation phase.
+func GetMainPhases() []string {
+	return []string{
 		OperationPhaseInfrastructure,
 		OperationPhaseKubernetes,
 		OperationPhaseDistribution,
 		OperationPhasePlugins,
-		OperationPhaseAll:
-		return nil
-
-	default:
-		return ErrUnsupportedPhase
 	}
 }
 
-func ValidateOperationPhase(phase string) error {
-	err := CheckPhase(phase)
-	if err == nil {
-		return nil
-	}
-
-	switch phase {
-	case OperationSubPhasePreInfrastructure,
+// GetOperationPhases returns all the sub-phases that can be used in the operation phase.
+func GetOperationPhases() []string {
+	return []string{
+		OperationSubPhasePreInfrastructure,
 		OperationSubPhasePostInfrastructure,
 		OperationSubPhasePreKubernetes,
 		OperationSubPhasePostKubernetes,
 		OperationSubPhasePreDistribution,
-		OperationSubPhasePostDistribution:
-		return nil
-
-	default:
-		return ErrUnsupportedOperationPhase
+		OperationSubPhasePostDistribution,
 	}
 }
 
-func ValidateMainPhases(phase string) error {
-	switch phase {
-	case OperationPhaseInfrastructure,
-		OperationPhaseKubernetes,
-		OperationPhaseDistribution,
-		OperationPhasePlugins:
+func ValidateOperationPhase(phase string) error {
+	// Check if the phase is a valid main or additional phase.
+	if err := CheckPhase(phase); err == nil {
 		return nil
-
-	default:
-		return ErrUnsupportedPhase
 	}
+
+	// Check if the phase is a valid sub-phase.
+	if slices.Contains(GetOperationPhases(), phase) {
+		return nil
+	}
+
+	return ErrUnsupportedOperationPhase
+}
+
+func ValidateMainPhases(phase string) error {
+	if slices.Contains(GetMainPhases(), phase) {
+		return nil
+	}
+
+	return ErrUnsupportedPhase
 }
 
 func GetPhasesOrder() []string {

--- a/pkg/distribution/download.go
+++ b/pkg/distribution/download.go
@@ -93,8 +93,8 @@ func (d *Downloader) Download(
 	}
 
 	if !compatChecker.IsCompatible() {
-		logrus.Warnf("The specified KFD version %s is not supported by this version of furyctl, "+
-			"please upgrade furyctl to the latest version or use a supported KFD version. "+
+		logrus.Warnf("The specified SD version %s is not supported by this version of furyctl, "+
+			"please upgrade furyctl to the latest version or use a supported SD version. "+
 			"Run `furyctl get supported-versions` for a compatibility matrix.",
 			minimalConf.Spec.DistributionVersion)
 	}


### PR DESCRIPTION
### Summary 💡

- Add tab completion for known values of the flags, like the options for the phase flag.
- Improve version checking for the create config command.
- A little refactoring to not repeat ourselves in where are these values defined.


### Description 📝

Improve UX by allowing to tab-complete valid options for flags that take specific values like --phase, --start-from, --kind an similar.

I also took the chance to do a little refactoring so we start to have some unique source of truth for some of this things.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that all the modified flags tab-autocomplete the right values
- [x] Tested that an on-prem cluster creation still works.
- [x] Tested that an on-prem cluster upgrade still works.

### Future work 🔧

In general the code structure is not clear to me, I believe that we can improve and better organize it, having some common centralized definitons instead of repeating our selves all over the place.

For example, the list of valid Kinds should be available in the APIs module instead of having it inside the compatibility.go file. Speaking of the API module, we seem to have 2? One in the distribution's repository and one here in furyctl's, I don't get why.