### PR TITLE
fix: fallback to spec.kubernetes.vpcId when infra output.json has no vpc_id

### DIFF
--- a/internal/apis/kfd/v1alpha2/ekscluster/common/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/common/distribution.go
@@ -142,34 +142,30 @@ func (d *Distribution) extractVpcIDFromPrevPhases(fMerger *merge.Merger) (string
 		var infraOut terraform.OutputJSON
 
 		if err := json.Unmarshal(infraOutJSON, &infraOut); err == nil {
-			if infraOut["vpc_id"] == nil {
-				return vpcID, ErrVpcIDNotFound
+			if infraOut["vpc_id"] != nil {
+				vpcIDOut, ok := infraOut["vpc_id"].Value.(string)
+				if !ok {
+					return vpcID, ErrCastingVpcIDToStr
+				}
+
+				return vpcIDOut, nil
 			}
-
-			vpcIDOut, ok := infraOut["vpc_id"].Value.(string)
-			if !ok {
-				return vpcID, ErrCastingVpcIDToStr
-			}
-
-			vpcID = vpcIDOut
 		}
-	} else {
-		fModel := merge.NewDefaultModel((*fMerger.GetBase()).Content(), ".spec.kubernetes")
-
-		kubeFromFuryctlConf, err := fModel.Get()
-		if err != nil {
-			return vpcID, fmt.Errorf("error getting kubernetes from furyctl config: %w", err)
-		}
-
-		vpcFromFuryctlConf, ok := kubeFromFuryctlConf["vpcId"].(string)
-		if !ok && !d.DryRun {
-			return vpcID, ErrCastingVpcIDToStr
-		}
-
-		vpcID = vpcFromFuryctlConf
 	}
 
-	return vpcID, nil
+	fModel := merge.NewDefaultModel((*fMerger.GetBase()).Content(), ".spec.kubernetes")
+
+	kubeFromFuryctlConf, err := fModel.Get()
+	if err != nil {
+		return vpcID, fmt.Errorf("error getting kubernetes from furyctl config: %w", err)
+	}
+
+	vpcFromFuryctlConf, ok := kubeFromFuryctlConf["vpcId"].(string)
+	if !ok && !d.DryRun {
+		return vpcID, ErrCastingVpcIDToStr
+	}
+
+	return vpcFromFuryctlConf, nil
 }
 
 func (d *Distribution) PreparePostTerraform(

--- a/internal/apis/kfd/v1alpha2/ekscluster/common/distribution_internal_test.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/common/distribution_internal_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/pkg/merge"
+)
+
+// kubeConfig returns a furyctl config content carrying spec.kubernetes.vpcId.
+func kubeConfig(vpcID any) map[any]any {
+	return map[any]any{
+		"spec": map[any]any{
+			"kubernetes": map[any]any{
+				"vpcId": vpcID,
+			},
+		},
+	}
+}
+
+// TestDistribution_extractVpcIDFromPrevPhases covers vpc_id resolution and its
+// fallback to spec.kubernetes.vpcId when output.json has no usable vpc_id.
+func TestDistribution_extractVpcIDFromPrevPhases(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		// Parsed furyctl config that feeds the merger base.
+		furyctlConf map[any]any
+		// When non-empty, it is written to output.json in the infra outputs
+		// dir; when empty, no output.json file exists.
+		outputJSON string
+		dryRun     bool
+
+		want            string
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:        "output.json has a valid vpc_id and takes precedence over the config",
+			furyctlConf: kubeConfig("vpc-from-config"),
+			outputJSON:  `{"vpc_id":{"sensitive":false,"value":"vpc-from-output"}}`,
+			want:        "vpc-from-output",
+		},
+		{
+			name:        "output.json vpc_id is not a string returns a casting error",
+			furyctlConf: kubeConfig("vpc-from-config"),
+			outputJSON:  `{"vpc_id":{"value":42}}`,
+			wantErrIs:   ErrCastingVpcIDToStr,
+		},
+		{
+			name:        "output.json without vpc_id falls back to the config vpcId",
+			furyctlConf: kubeConfig("vpc-from-config"),
+			outputJSON:  `{"nat_gateway_ids":{"value":["nat-1"]}}`,
+			want:        "vpc-from-config",
+		},
+		{
+			name:        "output.json with a null vpc_id falls back to the config vpcId",
+			furyctlConf: kubeConfig("vpc-from-config"),
+			outputJSON:  `{"vpc_id":null}`,
+			want:        "vpc-from-config",
+		},
+		{
+			name:        "unparseable output.json falls back to the config vpcId",
+			furyctlConf: kubeConfig("vpc-from-config"),
+			outputJSON:  `}{ not json`,
+			want:        "vpc-from-config",
+		},
+		{
+			name:        "no output.json falls back to the config vpcId",
+			furyctlConf: kubeConfig("vpc-from-config"),
+			want:        "vpc-from-config",
+		},
+		{
+			name:        "no output.json and vpcId not set returns a casting error",
+			furyctlConf: kubeConfig(nil),
+			wantErrIs:   ErrCastingVpcIDToStr,
+		},
+		{
+			name:        "no output.json and vpcId not set is tolerated on dry-run",
+			furyctlConf: kubeConfig(nil),
+			dryRun:      true,
+		},
+		{
+			name:            "no output.json and missing spec.kubernetes returns a wrapped error",
+			furyctlConf:     map[any]any{"spec": map[any]any{}},
+			wantErrContains: "error getting kubernetes from furyctl config",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			outputsDir := t.TempDir()
+
+			if tc.outputJSON != "" {
+				if err := os.WriteFile(
+					filepath.Join(outputsDir, "output.json"),
+					[]byte(tc.outputJSON),
+					0o600,
+				); err != nil {
+					t.Fatalf("error writing output.json: %v", err)
+				}
+			}
+
+			d := &Distribution{
+				DryRun:                             tc.dryRun,
+				InfrastructureTerraformOutputsPath: outputsDir,
+			}
+
+			base := merge.NewDefaultModel(tc.furyctlConf, ".spec.kubernetes")
+			got, err := d.extractVpcIDFromPrevPhases(merge.NewMerger(base, base))
+
+			switch {
+			case tc.wantErrIs != nil:
+				require.ErrorIs(t, err, tc.wantErrIs)
+
+			case tc.wantErrContains != "":
+				require.ErrorContains(t, err, tc.wantErrContains)
+
+			default:
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Summary 💡

   When running the infrastructure phase without creating a VPC (because it already exists), the `output.json` file is created but does not contain a `vpc_id` key. This causes `ErrVpcIDNotFound` in the distribution phase, preventing the fallback to `.spec.kubernetes.vpcId` from the furyctl config.

   Closes:

   Relates:

   ### Description 📝

   The `extractVpcIDFromPrevPhases` function in the distribution phase had an `if/else` structure where the fallback to `.spec.kubernetes.vpcId` was only reached when `output.json` did not exist at all (`os.ReadFile` error).

   When the infrastructure phase runs without creating a VPC, it still produces an `output.json` (empty or without `vpc_id`). In this case, the code entered the `if` branch, found no `vpc_id`, and returned `ErrVpcIDNotFound` instead of falling through to the furyctl config fallback.

   The fix removes the exclusive `if/else` structure so that when `output.json` exists but does not contain `vpc_id`, execution continues to the fallback that reads the value from `.spec.kubernetes.vpcId`.

   ### Breaking Changes 💔

   None.

   ### Tests performed 🧪

   - [x] Project compiles successfully with `go build ./...`
   - [ ] Tested the distribution phase with an existing VPC and no `vpc_id` in infra output

   ### Future work 🔧

   - Add unit tests for `extractVpcIDFromPrevPhases` covering the different fallback scenarios.
   - Consider applying the same fix to `kubernetes.go` where `ErrVpcIDNotFound` is also returned in a similar pattern.