### PR TITLE
fix(398): add new from node immutable reducer

### DIFF
--- a/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
@@ -10,10 +10,10 @@ import (
 	"path"
 
 	r3diff "github.com/r3labs/diff/v3"
-	"github.com/sighupio/fury-distribution/pkg/apis/config"
-	"github.com/sighupio/fury-distribution/pkg/apis/ekscluster/v1alpha2/private"
 	"github.com/sirupsen/logrus"
 
+	"github.com/sighupio/fury-distribution/pkg/apis/config"
+	"github.com/sighupio/fury-distribution/pkg/apis/ekscluster/v1alpha2/private"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/supported"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/vpn"

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
@@ -11,10 +11,10 @@ import (
 	"path"
 
 	r3diff "github.com/r3labs/diff/v3"
-	"github.com/sighupio/fury-distribution/pkg/apis/config"
-	"github.com/sighupio/fury-distribution/pkg/apis/kfddistribution/v1alpha2/public"
 	"github.com/sirupsen/logrus"
 
+	"github.com/sighupio/fury-distribution/pkg/apis/config"
+	"github.com/sighupio/fury-distribution/pkg/apis/kfddistribution/v1alpha2/public"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/kfddistribution/supported"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/distribution"

--- a/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
@@ -10,10 +10,10 @@ import (
 	"path"
 
 	r3diff "github.com/r3labs/diff/v3"
-	"github.com/sighupio/fury-distribution/pkg/apis/config"
-	"github.com/sighupio/fury-distribution/pkg/apis/onpremises/v1alpha2/public"
 	"github.com/sirupsen/logrus"
 
+	"github.com/sighupio/fury-distribution/pkg/apis/config"
+	"github.com/sighupio/fury-distribution/pkg/apis/onpremises/v1alpha2/public"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/onpremises/supported"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/state"

--- a/pkg/rulesextractor/ekscluster.go
+++ b/pkg/rulesextractor/ekscluster.go
@@ -35,31 +35,55 @@ func NewEKSClusterRulesExtractor(distributionPath string) (*EKSExtractor, error)
 	return &builder, nil
 }
 
-func (r *EKSExtractor) GetImmutables(phase string) []string {
+func (r *EKSExtractor) GetImmutableRules(phase string) []Rule {
 	switch phase {
 	case cluster.OperationPhaseInfrastructure:
 		if r.Spec.Infrastructure == nil {
-			return []string{}
+			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractImmutablesFromRules(*r.Spec.Infrastructure)
+		var immutableRules []Rule
+
+		for _, rule := range *r.Spec.Infrastructure {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+
+		return immutableRules
 
 	case cluster.OperationPhaseKubernetes:
 		if r.Spec.Kubernetes == nil {
-			return []string{}
+			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractImmutablesFromRules(*r.Spec.Kubernetes)
+		var immutableRules []Rule
+
+		for _, rule := range *r.Spec.Kubernetes {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+
+		return immutableRules
 
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
-			return []string{}
+			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractImmutablesFromRules(*r.Spec.Distribution)
+		var immutableRules []Rule
+
+		for _, rule := range *r.Spec.Distribution {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+
+		return immutableRules
 
 	default:
-		return []string{}
+		return []Rule{}
 	}
 }
 
@@ -101,4 +125,8 @@ func (r *EKSExtractor) UnsupportedReducerRulesByDiffs(rls []Rule, ds diff.Change
 
 func (r *EKSExtractor) UnsafeReducerRulesByDiffs(rls []Rule, ds diff.Changelog) []Rule {
 	return r.BaseExtractor.UnsafeReducerRulesByDiffs(rls, ds)
+}
+
+func (r *EKSExtractor) FilterSafeImmutableRules(rules []Rule, ds diff.Changelog) []Rule {
+	return r.BaseExtractor.FilterSafeImmutableRules(rules, ds)
 }

--- a/pkg/rulesextractor/ekscluster_test.go
+++ b/pkg/rulesextractor/ekscluster_test.go
@@ -10,36 +10,38 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/r3labs/diff/v3"
+
 	eksrules "github.com/sighupio/furyctl/pkg/rulesextractor"
 	rules "github.com/sighupio/furyctl/pkg/rulesextractor"
 )
 
-func TestEKSBuilder_GetImmutables(t *testing.T) {
+func TestEKSBuilder_GetImmutableRules(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		desc         string
 		eksRulesSpec *rules.Spec
 		phase        string
-		want         []string
+		want         []rules.Rule
 	}{
 		{
 			desc:         "infrastructure - empty",
 			eksRulesSpec: &rules.Spec{},
 			phase:        "infrastructure",
-			want:         []string{},
+			want:         []rules.Rule{},
 		},
 		{
 			desc:         "kubernetes - empty",
 			eksRulesSpec: &rules.Spec{},
 			phase:        "kubernetes",
-			want:         []string{},
+			want:         []rules.Rule{},
 		},
 		{
 			desc:         "distribution - empty",
 			eksRulesSpec: &rules.Spec{},
 			phase:        "distribution",
-			want:         []string{},
+			want:         []rules.Rule{},
 		},
 		{
 			desc: "infrastructure - not empty",
@@ -56,7 +58,12 @@ func TestEKSBuilder_GetImmutables(t *testing.T) {
 				},
 			},
 			phase: "infrastructure",
-			want:  []string{"foo"},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
 		},
 		{
 			desc: "kubernetes - not empty",
@@ -73,7 +80,12 @@ func TestEKSBuilder_GetImmutables(t *testing.T) {
 				},
 			},
 			phase: "kubernetes",
-			want:  []string{"foo"},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
 		},
 		{
 			desc: "distribution - not empty",
@@ -90,7 +102,12 @@ func TestEKSBuilder_GetImmutables(t *testing.T) {
 				},
 			},
 			phase: "distribution",
-			want:  []string{"foo"},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
 		},
 	}
 
@@ -104,10 +121,135 @@ func TestEKSBuilder_GetImmutables(t *testing.T) {
 				Spec: *tC.eksRulesSpec,
 			}
 
-			got := builder.GetImmutables(tC.phase)
+			got := builder.GetImmutableRules(tC.phase)
 
 			if !reflect.DeepEqual(got, tC.want) {
-				t.Errorf("expected immutables to be %v, got: %v", tC.want, got)
+				t.Errorf("expected immutable rules to be %v, got: %v", tC.want, got)
+			}
+		})
+	}
+}
+
+func TestEKSBuilder_FilterSafeImmutableRules(t *testing.T) {
+	t.Parallel()
+
+	var foo, bar any
+
+	foo = "foo"
+	bar = "bar"
+
+	testCases := []struct {
+		desc         string
+		eksRulesSpec *rules.Spec
+		rules        []rules.Rule
+		diffs        diff.Changelog
+		want         []rules.Rule
+	}{
+		{
+			desc:         "empty rules",
+			eksRulesSpec: &rules.Spec{},
+			rules:        []rules.Rule{},
+			diffs:        diff.Changelog{},
+			want:         []rules.Rule{},
+		},
+		{
+			desc:         "no safe conditions",
+			eksRulesSpec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
+		},
+		{
+			desc:         "matching safe conditions",
+			eksRulesSpec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &bar,
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{},
+		},
+		{
+			desc:         "non-matching safe conditions",
+			eksRulesSpec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &foo, // Doesn't match the diff
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &foo,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tC := range testCases {
+		tC := tC
+
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			builder := eksrules.EKSExtractor{
+				Spec: *tC.eksRulesSpec,
+			}
+
+			got := builder.FilterSafeImmutableRules(tC.rules, tC.diffs)
+
+			if !reflect.DeepEqual(got, tC.want) {
+				t.Errorf("expected filtered rules to be %v, got: %v", tC.want, got)
 			}
 		})
 	}

--- a/pkg/rulesextractor/extractor.go
+++ b/pkg/rulesextractor/extractor.go
@@ -137,25 +137,9 @@ func (b *BaseExtractor) FilterSafeImmutableRules(rules []Rule, ds diff.Changelog
 	filteredRules := make([]Rule, 0)
 
 	for _, rule := range rules {
-		// Create an empty reducer to use with the isReducerSafe function.
-		dummyReducer := Reducer{}
-
-		// Find the diff that matches this rule's path.
-		for _, d := range ds {
-			joinedPath := "." + strings.Join(d.Path, ".")
-			changePath := numbersToWildcardRegex.ReplaceAllString(joinedPath, ".*")
-
-			if changePath == rule.Path {
-				dummyReducer.From = d.From
-				dummyReducer.To = d.To
-
-				break
-			}
-		}
-
 		// If the rule has safe conditions and they match, skip this rule.
 		if rule.Safe != nil && len(*rule.Safe) > 0 {
-			if b.isReducerSafe(dummyReducer, *rule.Safe, ds) {
+			if b.isImmutableRuleSafe(rule, ds) {
 				continue
 			}
 		}
@@ -164,6 +148,81 @@ func (b *BaseExtractor) FilterSafeImmutableRules(rules []Rule, ds diff.Changelog
 	}
 
 	return filteredRules
+}
+
+func (b *BaseExtractor) isImmutableRuleSafe(rule Rule, ds diff.Changelog) bool {
+	if rule.Safe == nil || len(*rule.Safe) == 0 {
+		return false
+	}
+
+	// Find the diff that matches this rule's path.
+	var matchingDiffFrom, matchingDiffTo any
+
+	for _, d := range ds {
+		joinedPath := "." + strings.Join(d.Path, ".")
+		changePath := numbersToWildcardRegex.ReplaceAllString(joinedPath, ".*")
+
+		if changePath == rule.Path {
+			matchingDiffFrom = d.From
+			matchingDiffTo = d.To
+
+			break
+		}
+	}
+
+	for _, s := range *rule.Safe {
+		// Check From/To conditions.
+		fromToMatch := (s.From == nil || matchingDiffFrom == *s.From) &&
+			(s.To == nil || matchingDiffTo == *s.To)
+
+		// Check FromNodes conditions.
+		fromNodesMatch := b.areNodeConditionsMet(s.FromNodes, ds)
+
+		// If either From/To conditions or FromNodes conditions match, the rule is safe.
+		if (s.FromNodes == nil && fromToMatch) ||
+			(s.From == nil && s.To == nil && fromNodesMatch) ||
+			(fromToMatch && fromNodesMatch) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (*BaseExtractor) areNodeConditionsMet(fromNodes *[]FromNode, ds diff.Changelog) bool {
+	if fromNodes == nil || len(*fromNodes) == 0 {
+		return true // No conditions means they're met by default.
+	}
+
+	allNodesMatch := true
+
+	for _, node := range *fromNodes {
+		if node.Path == nil {
+			continue
+		}
+
+		// Check if the path exists in the diffs and has the expected value.
+		nodeMatches := false
+
+		for _, d := range ds {
+			joinedPath := "." + strings.Join(d.Path, ".")
+			if joinedPath == *node.Path &&
+				((node.Value == nil && d.From == "none") ||
+					(node.Value != nil && d.From == *node.Value)) {
+				nodeMatches = true
+
+				break
+			}
+		}
+
+		if !nodeMatches {
+			allNodesMatch = false
+
+			break
+		}
+	}
+
+	return allNodesMatch
 }
 
 func (b *BaseExtractor) GetReducers(_ string) []Rule {
@@ -270,47 +329,13 @@ func (b *BaseExtractor) areReducersSafe(reducers *[]Reducer, safe *[]Safe, ds di
 	return true
 }
 
-func (*BaseExtractor) isReducerSafe(reducer Reducer, safe []Safe, ds diff.Changelog) bool {
+func (b *BaseExtractor) isReducerSafe(reducer Reducer, safe []Safe, ds diff.Changelog) bool {
 	for _, s := range safe {
 		// Check From/To conditions.
 		fromToMatch := (s.From == nil || reducer.From == *s.From) && (s.To == nil || reducer.To == *s.To)
 
-		// Check FromNodes conditions if present.
-		fromNodesMatch := false
-
-		if s.FromNodes != nil && len(*s.FromNodes) > 0 {
-			allNodesMatch := true
-
-			for _, node := range *s.FromNodes {
-				if node.Path == nil {
-					continue
-				}
-
-				// Check if the path exists in the diffs and has the expected value.
-				nodeMatches := false
-
-				for _, d := range ds {
-					joinedPath := "." + strings.Join(d.Path, ".")
-					if joinedPath == *node.Path &&
-						((node.Value == nil && d.From == "none") ||
-							(node.Value != nil && d.From == *node.Value)) {
-						nodeMatches = true
-						break
-					}
-				}
-
-				if !nodeMatches {
-					allNodesMatch = false
-
-					break
-				}
-			}
-
-			fromNodesMatch = allNodesMatch
-		} else {
-			// If no FromNodes conditions, consider it a match.
-			fromNodesMatch = true
-		}
+		// Check FromNodes conditions using the dedicated function.
+		fromNodesMatch := b.areNodeConditionsMet(s.FromNodes, ds)
 
 		// If either From/To conditions or FromNodes conditions match, the rule is safe.
 		if (s.FromNodes == nil && fromToMatch) ||

--- a/pkg/rulesextractor/extractor.go
+++ b/pkg/rulesextractor/extractor.go
@@ -34,20 +34,28 @@ type Unsupported struct {
 	Reason *string `yaml:"reason,omitempty"`
 }
 
+type FromNode struct {
+	Path  *string `yaml:"path"`
+	Value *any    `yaml:"value"`
+}
+
 type Safe struct {
-	From *any `yaml:"from,omitempty"`
-	To   *any `yaml:"to,omitempty"`
+	From      *any        `yaml:"from,omitempty"`
+	To        *any        `yaml:"to,omitempty"`
+	FromNodes *[]FromNode `yaml:"fromNodes,omitempty"`
 }
 
 type Reducer struct {
-	Key       string `yaml:"key"`
-	Lifecycle string `yaml:"lifecycle"`
-	From      any    `yaml:"from"`
-	To        any    `yaml:"to"`
+	Key       string      `yaml:"key"`
+	Lifecycle string      `yaml:"lifecycle"`
+	From      any         `yaml:"from"`
+	To        any         `yaml:"to"`
+	FromNodes *[]FromNode `yaml:"fromNodes,omitempty"`
 }
 
 type Extractor interface {
-	GetImmutables(phase string) []string
+	GetImmutableRules(phase string) []Rule
+	FilterSafeImmutableRules(rules []Rule, ds diff.Changelog) []Rule
 	GetReducers(phase string) []Rule
 	ReducerRulesByDiffs(reducers []Rule, ds diff.Changelog) []Rule
 	UnsupportedReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule
@@ -92,6 +100,70 @@ func (b *BaseExtractor) GetImmutables(_ string) []string {
 	}
 
 	return immutables
+}
+
+// GetImmutableRules returns all the rules that are marked as immutable.
+func (b *BaseExtractor) GetImmutableRules(_ string) []Rule {
+	var immutableRules []Rule
+
+	if b.Spec.Infrastructure != nil {
+		for _, rule := range *b.Spec.Infrastructure {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+	}
+
+	if b.Spec.Kubernetes != nil {
+		for _, rule := range *b.Spec.Kubernetes {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+	}
+
+	if b.Spec.Distribution != nil {
+		for _, rule := range *b.Spec.Distribution {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+	}
+
+	return immutableRules
+}
+
+func (b *BaseExtractor) FilterSafeImmutableRules(rules []Rule, ds diff.Changelog) []Rule {
+	filteredRules := make([]Rule, 0)
+
+	for _, rule := range rules {
+		// Create an empty reducer to use with the isReducerSafe function.
+		dummyReducer := Reducer{}
+
+		// Find the diff that matches this rule's path.
+		for _, d := range ds {
+			joinedPath := "." + strings.Join(d.Path, ".")
+			changePath := numbersToWildcardRegex.ReplaceAllString(joinedPath, ".*")
+
+			if changePath == rule.Path {
+				dummyReducer.From = d.From
+				dummyReducer.To = d.To
+
+				break
+			}
+		}
+
+		// If the rule has safe conditions and they match, skip this rule.
+		if rule.Safe != nil && len(*rule.Safe) > 0 {
+			if b.isReducerSafe(dummyReducer, *rule.Safe, ds) {
+				continue
+			}
+		}
+
+		filteredRules = append(filteredRules, rule)
+	}
+
+	return filteredRules
 }
 
 func (b *BaseExtractor) GetReducers(_ string) []Rule {
@@ -173,7 +245,7 @@ func (b *BaseExtractor) UnsafeReducerRulesByDiffs(rules []Rule, ds diff.Changelo
 
 	for _, rule := range b.ReducerRulesByDiffs(rules, ds) {
 		if rule.Safe != nil && len(*rule.Safe) > 0 {
-			if b.areReducersSafe(rule.Reducers, rule.Safe) {
+			if b.areReducersSafe(rule.Reducers, rule.Safe, ds) {
 				continue
 			}
 		}
@@ -184,13 +256,13 @@ func (b *BaseExtractor) UnsafeReducerRulesByDiffs(rules []Rule, ds diff.Changelo
 	return filteredRules
 }
 
-func (b *BaseExtractor) areReducersSafe(reducers *[]Reducer, safe *[]Safe) bool {
+func (b *BaseExtractor) areReducersSafe(reducers *[]Reducer, safe *[]Safe, ds diff.Changelog) bool {
 	if safe == nil {
 		return false
 	}
 
 	for _, r := range *reducers {
-		if !b.isReducerSafe(r, *safe) {
+		if !b.isReducerSafe(r, *safe, ds) {
 			return false
 		}
 	}
@@ -198,9 +270,52 @@ func (b *BaseExtractor) areReducersSafe(reducers *[]Reducer, safe *[]Safe) bool 
 	return true
 }
 
-func (*BaseExtractor) isReducerSafe(reducer Reducer, safe []Safe) bool {
+func (*BaseExtractor) isReducerSafe(reducer Reducer, safe []Safe, ds diff.Changelog) bool {
 	for _, s := range safe {
-		if (s.From == nil || reducer.From == *s.From) && (s.To == nil || reducer.To == *s.To) {
+		// Check From/To conditions.
+		fromToMatch := (s.From == nil || reducer.From == *s.From) && (s.To == nil || reducer.To == *s.To)
+
+		// Check FromNodes conditions if present.
+		fromNodesMatch := false
+
+		if s.FromNodes != nil && len(*s.FromNodes) > 0 {
+			allNodesMatch := true
+
+			for _, node := range *s.FromNodes {
+				if node.Path == nil {
+					continue
+				}
+
+				// Check if the path exists in the diffs and has the expected value.
+				nodeMatches := false
+
+				for _, d := range ds {
+					joinedPath := "." + strings.Join(d.Path, ".")
+					if joinedPath == *node.Path &&
+						((node.Value == nil && d.From == "none") ||
+							(node.Value != nil && d.From == *node.Value)) {
+						nodeMatches = true
+						break
+					}
+				}
+
+				if !nodeMatches {
+					allNodesMatch = false
+
+					break
+				}
+			}
+
+			fromNodesMatch = allNodesMatch
+		} else {
+			// If no FromNodes conditions, consider it a match.
+			fromNodesMatch = true
+		}
+
+		// If either From/To conditions or FromNodes conditions match, the rule is safe.
+		if (s.FromNodes == nil && fromToMatch) ||
+			(s.From == nil && s.To == nil && fromNodesMatch) ||
+			(fromToMatch && fromNodesMatch) {
 			return true
 		}
 	}

--- a/pkg/rulesextractor/extractor.go
+++ b/pkg/rulesextractor/extractor.go
@@ -35,10 +35,9 @@ type Unsupported struct {
 }
 
 type FromNode struct {
-	Path  *string `yaml:"path"`
-	From  *string `yaml:"from"`
-	To    *string `yaml:"to"`
-	Value *any    `yaml:"value"` // For backward compatibility
+	Path *string `yaml:"path"`
+	From *string `yaml:"from"`
+	To   *string `yaml:"to"`
 }
 
 type Safe struct {
@@ -196,7 +195,7 @@ func (b *BaseExtractor) areNodeConditionsMet(fromNodes *[]FromNode, ds diff.Chan
 		return true // No conditions means they're met by default.
 	}
 
-	// We need at least one node to match
+	// We need at least one node to match.
 	anyNodeMatches := false
 
 	for _, node := range *fromNodes {
@@ -210,16 +209,9 @@ func (b *BaseExtractor) areNodeConditionsMet(fromNodes *[]FromNode, ds diff.Chan
 		for _, d := range ds {
 			joinedPath := "." + strings.Join(d.Path, ".")
 			if joinedPath == *node.Path {
-				// Check if the node matches based on From/To or Value
-				if node.Value != nil {
-					// If Value is specified, check if it matches the From value in the diff
-					nodeMatches = (d.From == *node.Value) ||
-						(*node.Value == "none" && d.From == nil)
-				} else {
-					// Otherwise use the From/To fields
-					nodeMatches = b.checkConditionFrom(node.From, d.From) &&
-						b.checkConditionTo(node.To, d.To)
-				}
+				// Check if the node matches based on From/To or Value.
+				nodeMatches = b.checkConditionFrom(node.From, d.From) &&
+					b.checkConditionTo(node.To, d.To)
 
 				if nodeMatches {
 					break
@@ -229,24 +221,27 @@ func (b *BaseExtractor) areNodeConditionsMet(fromNodes *[]FromNode, ds diff.Chan
 
 		if nodeMatches {
 			anyNodeMatches = true
-			break // We found a matching node, no need to check others
+
+			break // We found a matching node, no need to check others.
 		}
 	}
 
 	return anyNodeMatches
 }
 
-func (*BaseExtractor) checkConditionFrom(nodeFrom *string, diffFrom interface{}) bool {
+func (*BaseExtractor) checkConditionFrom(nodeFrom *string, diffFrom any) bool {
 	if nodeFrom == nil || *nodeFrom == "" {
 		return true
 	}
+
 	return (*nodeFrom == "none" && diffFrom == nil) || (diffFrom != nil && diffFrom == *nodeFrom)
 }
 
-func (*BaseExtractor) checkConditionTo(nodeTo *string, diffTo interface{}) bool {
+func (*BaseExtractor) checkConditionTo(nodeTo *string, diffTo any) bool {
 	if nodeTo == nil || *nodeTo == "" {
 		return true
 	}
+
 	return (*nodeTo == "none" && diffTo == nil) || (diffTo != nil && diffTo == *nodeTo)
 }
 

--- a/pkg/rulesextractor/extractor_test.go
+++ b/pkg/rulesextractor/extractor_test.go
@@ -978,9 +978,8 @@ func TestBaseExtractor_UnsafeReducerRulesByDiffs(t *testing.T) {
 						{
 							FromNodes: &[]rules.FromNode{
 								{
-									Path:  stringPtr(".spec.distribution.modules.logging.type"),
-									From:  stringPtr("none"),
-									Value: anyPtr(none),
+									Path: stringPtr(".spec.distribution.modules.logging.type"),
+									From: stringPtr("none"),
 								},
 							},
 						},
@@ -1018,9 +1017,8 @@ func TestBaseExtractor_UnsafeReducerRulesByDiffs(t *testing.T) {
 						{
 							FromNodes: &[]rules.FromNode{
 								{
-									Path:  stringPtr(".spec.distribution.modules.logging.type"),
-									From:  stringPtr("none"),
-									Value: anyPtr(none),
+									Path: stringPtr(".spec.distribution.modules.logging.type"),
+									From: stringPtr("none"),
 								},
 							},
 						},
@@ -1055,9 +1053,8 @@ func TestBaseExtractor_UnsafeReducerRulesByDiffs(t *testing.T) {
 						{
 							FromNodes: &[]rules.FromNode{
 								{
-									Path:  stringPtr(".spec.distribution.modules.logging.type"),
-									From:  stringPtr("none"),
-									Value: anyPtr(none),
+									Path: stringPtr(".spec.distribution.modules.logging.type"),
+									From: stringPtr("none"),
 								},
 							},
 						},
@@ -1375,9 +1372,8 @@ func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
 						{
 							FromNodes: &[]rules.FromNode{
 								{
-									Path:  stringPtr(".spec.distribution.modules.logging.type"),
-									From:  stringPtr("none"),
-									Value: anyPtr(none),
+									Path: stringPtr(".spec.distribution.modules.logging.type"),
+									From: stringPtr("none"),
 								},
 							},
 						},
@@ -1410,9 +1406,8 @@ func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
 						{
 							FromNodes: &[]rules.FromNode{
 								{
-									Path:  stringPtr(".spec.distribution.modules.logging.type"),
-									From:  stringPtr("none"),
-									Value: anyPtr(none),
+									Path: stringPtr(".spec.distribution.modules.logging.type"),
+									From: stringPtr("none"),
 								},
 							},
 						},
@@ -1441,9 +1436,8 @@ func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
 						{
 							FromNodes: &[]rules.FromNode{
 								{
-									Path:  stringPtr(".spec.distribution.modules.logging.type"),
-									From:  stringPtr("none"),
-									Value: anyPtr(none),
+									Path: stringPtr(".spec.distribution.modules.logging.type"),
+									From: stringPtr("none"),
 								},
 							},
 						},
@@ -1463,9 +1457,8 @@ func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
 							To:   anyPtr(tsdbDate),
 							FromNodes: &[]rules.FromNode{
 								{
-									Path:  stringPtr(".spec.distribution.modules.logging.type"),
-									From:  stringPtr("none"),
-									Value: anyPtr(none),
+									Path: stringPtr(".spec.distribution.modules.logging.type"),
+									From: stringPtr("none"),
 								},
 							},
 						},

--- a/pkg/rulesextractor/extractor_test.go
+++ b/pkg/rulesextractor/extractor_test.go
@@ -684,10 +684,6 @@ func TestBaseExtractor_UnsafeReducerRulesByDiffs(t *testing.T) {
 		return &s
 	}
 
-	anyPtr := func(a any) *any {
-		return &a
-	}
-
 	testCases := []struct {
 		name  string
 		rules []rules.Rule
@@ -983,6 +979,7 @@ func TestBaseExtractor_UnsafeReducerRulesByDiffs(t *testing.T) {
 							FromNodes: &[]rules.FromNode{
 								{
 									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									From:  stringPtr("none"),
 									Value: anyPtr(none),
 								},
 							},
@@ -1022,6 +1019,7 @@ func TestBaseExtractor_UnsafeReducerRulesByDiffs(t *testing.T) {
 							FromNodes: &[]rules.FromNode{
 								{
 									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									From:  stringPtr("none"),
 									Value: anyPtr(none),
 								},
 							},
@@ -1058,6 +1056,7 @@ func TestBaseExtractor_UnsafeReducerRulesByDiffs(t *testing.T) {
 							FromNodes: &[]rules.FromNode{
 								{
 									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									From:  stringPtr("none"),
 									Value: anyPtr(none),
 								},
 							},
@@ -1377,6 +1376,7 @@ func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
 							FromNodes: &[]rules.FromNode{
 								{
 									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									From:  stringPtr("none"),
 									Value: anyPtr(none),
 								},
 							},
@@ -1411,6 +1411,7 @@ func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
 							FromNodes: &[]rules.FromNode{
 								{
 									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									From:  stringPtr("none"),
 									Value: anyPtr(none),
 								},
 							},
@@ -1441,6 +1442,7 @@ func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
 							FromNodes: &[]rules.FromNode{
 								{
 									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									From:  stringPtr("none"),
 									Value: anyPtr(none),
 								},
 							},
@@ -1462,6 +1464,7 @@ func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
 							FromNodes: &[]rules.FromNode{
 								{
 									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									From:  stringPtr("none"),
 									Value: anyPtr(none),
 								},
 							},

--- a/pkg/rulesextractor/extractor_test.go
+++ b/pkg/rulesextractor/extractor_test.go
@@ -1160,3 +1160,342 @@ func TestBaseExtractor_ExtractReducerRules(t *testing.T) {
 		})
 	}
 }
+
+func TestBaseExtractor_FilterSafeImmutableRules(t *testing.T) {
+	t.Parallel()
+
+	var foo, bar, none, loki, tsdbDate any
+
+	foo = "foo"
+	bar = "bar"
+	none = "none"
+	loki = "loki"
+	tsdbDate = "2023-01-01"
+
+	stringPtr := func(s string) *string {
+		return &s
+	}
+
+	anyPtr := func(a any) *any {
+		return &a
+	}
+
+	testCases := []struct {
+		name  string
+		rules []rules.Rule
+		diffs diff.Changelog
+		want  []rules.Rule
+	}{
+		{
+			name:  "should return empty slice if no rules",
+			rules: []rules.Rule{},
+			diffs: diff.Changelog{
+				{
+					Type: diff.CREATE,
+					Path: []string{"foo"},
+				},
+			},
+			want: []rules.Rule{},
+		},
+		{
+			name: "should handle nil diffs",
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &bar,
+						},
+					},
+				},
+			},
+			diffs: nil,
+			want: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &bar,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle nil safe",
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe:      nil,
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Type: diff.CREATE,
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe:      nil,
+				},
+			},
+		},
+		{
+			name: "should handle empty safe",
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe:      &[]rules.Safe{},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Type: diff.CREATE,
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe:      &[]rules.Safe{},
+				},
+			},
+		},
+		{
+			name: "should filter out rules with matching from/to conditions",
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &bar,
+						},
+					},
+				},
+				{
+					Path:      ".bar",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &bar,
+							To:   &foo,
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Type: diff.CREATE,
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+				{
+					Type: diff.CREATE,
+					Path: []string{"bar"},
+					From: "bar",
+					To:   "foo",
+				},
+			},
+			want: []rules.Rule{}, // Both rules are filtered out because they match their safe conditions
+		},
+		{
+			name: "should keep rules without matching from/to conditions",
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &bar,
+						},
+					},
+				},
+				{
+					Path:      ".bar",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &bar,
+							To:   &bar, // Doesn't match the diff
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Type: diff.CREATE,
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+				{
+					Type: diff.CREATE,
+					Path: []string{"bar"},
+					From: "bar",
+					To:   "foo",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      ".bar",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &bar,
+							To:   &bar,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should filter out rules with matching FromNodes conditions",
+			rules: []rules.Rule{
+				{
+					Path:      ".spec.distribution.modules.logging.loki.tsdbStartDate",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							FromNodes: &[]rules.FromNode{
+								{
+									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									Value: anyPtr(none),
+								},
+							},
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Type: diff.UPDATE,
+					Path: []string{"spec", "distribution", "modules", "logging", "type"},
+					From: none,
+					To:   loki,
+				},
+				{
+					Type: diff.UPDATE,
+					Path: []string{"spec", "distribution", "modules", "logging", "loki", "tsdbStartDate"},
+					From: nil,
+					To:   tsdbDate,
+				},
+			},
+			want: []rules.Rule{}, // Rule is filtered out because FromNodes condition matches
+		},
+		{
+			name: "should keep rules without matching FromNodes conditions",
+			rules: []rules.Rule{
+				{
+					Path:      ".spec.distribution.modules.logging.loki.tsdbStartDate",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							FromNodes: &[]rules.FromNode{
+								{
+									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									Value: anyPtr(none),
+								},
+							},
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Type: diff.UPDATE,
+					Path: []string{"spec", "distribution", "modules", "logging", "type"},
+					From: loki, // Not "none", so the condition doesn't match
+					To:   loki,
+				},
+				{
+					Type: diff.UPDATE,
+					Path: []string{"spec", "distribution", "modules", "logging", "loki", "tsdbStartDate"},
+					From: nil,
+					To:   tsdbDate,
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      ".spec.distribution.modules.logging.loki.tsdbStartDate",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							FromNodes: &[]rules.FromNode{
+								{
+									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									Value: anyPtr(none),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should filter out rules with matching combined conditions",
+			rules: []rules.Rule{
+				{
+					Path:      ".spec.distribution.modules.logging.loki.tsdbStartDate",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: anyPtr(nil),
+							To:   anyPtr(tsdbDate),
+							FromNodes: &[]rules.FromNode{
+								{
+									Path:  stringPtr(".spec.distribution.modules.logging.type"),
+									Value: anyPtr(none),
+								},
+							},
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Type: diff.UPDATE,
+					Path: []string{"spec", "distribution", "modules", "logging", "type"},
+					From: none,
+					To:   loki,
+				},
+				{
+					Type: diff.UPDATE,
+					Path: []string{"spec", "distribution", "modules", "logging", "loki", "tsdbStartDate"},
+					From: nil,
+					To:   tsdbDate,
+				},
+			},
+			want: []rules.Rule{}, // Rule is filtered out because both From/To and FromNodes conditions match
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			x := rules.NewBaseExtractor(rules.Spec{})
+
+			got := x.FilterSafeImmutableRules(tc.rules, tc.diffs)
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/rulesextractor/kfddistribution.go
+++ b/pkg/rulesextractor/kfddistribution.go
@@ -37,17 +37,25 @@ func NewDistroClusterRulesExtractor(distributionPath string) (*DistroExtractor, 
 	return &builder, nil
 }
 
-func (r *DistroExtractor) GetImmutables(phase string) []string {
+func (r *DistroExtractor) GetImmutableRules(phase string) []Rule {
 	switch phase {
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
-			return []string{}
+			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractImmutablesFromRules(*r.Spec.Distribution)
+		var immutableRules []Rule
+
+		for _, rule := range *r.Spec.Distribution {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+
+		return immutableRules
 
 	default:
-		return []string{}
+		return []Rule{}
 	}
 }
 
@@ -75,4 +83,8 @@ func (r *DistroExtractor) UnsupportedReducerRulesByDiffs(rls []Rule, ds diff.Cha
 
 func (r *DistroExtractor) UnsafeReducerRulesByDiffs(rls []Rule, ds diff.Changelog) []Rule {
 	return r.BaseExtractor.UnsafeReducerRulesByDiffs(rls, ds)
+}
+
+func (r *DistroExtractor) FilterSafeImmutableRules(rules []Rule, ds diff.Changelog) []Rule {
+	return r.BaseExtractor.FilterSafeImmutableRules(rules, ds)
 }

--- a/pkg/rulesextractor/kfddistribution_test.go
+++ b/pkg/rulesextractor/kfddistribution_test.go
@@ -10,24 +10,26 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/r3labs/diff/v3"
+
 	rules "github.com/sighupio/furyctl/pkg/rulesextractor"
 	rules_extractor "github.com/sighupio/furyctl/pkg/rulesextractor"
 )
 
-func TestKFDBuilder_GetImmutables(t *testing.T) {
+func TestKFDBuilder_GetImmutableRules(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		desc  string
 		Spec  *rules.Spec
 		phase string
-		want  []string
+		want  []rules.Rule
 	}{
 		{
 			desc:  "distribution - empty",
 			Spec:  &rules.Spec{},
 			phase: "distribution",
-			want:  []string{},
+			want:  []rules.Rule{},
 		},
 		{
 			desc: "distribution - not empty",
@@ -44,7 +46,12 @@ func TestKFDBuilder_GetImmutables(t *testing.T) {
 				},
 			},
 			phase: "distribution",
-			want:  []string{"foo"},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
 		},
 	}
 
@@ -58,10 +65,135 @@ func TestKFDBuilder_GetImmutables(t *testing.T) {
 				Spec: *tC.Spec,
 			}
 
-			got := builder.GetImmutables(tC.phase)
+			got := builder.GetImmutableRules(tC.phase)
 
 			if !reflect.DeepEqual(got, tC.want) {
-				t.Errorf("expected immutables to be %v, got: %v", tC.want, got)
+				t.Errorf("expected immutable rules to be %v, got: %v", tC.want, got)
+			}
+		})
+	}
+}
+
+func TestKFDBuilder_FilterSafeImmutableRules(t *testing.T) {
+	t.Parallel()
+
+	var foo, bar any
+
+	foo = "foo"
+	bar = "bar"
+
+	testCases := []struct {
+		desc  string
+		Spec  *rules.Spec
+		rules []rules.Rule
+		diffs diff.Changelog
+		want  []rules.Rule
+	}{
+		{
+			desc:  "empty rules",
+			Spec:  &rules.Spec{},
+			rules: []rules.Rule{},
+			diffs: diff.Changelog{},
+			want:  []rules.Rule{},
+		},
+		{
+			desc: "no safe conditions",
+			Spec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
+		},
+		{
+			desc: "matching safe conditions",
+			Spec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &bar,
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{},
+		},
+		{
+			desc: "non-matching safe conditions",
+			Spec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &foo, // Doesn't match the diff
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &foo,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tC := range testCases {
+		tC := tC
+
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			builder := rules_extractor.DistroExtractor{
+				Spec: *tC.Spec,
+			}
+
+			got := builder.FilterSafeImmutableRules(tC.rules, tC.diffs)
+
+			if !reflect.DeepEqual(got, tC.want) {
+				t.Errorf("expected filtered rules to be %v, got: %v", tC.want, got)
 			}
 		})
 	}

--- a/pkg/rulesextractor/onpremises.go
+++ b/pkg/rulesextractor/onpremises.go
@@ -36,6 +36,21 @@ func NewOnPremClusterRulesExtractor(distributionPath string) (*OnPremExtractor, 
 
 func (r *OnPremExtractor) GetImmutableRules(phase string) []Rule {
 	switch phase {
+	case cluster.OperationPhaseKubernetes:
+		if r.Spec.Kubernetes == nil {
+			return []Rule{}
+		}
+
+		var immutableRules []Rule
+
+		for _, rule := range *r.Spec.Kubernetes {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+
+		return immutableRules
+
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
 			return []Rule{}

--- a/pkg/rulesextractor/onpremises.go
+++ b/pkg/rulesextractor/onpremises.go
@@ -34,24 +34,25 @@ func NewOnPremClusterRulesExtractor(distributionPath string) (*OnPremExtractor, 
 	return &builder, nil
 }
 
-func (r *OnPremExtractor) GetImmutables(phase string) []string {
+func (r *OnPremExtractor) GetImmutableRules(phase string) []Rule {
 	switch phase {
-	case cluster.OperationPhaseKubernetes:
-		if r.Spec.Kubernetes == nil {
-			return []string{}
-		}
-
-		return r.BaseExtractor.ExtractImmutablesFromRules(*r.Spec.Kubernetes)
-
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
-			return []string{}
+			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractImmutablesFromRules(*r.Spec.Distribution)
+		var immutableRules []Rule
+
+		for _, rule := range *r.Spec.Distribution {
+			if rule.Immutable {
+				immutableRules = append(immutableRules, rule)
+			}
+		}
+
+		return immutableRules
 
 	default:
-		return []string{}
+		return []Rule{}
 	}
 }
 
@@ -86,4 +87,8 @@ func (r *OnPremExtractor) UnsupportedReducerRulesByDiffs(rls []Rule, ds diff.Cha
 
 func (r *OnPremExtractor) UnsafeReducerRulesByDiffs(rls []Rule, ds diff.Changelog) []Rule {
 	return r.BaseExtractor.UnsafeReducerRulesByDiffs(rls, ds)
+}
+
+func (r *OnPremExtractor) FilterSafeImmutableRules(rules []Rule, ds diff.Changelog) []Rule {
+	return r.BaseExtractor.FilterSafeImmutableRules(rules, ds)
 }

--- a/pkg/rulesextractor/onpremises_test.go
+++ b/pkg/rulesextractor/onpremises_test.go
@@ -10,30 +10,32 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/r3labs/diff/v3"
+
 	onpremrules "github.com/sighupio/furyctl/pkg/rulesextractor"
 	rules "github.com/sighupio/furyctl/pkg/rulesextractor"
 )
 
-func TestOnPremisesBuilder_GetImmutables(t *testing.T) {
+func TestOnPremisesBuilder_GetImmutableRules(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		desc            string
 		onPremRulesSpec *rules.Spec
 		phase           string
-		want            []string
+		want            []rules.Rule
 	}{
 		{
 			desc:            "kubernetes - empty",
 			onPremRulesSpec: &rules.Spec{},
 			phase:           "kubernetes",
-			want:            []string{},
+			want:            []rules.Rule{},
 		},
 		{
 			desc:            "distribution - empty",
 			onPremRulesSpec: &rules.Spec{},
 			phase:           "distribution",
-			want:            []string{},
+			want:            []rules.Rule{},
 		},
 		{
 			desc: "kubernetes - not empty",
@@ -50,7 +52,12 @@ func TestOnPremisesBuilder_GetImmutables(t *testing.T) {
 				},
 			},
 			phase: "kubernetes",
-			want:  []string{"foo"},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
 		},
 		{
 			desc: "distribution - not empty",
@@ -67,7 +74,12 @@ func TestOnPremisesBuilder_GetImmutables(t *testing.T) {
 				},
 			},
 			phase: "distribution",
-			want:  []string{"foo"},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
 		},
 	}
 
@@ -81,10 +93,135 @@ func TestOnPremisesBuilder_GetImmutables(t *testing.T) {
 				Spec: *tC.onPremRulesSpec,
 			}
 
-			got := builder.GetImmutables(tC.phase)
+			got := builder.GetImmutableRules(tC.phase)
 
 			if !reflect.DeepEqual(got, tC.want) {
-				t.Errorf("expected immutables to be %v, got: %v", tC.want, got)
+				t.Errorf("expected immutable rules to be %v, got: %v", tC.want, got)
+			}
+		})
+	}
+}
+
+func TestOnPremisesBuilder_FilterSafeImmutableRules(t *testing.T) {
+	t.Parallel()
+
+	var foo, bar any
+
+	foo = "foo"
+	bar = "bar"
+
+	testCases := []struct {
+		desc            string
+		onPremRulesSpec *rules.Spec
+		rules           []rules.Rule
+		diffs           diff.Changelog
+		want            []rules.Rule
+	}{
+		{
+			desc:            "empty rules",
+			onPremRulesSpec: &rules.Spec{},
+			rules:           []rules.Rule{},
+			diffs:           diff.Changelog{},
+			want:            []rules.Rule{},
+		},
+		{
+			desc:            "no safe conditions",
+			onPremRulesSpec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      "foo",
+					Immutable: true,
+				},
+			},
+		},
+		{
+			desc:            "matching safe conditions",
+			onPremRulesSpec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &bar,
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{},
+		},
+		{
+			desc:            "non-matching safe conditions",
+			onPremRulesSpec: &rules.Spec{},
+			rules: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &foo, // Doesn't match the diff
+						},
+					},
+				},
+			},
+			diffs: diff.Changelog{
+				{
+					Path: []string{"foo"},
+					From: "foo",
+					To:   "bar",
+				},
+			},
+			want: []rules.Rule{
+				{
+					Path:      ".foo",
+					Immutable: true,
+					Safe: &[]rules.Safe{
+						{
+							From: &foo,
+							To:   &foo,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tC := range testCases {
+		tC := tC
+
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			builder := onpremrules.OnPremExtractor{
+				Spec: *tC.onPremRulesSpec,
+			}
+
+			got := builder.FilterSafeImmutableRules(tC.rules, tC.diffs)
+
+			if !reflect.DeepEqual(got, tC.want) {
+				t.Errorf("expected filtered rules to be %v, got: %v", tC.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
### Summary 💡

This PR enhances the rules extractor functionality by adding a new `FromNode` feature that allows for more context-aware immutability checks. 
This improvement enables the system to determine if a field should be considered immutable based on the state of other fields in the configuration.

The implementation has been refactored to work both with and without reducers.

Closes: [#398](https://github.com/sighupio/distribution/issues/398)

### Description 📝

The PR introduces some modifications to the rules extractor system:

1. Added a new `FromNode` struct that allows for referencing other nodes in the configuration when determining if a rule is safe to modify. for example:
```yaml
  - path: .spec.distribution.modules.logging.loki.tsdbStartDate
    immutable: true
    description: "changes to Loki's TSDB start date have been detected. This parameter cannot be changed once set."  
    safe:
      - fromNodes:
        - path: ".spec.distribution.modules.logging.type"
          from: none
        - path: ".spec.distribution.modules.logging.type"
          to: none
```

2. Enhanced the `Safe` and `Reducer` structs to include the new `FromNodes` field, enabling more sophisticated safety checks.

3. Refactored the immutability checking logic across all cluster types (EKS, KFD Distribution, and On-premises):
   - Changed `GetImmutables` to return `[]Rule` instead of `[]string` with the new method `GetImmutableRules`
   - Added a new method `FilterSafeImmutableRules` to filter out rules that have matching safe conditions
   - Updated the preflight checks to use these new methods

4. Enhanced the safety checking with dedicated methods:
   - Added `areNodeConditionsMet` to extract the node condition checking logic
   - Added `isImmutableRuleSafe` to directly check if an immutable rule is safe
   - Updated `isReducerSafe` to use the new `areNodeConditionsMet` method

5. Added comprehensive tests for the new functionality, particularly for the FromNodes condition handling.

This implementation allows for more nuanced rules, such as "this field is immutable unless another field has a specific value." 

For example, we can now define rules where a field like `tsdbStartDate` can be modified only when the logging type was previously set to "none".

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Added unit tests for the new FromNode functionality
- [x] Tested with a kind cluster 
   - migrating from `logging.type: none` to `logging.type: loki` -> does not get blocked
   - migrating from `logging.type: loki` to `logging.type: opensearch` -> does not get blocked
   - migrating from `logging.type: loki` to `logging.type: none` -> does not get blocked
   - migrating from `logging.type: loki` to `logging.type: opensearch` -> gets blocked
   - regression test: migrating from ingress single to ingress dual -> still gets blocked

### Future work 🔧

N/A