### PR TITLE
testing: increase e2e AWS infra timeout to prevent flaky failures

### DIFF
--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -631,7 +631,7 @@ var (
 				session, err := gexec.Start(createInfraCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
 
-				Eventually(path.Join(tfPath, "plan", "terraform.plan"), 120*time.Second).Should(BeAnExistingFile())
+				Eventually(path.Join(tfPath, "plan", "terraform.plan"), 240*time.Second).Should(BeAnExistingFile())
 
 				Eventually(session).Should(gexec.Exit(0))
 
@@ -680,7 +680,7 @@ var (
 				session, err := gexec.Start(createKubeCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).To(Not(HaveOccurred()))
 
-				Eventually(path.Join(tfPath, "plan", "terraform.plan"), 120*time.Second).Should(BeAnExistingFile())
+				Eventually(path.Join(tfPath, "plan", "terraform.plan"), 240*time.Second).Should(BeAnExistingFile())
 
 				Eventually(session).Should(gexec.Exit(0))
 


### PR DESCRIPTION
### Summary 💡

Increase e2e test timeouts for AWS infrastructure tests from 120s to 240s to prevent randomly flaky failures caused by variable API latency. Tests typically complete in 25-30 seconds. The 240s timeout accommodates that variability.

### Description 📝

See above.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] ran [3419](https://ci.sighup.io/sighupio/furyctl/3419)

### Future work 🔧

None.