### PR TITLE
fix: hardcode arch for kustomize 3.10.0

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,7 +9,9 @@ TBD
 ## Bug fixes 🐞
 
 - [[#649](https://github.com/sighupio/furyctl/pull/649)] Validate that no positional arguments are passed to commands that do not support them.
+- [[#650](https://github.com/sighupio/furyctl/pull/650)] Fallback to AMD64 binary for kustomize 3.10.0 (used in SD v1.31.0, for example) because ARM binary is not available.
 
 ## Breaking Changes 💔
 
 TBD
+

--- a/internal/dependencies/tools/kustomize.go
+++ b/internal/dependencies/tools/kustomize.go
@@ -17,7 +17,7 @@ import (
 func NewKustomize(runner *kustomize.Runner, version string) *Kustomize {
 	arch := runtime.GOARCH
 	// Older versions of kustomize did not provide ARM64 binaries.
-	if version == "3.5.3" {
+	if version == "3.5.3" || version == "3.10.0" {
 		arch = "amd64"
 	}
 

--- a/internal/dependencies/tools/kustomize_test.go
+++ b/internal/dependencies/tools/kustomize_test.go
@@ -36,6 +36,23 @@ func Test_OldKustomize_SupportsDownload(t *testing.T) {
 	}
 }
 
+func Test_Kustomize3_10_0_SupportsDownload(t *testing.T) {
+	a := tools.NewKustomize(newKustomizeRunner(), "3.10.0")
+
+	if a.SupportsDownload() != true {
+		t.Errorf("kustomize download must be supported")
+	}
+
+	wantSrcPath := fmt.Sprintf(
+		"https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.10.0/kustomize_v3.10.0_%s_amd64.tar.gz",
+		runtime.GOOS,
+	)
+
+	if a.SrcPath() != wantSrcPath {
+		t.Errorf("Wrong kustomize src path: want = %s, got = %s", wantSrcPath, a.SrcPath())
+	}
+}
+
 func Test_Kustomize_SupportsDownload(t *testing.T) {
 	a := tools.NewKustomize(newKustomizeRunner(), "5.6.0")
 


### PR DESCRIPTION
### Summary 💡

Harcode the architecture for kustomize 3.10.0 like we did for 3.5.3.

### Description 📝


We are using kustmomize 3.10.0 in SD version 1.31.0, this version of kustomize does not have an arm64 build and and we did not consider this version of kustomize in the download logic. This makes the dependencies download fail for a 1.31.0 cluster on ARM machines.

This PR harcodes the architecture for this version of kustomize like we did for 3.5.3 so we fallback to the amd64 build of kustomize.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that for clusters with SD v1.33.0 configuration file that furyctl still downloads the right binary (arm architecture)
- [x] Tested with a v1.31.0 SD cluster configuration file that furyctl build with this fix downloads the binary for amd64 and in the right version:

```shell
$ furyctl create config --version v1.31.0 --kind OnPremises
INFO Downloading distribution...
INFO Compatibility patches applied for v1.31.0
INFO Configuration file created successfully at: /tmp/furyctl.yaml

$ furyctl download dependencies --outdir .
INFO Compatibility patches applied for v1.31.0
INFO Downloading dependencies...
WARN 'awscli' download is not supported, please install it manually if not present
INFO Dependencies download succeeded

$ file .furyctl/bin/kustomize/3.10.0/kustomize
.furyctl/bin/kustomize/3.10.0/kustomize: Mach-O 64-bit executable x86_64

$ .furyctl/bin/kustomize/3.10.0/kustomize version
{Version:kustomize/v3.10.0 GitCommit:602ad8aa98e2e17f6c9119e027a09757e63c8bec BuildDate:2021-02-10T00:00:50Z GoOs:darwin GoArch:amd64}
```

### Future work 🔧

None