### PR TITLE
fix: remove the INFO prefix from plain text output

### DIFF
--- a/cmd/get/supported-versions.go
+++ b/cmd/get/supported-versions.go
@@ -7,6 +7,7 @@ package get
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -57,7 +58,7 @@ func NewSupportedVersionsCmd() *cobra.Command {
 			}
 
 			kindsToPrint := kinds
-			msg := "list of currently supported SD versions and their compatibility with this version of furyctl for "
+			msg := "List of currently supported SD versions and their compatibility with this version of furyctl for "
 
 			// Check if the kind flag is set, if it is not set we will print all kinds.
 			if cmd.Flags().Changed("kind") {
@@ -76,7 +77,9 @@ func NewSupportedVersionsCmd() *cobra.Command {
 				msg += "each kind\n"
 			}
 
-			logrus.Info(msg + FormatSupportedVersions(releases, kindsToPrint))
+			if _, err := fmt.Fprint(os.Stdout, msg+FormatSupportedVersions(releases, kindsToPrint)); err != nil {
+				return fmt.Errorf("error writing output: %w", err)
+			}
 			cmdEvent.AddSuccessMessage("supported SD versions")
 			tracker.Track(cmdEvent)
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to knwo that you are working on this change, and let's you have a 
place to track your work in progress.

When opening PRs in Draft, don't assign reviewers until the PR is ready for review.  Once you are confortable with the
status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

<!-- Write a short summary of the changes that this PR introduces and the motivations -->

Fixes plain text output for get supported-versions; replace logrus.Info with fmt.Fprint(os.Stdout) so the INFO level prefix is not shown.

### Description 📝

See above.

Before:

```
furyctl get supported-versions
INFO list of currently supported SD versions and their compatibility with this version of furyctl for each kind
```

After:

```
./furyctl get supported-versions
List of currently supported SD versions and their compatibility with this version of furyctl for each kind
```

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] CI https://ci.sighup.io/sighupio/furyctl/3529


### Future work 🔧

None
