### PR TITLE
fix(dump template): use workdir instead of outputDir

### DIFF
--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -51,7 +51,7 @@ func NewTemplateCmd() *cobra.Command {
 		Use:   "template",
 		Short: "Renders the distribution's code from template files parametrized with the configuration file",
 		Long: `Generates a folder with the parametrized version of the Terraform and Kustomization code for deploying the SIGHUP Distribution into a cluster.
-The command will dump into a 'distribution' folder in the working diretory all the rendered files using the parameters set in the configuration file.`,
+The command will dump into a 'distribution' folder in the working directory all the rendered files using the parameters set in the configuration file.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRun: func(cmd *cobra.Command, _ []string) {

--- a/internal/distribution/iac.go
+++ b/internal/distribution/iac.go
@@ -141,6 +141,7 @@ func (m *IACBuilder) Build() error {
 
 	if !m.noOverwrite {
 		logrus.Debugf("removing target directory %s", m.outDir)
+
 		if err = os.RemoveAll(m.outDir); err != nil {
 			return fmt.Errorf("error removing target directory: %w", err)
 		}

--- a/internal/distribution/iac.go
+++ b/internal/distribution/iac.go
@@ -140,6 +140,7 @@ func (m *IACBuilder) Build() error {
 	}
 
 	if !m.noOverwrite {
+		logrus.Debugf("removing target directory %s", m.outDir)
 		if err = os.RemoveAll(m.outDir); err != nil {
 			return fmt.Errorf("error removing target directory: %w", err)
 		}

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestE2e(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Furyctl E2e Suite")
+	RunSpecs(t, "furyctl E2E Suite")
 }
 
 const (
@@ -369,13 +369,11 @@ var (
 				bp := filepath.Join(basepath, folder)
 				tp := filepath.Join(bp, "distribution")
 				RemoveAll(tp)
-
 				return bp
 			}
 
 			It("fails if no distribution yaml is found", func() {
 				bp := Setup("no-distribution-yaml")
-
 				out, err := FuryctlDumpTemplate(bp, false)
 
 				Expect(err).To(HaveOccurred())
@@ -442,7 +440,6 @@ var (
 
 			It("succeeds when given a complex template", func() {
 				bp := Setup("complex")
-
 				_, err := FuryctlDumpTemplate(bp, false)
 
 				Expect(err).To(Not(HaveOccurred()))

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -355,7 +355,6 @@ var (
 					"--debug",
 					"--workdir", workdir,
 					"--distro-location", ".",
-					"--outdir", "target",
 					"--disable-analytics",
 					"--log", "stdout",
 					"--skip-validation",
@@ -368,8 +367,7 @@ var (
 			}
 			Setup := func(folder string) string {
 				bp := filepath.Join(basepath, folder)
-				tp := filepath.Join(bp, "target")
-
+				tp := filepath.Join(bp, "distribution")
 				RemoveAll(tp)
 
 				return bp
@@ -408,7 +406,7 @@ var (
 				_, err := FuryctlDumpTemplate(bp, false)
 
 				Expect(err).To(HaveOccurred())
-				Expect(bp + "/target/distribution/file.txt").To(Not(BeAnExistingFile()))
+				Expect(bp + "/distribution/file.txt").To(Not(BeAnExistingFile()))
 			})
 
 			It("succeeds when given a simple template on dry-run", func() {
@@ -417,7 +415,7 @@ var (
 				_, err := FuryctlDumpTemplate(bp, true)
 
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(FileContent(bp + "/target/distribution/file.txt")).To(ContainSubstring("testValue"))
+				Expect(FileContent(bp + "/distribution/file.txt")).To(ContainSubstring("testValue"))
 			})
 
 			It("succeeds when given a simple template", func() {
@@ -426,7 +424,7 @@ var (
 				_, err := FuryctlDumpTemplate(bp, false)
 
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(FileContent(bp + "/target/distribution/file.txt")).To(ContainSubstring("testValue"))
+				Expect(FileContent(bp + "/distribution/file.txt")).To(ContainSubstring("testValue"))
 			})
 
 			It("succeeds when given a complex template on dry-run", func() {
@@ -435,10 +433,10 @@ var (
 				_, err := FuryctlDumpTemplate(bp, true)
 
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(bp + "/target/distribution/config/example.yaml").To(BeAnExistingFile())
-				Expect(bp + "/target/distribution/kustomization.yaml").To(BeAnExistingFile())
-				Expect(FileContent(bp + "/target/distribution/config/example.yaml")).To(ContainSubstring("configdata: example"))
-				Expect(FileContent(bp + "/target/distribution/kustomization.yaml")).
+				Expect(bp + "/distribution/config/example.yaml").To(BeAnExistingFile())
+				Expect(bp + "/distribution/kustomization.yaml").To(BeAnExistingFile())
+				Expect(FileContent(bp + "/distribution/config/example.yaml")).To(ContainSubstring("configdata: example"))
+				Expect(FileContent(bp + "/distribution/kustomization.yaml")).
 					To(Equal(FileContent(bp + "/data/expected-kustomization.yaml")))
 			})
 
@@ -448,10 +446,10 @@ var (
 				_, err := FuryctlDumpTemplate(bp, false)
 
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(bp + "/target/distribution/config/example.yaml").To(BeAnExistingFile())
-				Expect(bp + "/target/distribution/kustomization.yaml").To(BeAnExistingFile())
-				Expect(FileContent(bp + "/target/distribution/config/example.yaml")).To(ContainSubstring("configdata: example"))
-				Expect(FileContent(bp + "/target/distribution/kustomization.yaml")).
+				Expect(bp + "/distribution/config/example.yaml").To(BeAnExistingFile())
+				Expect(bp + "/distribution/kustomization.yaml").To(BeAnExistingFile())
+				Expect(FileContent(bp + "/distribution/config/example.yaml")).To(ContainSubstring("configdata: example"))
+				Expect(FileContent(bp + "/distribution/kustomization.yaml")).
 					To(Equal(FileContent(bp + "/data/expected-kustomization.yaml")))
 			})
 		})


### PR DESCRIPTION
### Summary 💡

Use the workdir instead of the outputDir for target forlder where to dump the rendered template.

Fixes: #434 


### Description 📝

Previously the `dump template` command was using _sometimes_ the `outputDir` as the target where to dump the `distribution` folder containing the rendered templates.

With this change, the `dump template` command will create the `distribution` folder in the working directory and dump the rendered templates there always.

Note that the workdir can be set using the `--workdir` flag, like in the other commands.

### Breaking Changes 💔

If you relied on the command dumping to the output dir you may need to adjust the flags you are using.

### Tests performed 🧪

- [x] Tested the the command without flags works as expected: dumps to the workdir and the cache dir is created under the outdir.
- [x] Tested that specifying the `workdir` makes the command create the `distribution` folder in the path specified instead of where the command was launched from.
- [x] Tested the the no-overwrite flag is still working as expected.
- [x] Tested changing outdir to a custom folder and checked that the dump is not done inside it.
- [x] Tested setting both outdir and workdir and verified that the outdir is used only for internal files and that the `distribution` folder is dumped into the workdir.

### Future work 🔧

I think that naming the outdir outdir is confusing, the outdir is a "datadir" and not an output dir. This directory is used only for internal files.