### PR TITLE
chore: use iox const for permissions

### DIFF
--- a/cmd/dump/cli-reference.go
+++ b/cmd/dump/cli-reference.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sighupio/furyctl/internal/analytics"
 	"github.com/sighupio/furyctl/internal/app"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
+	iox "github.com/sighupio/furyctl/internal/x/io"
 )
 
 type CliReferenceCmdFlags struct {
@@ -54,7 +55,6 @@ func NewDumpCLIReferenceCmd() *cobra.Command {
 
 			flags := getDumpCliReferenceCmdFlags()
 
-			const outputFolderPerms = 0o755
 			outputFolder := flags.Workdir
 
 			if len(args) > 1 {
@@ -69,7 +69,7 @@ func NewDumpCLIReferenceCmd() *cobra.Command {
 				}
 			}
 
-			if err := os.MkdirAll(outputFolder, outputFolderPerms); err != nil {
+			if err := os.MkdirAll(outputFolder, iox.FullPermAccess); err != nil {
 				return ErrOutputFolderExists
 			}
 			outputPath := filepath.Join(outputFolder, "index.md")
@@ -120,7 +120,7 @@ func NewDumpCLIReferenceCmd() *cobra.Command {
 			}
 			for _, command := range cmd.Root().Commands() {
 				outputPath := filepath.Join(outputFolder, command.Name())
-				if err := os.MkdirAll(outputPath, outputFolderPerms); err != nil {
+				if err := os.MkdirAll(outputPath, iox.FullPermAccess); err != nil {
 					return fmt.Errorf("failed to create output folder: %w", err)
 				}
 				err := genMarkdownTreeCustom(command, outputPath, dummyFilePrepender, linkHandler)

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+
+	iox "github.com/sighupio/furyctl/internal/x/io"
 )
 
 var ErrLockFileExists = errors.New(
@@ -42,8 +44,7 @@ func (l *LockFile) Verify() error {
 }
 
 func (l *LockFile) Create() error {
-	const perms = os.FileMode(0o666)
-	if err := os.WriteFile(l.Path, []byte(strconv.Itoa(os.Getpid())), perms); err != nil {
+	if err := os.WriteFile(l.Path, []byte(strconv.Itoa(os.Getpid())), iox.RWPermAccessPermissive); err != nil {
 		return fmt.Errorf("error while creating lock file: %w", err)
 	}
 


### PR DESCRIPTION
### Summary 💡

Use the const that we already had on the iox package for setting file permissions instead of redefining them.

Thanks @al-pragliola for the tip

Relates: #604

### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that the lock file logic still works

### Future work 🔧

None