### PR TITLE
feat(immutable): pre post install commands

### DIFF
--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -139,7 +139,12 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 				"nodeStatus": status,
 			}).Debug("received node status update")
 
-			logrus.Infof("Node %s is %s", node, status)
+			if status == "installation-blocked" {
+				logrus.Errorf("Flatcar Installation on node %s is blocked because Flatcar is already installed on disk. Manual intervention required", node)
+			} else {
+				logrus.Infof("Node %s is %s", node, status)
+			}
+
 			// Check if all nodes are in "booted" status and log if so.
 			allBooted := true
 
@@ -152,7 +157,7 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 			}
 
 			if allBooted {
-				logrus.Infof("All %d nodes reached 'booted' state. Continuing...", len(*nodesStatus))
+				logrus.Infof("All %d nodes reached 'booted' state. Stopping server and continuing...", len(*nodesStatus))
 				close(inputCh)
 				cancel()
 			}

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
@@ -191,7 +191,9 @@ func (i *Infrastructure) renderRootTemplates() error {
 	cfg := template.Config{
 		Data: map[string]map[any]any{
 			"data": {
-				"ipxeServerURL": i.furyctlConf.Spec.Infrastructure.IpxeServer.Url,
+				"ipxeServerURL":                 i.furyctlConf.Spec.Infrastructure.IpxeServer.Url,
+				"ipxeServerPreInstallCommands":  i.furyctlConf.Spec.Infrastructure.IpxeServer.PreInstallCommands,
+				"ipxeServerPostInstallCommands": i.furyctlConf.Spec.Infrastructure.IpxeServer.PostInstallCommands,
 			},
 		},
 	}
@@ -441,14 +443,16 @@ func (i *Infrastructure) generateInstallFlatcarIgnitionFiles() error {
 		}
 
 		templateData := map[string]any{
-			"base64EncodedIgnition": base64Encoded,
-			"ipxeServerURL":         i.furyctlConf.Spec.Infrastructure.IpxeServer.Url,
-			"sshUsername":           i.furyctlConf.Spec.Infrastructure.Ssh.Username,
-			"sshPublicKey":          sshPublicKeyContent,
-			"installDisk":           node.Storage.InstallDisk,
-			"hostname":              node.Hostname,
-			"proxy":                 httpProxy,
-			"arch":                  node.Arch,
+			"base64EncodedIgnition":         base64Encoded,
+			"ipxeServerURL":                 i.furyctlConf.Spec.Infrastructure.IpxeServer.Url,
+			"ipxeServerPreInstallCommands":  i.furyctlConf.Spec.Infrastructure.IpxeServer.PreInstallCommands,
+			"ipxeServerPostInstallCommands": i.furyctlConf.Spec.Infrastructure.IpxeServer.PostInstallCommands,
+			"sshUsername":                   i.furyctlConf.Spec.Infrastructure.Ssh.Username,
+			"sshPublicKey":                  sshPublicKeyContent,
+			"installDisk":                   node.Storage.InstallDisk,
+			"hostname":                      node.Hostname,
+			"proxy":                         httpProxy,
+			"arch":                          node.Arch,
 		}
 
 		var renderedContent bytes.Buffer


### PR DESCRIPTION
### Summary 💡

Pass pre and post install commands from the ipxeServer configuration to the install-flatcar templates.

Handle installation-blocked node status.

Minor improvement to logs

Relates:
- https://github.com/sighupio/distribution/pull/524


### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested flatcar installation with pre and post install commands
- [x] Tested flatcar installation with pre install commands
- [x] Tested flatcar installation with post install commands
- [x] Tested flatcar installation without pre or post install commands


### Future work 🔧

None
