### PR TITLE
feat: add hasField and getFieldOrDefault template functions

### DIFF
--- a/pkg/template/funcmap.go
+++ b/pkg/template/funcmap.go
@@ -70,3 +70,132 @@ func HasKeyAny(m map[any]any, key any) bool {
 
 	return true
 }
+
+// HasField checks if a nested field exists in a data structure using dot-notation path.
+// Returns true if the field exists (even if nil/empty), false if any intermediate key is missing.
+//
+// Example:
+//
+//	HasField(data, "spec.kubernetes.apiServer.privateAccess")
+//	HasField(data, "metadata.name")
+//
+// This function never panics and always returns false for malformed paths or type mismatches.
+func HasField(data any, path string) bool {
+	if data == nil || path == "" {
+		return false
+	}
+
+	keys := strings.Split(path, ".")
+	current := data
+
+	for _, key := range keys {
+		if key == "" {
+			return false
+		}
+
+		// Try map[any]any first (most common in templates).
+		if m, ok := current.(map[any]any); ok {
+			val, exists := m[key]
+			if !exists {
+				return false
+			}
+
+			current = val
+
+			continue
+		}
+
+		// Try map[string]any as fallback.
+		if m, ok := current.(map[string]any); ok {
+			val, exists := m[key]
+			if !exists {
+				return false
+			}
+
+			current = val
+
+			continue
+		}
+
+		// Current value is not a map, can't traverse further.
+		return false
+	}
+
+	return true
+}
+
+// GetFieldOrDefault retrieves a nested field value using dot-notation path.
+// Returns the field value if found, otherwise returns the provided default value.
+//
+// Example:
+//
+//	GetFieldOrDefault(data, "spec.kubernetes.version", "1.28")
+//	GetFieldOrDefault(data, "metadata.labels.env", "production")
+//
+// This function never panics. It returns the default value for:
+//   - Missing keys at any level
+//   - Nil values at any level
+//   - Type mismatches during traversal
+//   - Empty or malformed paths
+func GetFieldOrDefault(data any, path string, defaultValue any) any {
+	if data == nil || path == "" {
+		return defaultValue
+	}
+
+	keys := strings.Split(path, ".")
+	current := data
+
+	for i, key := range keys {
+		if key == "" {
+			return defaultValue
+		}
+
+		// Try map[any]any first (most common in templates).
+		if m, ok := current.(map[any]any); ok {
+			val, exists := m[key]
+			if !exists {
+				return defaultValue
+			}
+
+			// If this is the last key, return the value (even if nil).
+			if i == len(keys)-1 {
+				if val == nil {
+					return defaultValue
+				}
+
+				return val
+			}
+
+			current = val
+
+			continue
+		}
+
+		// Try map[string]any as fallback.
+		if m, ok := current.(map[string]any); ok {
+			val, exists := m[key]
+			if !exists {
+				return defaultValue
+			}
+
+			// If this is the last key, return the value (even if nil).
+			if i == len(keys)-1 {
+				if val == nil {
+					return defaultValue
+				}
+
+				return val
+			}
+
+			current = val
+
+			continue
+		}
+
+		// Current value is not a map, can't traverse further.
+		return defaultValue
+	}
+
+	// Should not reach here, but return default as safety.
+	return defaultValue
+}

--- a/pkg/template/funcmap_test.go
+++ b/pkg/template/funcmap_test.go
@@ -130,3 +130,624 @@ func TestFromYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestHasField(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc string
+		data any
+		path string
+		want bool
+	}{
+		{
+			desc: "nil data returns false",
+			data: nil,
+			path: "spec.kubernetes",
+			want: false,
+		},
+		{
+			desc: "empty path returns false",
+			data: map[any]any{"spec": map[any]any{"kubernetes": "v1.28"}},
+			path: "",
+			want: false,
+		},
+		{
+			desc: "single level field exists",
+			data: map[any]any{"name": "test"},
+			path: "name",
+			want: true,
+		},
+		{
+			desc: "single level field missing",
+			data: map[any]any{"name": "test"},
+			path: "other",
+			want: false,
+		},
+		{
+			desc: "nested field exists - map[any]any",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path: "spec.kubernetes.version",
+			want: true,
+		},
+		{
+			desc: "nested field missing at first level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path: "metadata.name",
+			want: false,
+		},
+		{
+			desc: "nested field missing at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path: "spec.networking.version",
+			want: false,
+		},
+		{
+			desc: "nested field missing at leaf level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path: "spec.kubernetes.apiServer",
+			want: false,
+		},
+		{
+			desc: "field exists with nil value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": nil,
+				},
+			},
+			path: "spec.kubernetes",
+			want: true,
+		},
+		{
+			desc: "field exists with empty map value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{},
+				},
+			},
+			path: "spec.kubernetes",
+			want: true,
+		},
+		{
+			desc: "map[string]any data structure",
+			data: map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{
+						"env": "production",
+					},
+				},
+			},
+			path: "metadata.labels.env",
+			want: true,
+		},
+		{
+			desc: "mixed map types",
+			data: map[any]any{
+				"spec": map[string]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path: "spec.kubernetes.version",
+			want: true,
+		},
+		{
+			desc: "path with empty segment",
+			data: map[any]any{"spec": map[any]any{"kubernetes": "v1.28"}},
+			path: "spec..kubernetes",
+			want: false,
+		},
+		{
+			desc: "path ending with dot",
+			data: map[any]any{"spec": map[any]any{"kubernetes": "v1.28"}},
+			path: "spec.",
+			want: false,
+		},
+		{
+			desc: "path starting with dot",
+			data: map[any]any{"spec": map[any]any{"kubernetes": "v1.28"}},
+			path: ".spec.kubernetes",
+			want: false,
+		},
+		{
+			desc: "non-map intermediate value",
+			data: map[any]any{
+				"spec": "string-value",
+			},
+			path: "spec.kubernetes",
+			want: false,
+		},
+		{
+			desc: "deeply nested field exists",
+			data: map[any]any{
+				"a": map[any]any{
+					"b": map[any]any{
+						"c": map[any]any{
+							"d": map[any]any{
+								"e": "value",
+							},
+						},
+					},
+				},
+			},
+			path: "a.b.c.d.e",
+			want: true,
+		},
+		{
+			desc: "deeply nested field missing at deep level",
+			data: map[any]any{
+				"a": map[any]any{
+					"b": map[any]any{
+						"c": map[any]any{
+							"d": map[any]any{
+								"e": "value",
+							},
+						},
+					},
+				},
+			},
+			path: "a.b.c.d.f",
+			want: false,
+		},
+		{
+			desc: "field with boolean value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"enabled": false,
+				},
+			},
+			path: "spec.enabled",
+			want: true,
+		},
+		{
+			desc: "field with number value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"replicas": 3,
+				},
+			},
+			path: "spec.replicas",
+			want: true,
+		},
+		{
+			desc: "field with slice value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"items": []string{"a", "b", "c"},
+				},
+			},
+			path: "spec.items",
+			want: true,
+		},
+		{
+			desc: "nil value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": nil,
+				},
+			},
+			path: "spec.kubernetes.version",
+			want: false,
+		},
+		{
+			desc: "string value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": "v1.28",
+				},
+			},
+			path: "spec.kubernetes.version",
+			want: false,
+		},
+		{
+			desc: "number value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"replicas": 3,
+				},
+			},
+			path: "spec.replicas.count",
+			want: false,
+		},
+		{
+			desc: "boolean value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"enabled": true,
+				},
+			},
+			path: "spec.enabled.value",
+			want: false,
+		},
+		{
+			desc: "slice value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"items": []string{"a", "b"},
+				},
+			},
+			path: "spec.items.first",
+			want: false,
+		},
+	}
+
+	for _, tC := range testCases {
+		tC := tC
+
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := template.HasField(tC.data, tC.path)
+
+			if got != tC.want {
+				t.Fatalf("expected %v, got %v", tC.want, got)
+			}
+		})
+	}
+}
+
+func TestGetFieldOrDefault(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc         string
+		data         any
+		path         string
+		defaultValue any
+		want         any
+	}{
+		{
+			desc:         "nil data returns default",
+			data:         nil,
+			path:         "spec.kubernetes",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc:         "empty path returns default",
+			data:         map[any]any{"spec": "value"},
+			path:         "",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc:         "single level field exists",
+			data:         map[any]any{"name": "test"},
+			path:         "name",
+			defaultValue: "default",
+			want:         "test",
+		},
+		{
+			desc:         "single level field missing",
+			data:         map[any]any{"name": "test"},
+			path:         "other",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc: "nested field exists - map[any]any",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path:         "spec.kubernetes.version",
+			defaultValue: "1.27",
+			want:         "1.28",
+		},
+		{
+			desc: "nested field missing at first level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path:         "metadata.name",
+			defaultValue: "default-name",
+			want:         "default-name",
+		},
+		{
+			desc: "nested field missing at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path:         "spec.networking.version",
+			defaultValue: "v1",
+			want:         "v1",
+		},
+		{
+			desc: "nested field missing at leaf level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path:         "spec.kubernetes.apiServer",
+			defaultValue: "default-api",
+			want:         "default-api",
+		},
+		{
+			desc: "field exists with nil value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": nil,
+				},
+			},
+			path:         "spec.kubernetes",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc: "field exists with empty map value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": map[any]any{},
+				},
+			},
+			path:         "spec.kubernetes",
+			defaultValue: "default",
+			want:         map[any]any{},
+		},
+		{
+			desc: "field exists with empty string value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"name": "",
+				},
+			},
+			path:         "spec.name",
+			defaultValue: "default",
+			want:         "",
+		},
+		{
+			desc: "field exists with zero number value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"replicas": 0,
+				},
+			},
+			path:         "spec.replicas",
+			defaultValue: 5,
+			want:         0,
+		},
+		{
+			desc: "field exists with false boolean value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"enabled": false,
+				},
+			},
+			path:         "spec.enabled",
+			defaultValue: true,
+			want:         false,
+		},
+		{
+			desc: "map[string]any data structure",
+			data: map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{
+						"env": "production",
+					},
+				},
+			},
+			path:         "metadata.labels.env",
+			defaultValue: "development",
+			want:         "production",
+		},
+		{
+			desc: "mixed map types",
+			data: map[any]any{
+				"spec": map[string]any{
+					"kubernetes": map[any]any{
+						"version": "1.28",
+					},
+				},
+			},
+			path:         "spec.kubernetes.version",
+			defaultValue: "1.27",
+			want:         "1.28",
+		},
+		{
+			desc:         "path with empty segment",
+			data:         map[any]any{"spec": map[any]any{"kubernetes": "v1.28"}},
+			path:         "spec..kubernetes",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc:         "path ending with dot",
+			data:         map[any]any{"spec": map[any]any{"kubernetes": "v1.28"}},
+			path:         "spec.",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc:         "path starting with dot",
+			data:         map[any]any{"spec": map[any]any{"kubernetes": "v1.28"}},
+			path:         ".spec.kubernetes",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc: "non-map intermediate value",
+			data: map[any]any{
+				"spec": "string-value",
+			},
+			path:         "spec.kubernetes",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc: "deeply nested field exists",
+			data: map[any]any{
+				"a": map[any]any{
+					"b": map[any]any{
+						"c": map[any]any{
+							"d": map[any]any{
+								"e": "value",
+							},
+						},
+					},
+				},
+			},
+			path:         "a.b.c.d.e",
+			defaultValue: "default",
+			want:         "value",
+		},
+		{
+			desc: "deeply nested field missing at deep level",
+			data: map[any]any{
+				"a": map[any]any{
+					"b": map[any]any{
+						"c": map[any]any{
+							"d": map[any]any{
+								"e": "value",
+							},
+						},
+					},
+				},
+			},
+			path:         "a.b.c.d.f",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc: "default value is complex type",
+			data: map[any]any{
+				"spec": map[any]any{},
+			},
+			path:         "spec.missing",
+			defaultValue: map[string]string{"key": "value"},
+			want:         map[string]string{"key": "value"},
+		},
+		{
+			desc: "nil value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": nil,
+				},
+			},
+			path:         "spec.kubernetes.version",
+			defaultValue: "1.27",
+			want:         "1.27",
+		},
+		{
+			desc: "string value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"kubernetes": "v1.28",
+				},
+			},
+			path:         "spec.kubernetes.version",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc: "number value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"replicas": 3,
+				},
+			},
+			path:         "spec.replicas.count",
+			defaultValue: 0,
+			want:         0,
+		},
+		{
+			desc: "boolean value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"enabled": true,
+				},
+			},
+			path:         "spec.enabled.value",
+			defaultValue: false,
+			want:         false,
+		},
+		{
+			desc: "slice value at intermediate level",
+			data: map[any]any{
+				"spec": map[any]any{
+					"items": []string{"a", "b"},
+				},
+			},
+			path:         "spec.items.first",
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			desc: "retrieve slice value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"items": []string{"a", "b", "c"},
+				},
+			},
+			path:         "spec.items",
+			defaultValue: []string{},
+			want:         []string{"a", "b", "c"},
+		},
+		{
+			desc: "retrieve map value",
+			data: map[any]any{
+				"spec": map[any]any{
+					"config": map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			path:         "spec.config",
+			defaultValue: map[string]string{},
+			want:         map[string]string{"key1": "value1", "key2": "value2"},
+		},
+	}
+
+	for _, tC := range testCases {
+		tC := tC
+
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := template.GetFieldOrDefault(tC.data, tC.path, tC.defaultValue)
+
+			if !cmp.Equal(got, tC.want, cmpopts.EquateEmpty()) {
+				t.Fatalf("expected %+v, got %+v", tC.want, got)
+			}
+		})
+	}
+}

--- a/pkg/template/model.go
+++ b/pkg/template/model.go
@@ -75,6 +75,8 @@ func NewTemplateModel(
 	funcMap.Add("toYaml", ToYAML)
 	funcMap.Add("fromYaml", FromYAML)
 	funcMap.Add("hasKeyAny", HasKeyAny)
+	funcMap.Add("hasField", HasField)
+	funcMap.Add("getFieldOrDefault", GetFieldOrDefault)
 
 	return &Model{
 		SourcePath:           source,


### PR DESCRIPTION
### Summary 💡

This PR adds `hasField` and `getFieldOrDefault` template helper functions to eliminate complex nested conditionals in distribution templates. These functions use dot-notation paths (e.g., "spec.distribution.modules.aws.ebsCsiDriver.overrides.iamRoleName") to safely check nested field existence and retrieve values with defaults. Includes 56 comprehensive unit tests covering edge cases, nil handling, and type safety. Released in v0.33.2-rc.2

### Tests performed 🧪

- [x] Unit testing
- [ ] Tested e2e in the distribution project with modified templates