### PR TITLE
fix: goreleaser sort tags by creator date if there are more than one tag in the same commit

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ builds:
       - -X main.goVersion={{.Env.GO_VERSION}}
       - -X main.osArch={{.Arch}}
       - -X main.mixPanelToken={{.Env.MIX_PANEL_TOKEN}}
+git:
+  tag_sort: -version:creatordate
 archives:
   - name_template: "{{ tolower .ProjectName }}-{{ tolower .Os }}-{{ tolower .Arch }}"
 checksum:


### PR DESCRIPTION
### Summary 💡

Currently goreleaser sorts tags in the same commit alphabetically. 
This behaviour breaks in case we have multiple tags for the same commits for normal releases(eg. with v0.32.4-rc.0 and v0.32.4 it picks v0.32.4-rc.0 instead of v0.32.4)

We configured goreleaser to sort the tags by creation date


### Description 📝

see summary

### Breaking Changes 💔

None

### Tests performed 🧪


### Future work 🔧

