### PR TITLE
fix: fromnodes should check nodes even if they did not change

### DIFF
--- a/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
@@ -305,7 +305,7 @@ func (p *PreFlight) CreateDiffChecker(
 func (p *PreFlight) CheckImmutablesDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
 	var errs []error
 
-	r, err := rules.NewEKSClusterRulesExtractor(p.paths.DistroPath)
+	r, err := rules.NewEKSClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
 			return fmt.Errorf("error while creating rules builder: %w", err)
@@ -359,7 +359,7 @@ func (p *PreFlight) CheckImmutablesDiffs(d r3diff.Changelog, diffChecker diffs.C
 func (p *PreFlight) CheckReducersDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
 	var errs []error
 
-	r, err := rules.NewEKSClusterRulesExtractor(p.paths.DistroPath)
+	r, err := rules.NewEKSClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
 			return fmt.Errorf("error while creating rules builder: %w", err)

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -336,7 +336,7 @@ func (v *ClusterCreator) CreateAsync(
 		return
 	}
 
-	r, err := eksrules.NewEKSClusterRulesExtractor(v.paths.DistroPath)
+	r, err := eksrules.NewEKSClusterRulesExtractor(v.paths.DistroPath, renderedConfig)
 	if err != nil {
 		if !errors.Is(err, eksrules.ErrReadingRulesFile) {
 			errCh <- fmt.Errorf("error while creating rules builder: %w", err)

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
@@ -224,7 +224,7 @@ func (p *PreFlight) CreateDiffChecker(storedCfgStr []byte, renderedConfig map[st
 func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
 	var errs []error
 
-	r, err := rules.NewDistroClusterRulesExtractor(p.distroPath)
+	r, err := rules.NewDistroClusterRulesExtractor(p.distroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
 			return fmt.Errorf("error while creating rules builder: %w", err)
@@ -260,7 +260,7 @@ func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checke
 func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
 	var errs []error
 
-	r, err := rules.NewDistroClusterRulesExtractor(p.distroPath)
+	r, err := rules.NewDistroClusterRulesExtractor(p.distroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
 			return fmt.Errorf("error while creating rules builder: %w", err)

--- a/internal/apis/kfd/v1alpha2/kfddistribution/creator.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/creator.go
@@ -195,7 +195,7 @@ func (c *ClusterCreator) Create(startFrom string, _, _ int) error {
 		return fmt.Errorf("error while executing preflight phase: %w", err)
 	}
 
-	r, err := distrorules.NewDistroClusterRulesExtractor(c.paths.DistroPath)
+	r, err := distrorules.NewDistroClusterRulesExtractor(c.paths.DistroPath, renderedConfig)
 	if err != nil {
 		if !errors.Is(err, distrorules.ErrReadingRulesFile) {
 			return fmt.Errorf("error while creating rules builder: %w", err)

--- a/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
@@ -250,7 +250,7 @@ func (p *PreFlight) CreateDiffChecker(renderedConfig map[string]any) (diffs.Chec
 func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
 	var errs []error
 
-	r, err := rules.NewOnPremClusterRulesExtractor(p.paths.DistroPath)
+	r, err := rules.NewOnPremClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
 			return fmt.Errorf("error while creating rules builder: %w", err)
@@ -294,7 +294,7 @@ func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checke
 func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
 	var errs []error
 
-	r, err := rules.NewOnPremClusterRulesExtractor(p.paths.DistroPath)
+	r, err := rules.NewOnPremClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
 			return fmt.Errorf("error while creating rules builder: %w", err)

--- a/internal/apis/kfd/v1alpha2/onpremises/creator.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/creator.go
@@ -228,7 +228,7 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 		return fmt.Errorf("error while executing preflight phase: %w", err)
 	}
 
-	r, err := premrules.NewOnPremClusterRulesExtractor(c.paths.DistroPath)
+	r, err := premrules.NewOnPremClusterRulesExtractor(c.paths.DistroPath, renderedConfig)
 	if err != nil {
 		if !errors.Is(err, premrules.ErrReadingRulesFile) {
 			return fmt.Errorf("error while creating rules builder: %w", err)

--- a/pkg/diffs/checker.go
+++ b/pkg/diffs/checker.go
@@ -27,6 +27,8 @@ type Checker interface {
 	GenerateDiff() (r3diff.Changelog, error)
 	DiffToString(diffs r3diff.Changelog) string
 	FilterDiffFromPhase(changelog r3diff.Changelog, phasePath string) r3diff.Changelog
+	GetCurrentConfig() map[string]any
+	GetNewConfig() map[string]any
 }
 
 type BaseChecker struct {
@@ -39,6 +41,14 @@ func NewBaseChecker(currentConfig, newConfig map[string]any) *BaseChecker {
 		CurrentConfig: currentConfig,
 		NewConfig:     newConfig,
 	}
+}
+
+func (v *BaseChecker) GetCurrentConfig() map[string]any {
+	return v.CurrentConfig
+}
+
+func (v *BaseChecker) GetNewConfig() map[string]any {
+	return v.NewConfig
 }
 
 func (v *BaseChecker) GenerateDiff() (r3diff.Changelog, error) {

--- a/pkg/rulesextractor/ekscluster.go
+++ b/pkg/rulesextractor/ekscluster.go
@@ -19,7 +19,7 @@ type EKSExtractor struct {
 	Spec Spec
 }
 
-func NewEKSClusterRulesExtractor(distributionPath string) (*EKSExtractor, error) {
+func NewEKSClusterRulesExtractor(distributionPath string, renderedConfig map[string]any) (*EKSExtractor, error) {
 	builder := EKSExtractor{}
 
 	rulesPath := filepath.Join(distributionPath, "rules", "ekscluster-kfd-v1alpha2.yaml")
@@ -31,6 +31,7 @@ func NewEKSClusterRulesExtractor(distributionPath string) (*EKSExtractor, error)
 
 	builder.Spec = spec
 	builder.BaseExtractor = NewBaseExtractor(spec)
+	builder.BaseExtractor.RenderedConfig = renderedConfig
 
 	return &builder, nil
 }

--- a/pkg/rulesextractor/kfddistribution.go
+++ b/pkg/rulesextractor/kfddistribution.go
@@ -22,8 +22,12 @@ type DistroExtractor struct {
 	Spec Spec
 }
 
-func NewDistroClusterRulesExtractor(distributionPath string) (*DistroExtractor, error) {
-	builder := DistroExtractor{}
+func NewDistroClusterRulesExtractor(distributionPath string, renderedConfig map[string]any) (*DistroExtractor, error) {
+	builder := DistroExtractor{
+		BaseExtractor: &BaseExtractor{
+			RenderedConfig: renderedConfig,
+		},
+	}
 
 	rulesPath := filepath.Join(distributionPath, "rules", "kfddistribution-kfd-v1alpha2.yaml")
 

--- a/pkg/rulesextractor/onpremises.go
+++ b/pkg/rulesextractor/onpremises.go
@@ -19,8 +19,12 @@ type OnPremExtractor struct {
 	Spec Spec
 }
 
-func NewOnPremClusterRulesExtractor(distributionPath string) (*OnPremExtractor, error) {
-	builder := OnPremExtractor{}
+func NewOnPremClusterRulesExtractor(distributionPath string, renderedConfig map[string]any) (*OnPremExtractor, error) {
+	builder := OnPremExtractor{
+		BaseExtractor: &BaseExtractor{
+			RenderedConfig: renderedConfig,
+		},
+	}
 
 	rulesPath := filepath.Join(distributionPath, "rules", "onpremises-kfd-v1alpha2.yaml")
 


### PR DESCRIPTION
### Summary 💡

There was a problem with the `fromNodes` reducer in the immutability rules. If the referenced node did not change, the reducer did not have a way to check the current value.

Closes: https://github.com/sighupio/distribution/issues/398


### Description 📝

With this PR the `fromNodes` reducer can work even if the referenced node did not change.
for example with this rule:
```yaml
- path: .spec.distribution.modules.logging.loki.tsdbStartDate
    immutable: true
    description: "changes to Loki's TSDB start date have been detected. This parameter cannot be changed once set."  
    safe:
      - fromNodes:
        - path: ".spec.distribution.modules.logging.type"
          from: "none"
        - path: ".spec.distribution.modules.logging.type"
          to: "none"
        - path: ".spec.distribution.modules.logging.type"
          from: "opensearch"
        - path: ".spec.distribution.modules.logging.type"
          to: "opensearch"
```
changing this:
```
logging:
        type: none
        loki:
          tsdbStartDate: "2025-01-02"
```
to this:
```
logging:
        type: none
        loki:
          tsdbStartDate: "2025-01-03"
```
should still work

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] in a kfd cluster changing `logging.loki.tsdbStartDate: "2025-01-02"` to `logging.loki.tsdbStartDate: "2025-01-03"` while maintaing `logging.type: "none" in both cases -> does not get blocked
- [x] regression test in a kfd cluster changing `logging.type: none` to `logging.type: loki` -> does not get blocked
- [x] regression test in a kfd cluster changing `logging.type: loki` to `logging.type: none` -> does not get blocked
- [x] regression test in a kfd cluster changing `logging.loki.tsdbStartDate: "2025-01-02"` to `logging.loki.tsdbStartDate: "2025-01-03"` while "logging.type: "loki"` -> gets blocked

### Future work 🔧

None
