### PR TITLE
fix(cmd): validate positional args

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -78,12 +78,14 @@ func NewApplyCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	applyCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "apply",
 		Short: "Apply the configuration to create, update, or upgrade a battle-tested SIGHUP Distribution cluster",
 		Example: `  furyctl apply                                     Apply all the configuration to the cluster using the default configuration file name
   furyctl apply --config mycluster.yaml             Apply a custom configuration file
   furyctl apply --phase distribution                Apply a single phase, for example the distribution phase
   furyctl apply --post-apply-phases distribution    Apply all the phases, and repeat the distribution phase afterwards
+  furyctl apply --upgrade                           Upgrade a cluster after bumping it's version in the configuration file.
 `,
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			cmdEvent = analytics.NewCommandEvent(cobrax.GetFullname(cmd))

--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -40,6 +40,7 @@ func NewConfigCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	configCmd := &cobra.Command{
+		Args:    cobra.NoArgs,
 		Use:     "config",
 		Short:   "Scaffolds a new furyctl configuration file for a specific version and kind",
 		Example: "furyctl create config --kind OnPremises --version v1.30.0 --name test-cluster",

--- a/cmd/create/pki.go
+++ b/cmd/create/pki.go
@@ -93,6 +93,7 @@ func NewPKICmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	pkiCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "pki",
 		Short: "Creates the Public Key Infrastructure files needed for an on-premises cluster.",
 		Long: `Creates the Public Key Infrastructure files needed (CA, certificates, keys, etc.) by a Kubernetes cluster and its etcd database.

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -62,6 +62,7 @@ func NewClusterCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	clusterCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "cluster",
 		Short: "Deletes a cluster",
 		PreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -46,6 +46,7 @@ func NewDiffCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	diffCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "diff",
 		Short: "Diff the current configuration with the one in the cluster",
 		PreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/download/dependencies.go
+++ b/cmd/download/dependencies.go
@@ -33,6 +33,7 @@ func NewDependenciesCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	dependenciesCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "dependencies",
 		Short: "Download all dependencies for the SIGHUP Distribution version specified in the configuration file",
 		PreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -48,6 +48,7 @@ func NewTemplateCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	templateCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "template",
 		Short: "Renders the distribution's code from template files parametrized with the configuration file",
 		Long: `Generates a folder with the parametrized version of the Terraform and Kustomization code for deploying the SIGHUP Distribution into a cluster.

--- a/cmd/get/kubeconfig.go
+++ b/cmd/get/kubeconfig.go
@@ -36,6 +36,7 @@ func NewKubeconfigCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	kubeconfigCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "kubeconfig",
 		Short: "Get kubeconfig from a cluster",
 		PreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/get/supported-versions.go
+++ b/cmd/get/supported-versions.go
@@ -30,6 +30,7 @@ func NewSupportedVersionsCmd() *cobra.Command {
 	kinds := distribution.ConfigKinds()
 
 	supportedVersionCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "supported-versions",
 		Short: "List of currently supported SD versions and their compatibility with this version of furyctl for each kind.",
 		Long:  "List of currently supported SD versions and their compatibility with this version of furyctl for each kind. If the `--kind` parameter is specified, the command will only provide information about the selected provider.",

--- a/cmd/get/upgrade-paths.go
+++ b/cmd/get/upgrade-paths.go
@@ -36,6 +36,7 @@ func NewUpgradePathsCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	upgradePathsCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "upgrade-paths",
 		Short: "Get available upgrade paths for the kind and version defined in the configuration file or a custom one.",
 		Long:  `Get available upgrade paths for the kind and version defined in the configuration file or a custom one. If the "--from" or "--kind" parameters are specified, the command will give the upgrade path for those instead.`,

--- a/cmd/renew/certificates.go
+++ b/cmd/renew/certificates.go
@@ -33,6 +33,7 @@ func NewCertificatesCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	certificatesCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "certificates",
 		Short: "Renew certificates of the cluster's PKI used for componenents authentication",
 		Long:  "Renew certificates of the cluster's PKI used for componenents authentication. Note that this not renews other certificates like Ingress certificates or certificates managed by cert-manager",

--- a/cmd/validate/config.go
+++ b/cmd/validate/config.go
@@ -34,6 +34,7 @@ func NewConfigCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	configCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "config",
 		Short: "Validate configuration file",
 		PreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/validate/dependencies.go
+++ b/cmd/validate/dependencies.go
@@ -32,6 +32,7 @@ func NewDependenciesCmd() *cobra.Command {
 	var cmdEvent analytics.Event
 
 	dependenciesCmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "dependencies",
 		Short: "Validate dependencies for the SIGHUP Distribution version specified in the configuration file",
 		PreRun: func(cmd *cobra.Command, _ []string) {

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,15 @@
+# furyctl release vTBD
+
+Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
+
+## New features 🌟
+
+TBD
+
+## Bug fixes 🐞
+
+- [[#649](https://github.com/sighupio/furyctl/pull/649)] Validate that no positional arguments are passed to commands that do not support them.
+
+## Breaking Changes 💔
+
+TBD

--- a/test/e2e/furyctl_test.go
+++ b/test/e2e/furyctl_test.go
@@ -156,7 +156,7 @@ var (
 					"--config", filepath.Join(absBasepath, "furyctl.yaml"),
 					"--distro-location", absBasepath,
 					"--debug",
-					"--disable-analytics", "true",
+					"--disable-analytics",
 				)
 			}
 
@@ -243,7 +243,7 @@ var (
 					"--config", tempConfigPath,
 					"--distro-location", tempDir,
 					"--debug",
-					"--disable-analytics", "true",
+					"--disable-analytics",
 				)
 
 				Expect(err).To(Not(HaveOccurred()))
@@ -268,7 +268,7 @@ var (
 					"--distro-location", absBasepath,
 					"--bin-path", binpath,
 					"--debug",
-					"--disable-analytics", "true",
+					"--disable-analytics",
 					"--log", "stdout",
 				)
 			}
@@ -523,7 +523,7 @@ var (
 					"--config", workdir+"/target/furyctl.yaml",
 					"--kind", "EKSCluster",
 					"--debug",
-					"--disable-analytics", "true",
+					"--disable-analytics",
 					"--distro-location", absBasepath+"/distro",
 					"--version", "1.25.1",
 					"--log", "stdout",


### PR DESCRIPTION
Fail when user passes positional args to commands that do not require them, avoiding mistakes.

### Summary 💡

Modify all commands that don't take a positional argument to fail with an error when the user passes one (most probably by mistake).

Fixes #648


### Description 📝

See the linked issue on the rationale behind this change.

### Breaking Changes 💔

None, but furyctl invocations that included a positional argument by mistake could start failing now.

See for example the fix to the e2e test that were passing the `true` value to a flag that does not take one and it was being silently ignored as a positional argument.

### Tests performed 🧪

- [x] Tested that commands now fail with an error when a positional argument is passed instead of silently ignoring them.
- [x] Tested that commands still work as expected when they are invoked properly.

### Future work 🔧

None
