### PR TITLE
fix(onpremises,kfddistribution): check for a default SC

### DIFF
--- a/internal/apis/kfd/v1alpha2/onpremises/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/distribution.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -118,7 +119,7 @@ func (d *Distribution) prepare() (template.Config, error) {
 		return template.Config{}, fmt.Errorf("error connecting to cluster: %w", err)
 	}
 
-	logrus.Info("Checking storage classes...")
+	logrus.Info("Checking for a default storage class...")
 
 	getStorageClassesOutput, err := d.kubeRunner.Get(false, "", "storageclasses")
 	if err != nil {
@@ -130,7 +131,19 @@ func (d *Distribution) prepare() (template.Config, error) {
 			"No storage classes found in the cluster. " +
 				"logging module (if enabled), tracing module (if enabled), dr module (if enabled) " +
 				"and prometheus-operated package installation will be skipped. " +
-				"You need to install a StorageClass and re-run furyctl to install the missing components.",
+				"Install a *default* StorageClass and re-run furyctl to install the missing components.",
+		)
+
+		storageClassAvailable = false
+	}
+
+	defaultSC := "(default)"
+	if !strings.Contains(getStorageClassesOutput, defaultSC) && getStorageClassesOutput != "No resources found" {
+		logrus.Warn(
+			"No *default* storage classes found in the cluster. " +
+				"logging module (if enabled), tracing module (if enabled), dr module (if enabled) " +
+				"and prometheus-operated package installation will be skipped. " +
+				"Set a default StorageClass and re-run furyctl to install the missing components.",
 		)
 
 		storageClassAvailable = false


### PR DESCRIPTION
### Summary 💡

Check for the presence of a default storage class and not only that there are storage classes defined.

Closes: https://github.com/sighupio/distribution/issues/416


### Description 📝

Having storage classes defined is not enough, we assume there is at least one default storage class. This PR adds the check for a default SC.

We could drop the check for the presence of a storage class, being that checking for a default one covers also the presence of storage classes, but I left them because we can give better feedback to the user this way.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested deploy on a cluster without SC, got the right error.
- [x] Tested deploy on a cluster with SCs but without a default SC, got the right error.
- [x] Tested deploy on a cluster with SC, got no error.

tested for the on-prem and kfddistribution providers.

### Future work 🔧

We could use the structured output (json, yaml) of the command we parse the output from, but I think it's not worth the effort.