### PR TITLE
feat(immutable): wire the per-role upgrade orchestrator into apply --upgrade

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -502,7 +502,7 @@ func setupApplyCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(
 		"skip-nodes-upgrade",
 		false,
-		"On kind OnPremises, this will skip the upgrade of the nodes upgrading only the control-plane",
+		"On kind OnPremises and Immutable, this will skip the upgrade of the nodes upgrading only the control-plane",
 	)
 
 	cmd.Flags().Bool(
@@ -607,6 +607,6 @@ func setupApplyCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().String(
 		"upgrade-node",
 		"",
-		"On kind OnPremises, this will upgrade one specific node passed as parameter",
+		"On kind OnPremises and Immutable, this will upgrade one specific node passed as parameter",
 	)
 }

--- a/configs/upgrades/immutable/1.34.8-1.35.5/post-distribution.sh.tpl
+++ b/configs/upgrades/immutable/1.34.8-1.35.5/post-distribution.sh.tpl
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+set -eu
+
+kubectlbin="{{ .paths.kubectl }}"
+
+# Post-distribution upgrade hook — immutable 1.34.8 -> 1.35.5 (alpha).
+#
+# No distribution-module migration is required AFTER re-applying the modules for
+# this transition. If a future {from}-{to} needs to clean up or transform module
+# state once the new manifests are applied (delete superseded resources, migrate a
+# CRD, drop a removed component), add the steps here, mirroring on-prem's
+# configs/upgrades/onpremises/<from>-<to>/post-distribution.sh.tpl.
+#
+# On-prem pattern (delete resources superseded by the new version):
+#   "$kubectlbin" delete <resource> -n <namespace> --ignore-not-found
+
+echo "immutable upgrade: no post-distribution migration required for 1.34.8 -> 1.35.5 (kubectl: ${kubectlbin})"

--- a/configs/upgrades/immutable/1.34.8-1.35.5/pre-distribution.sh.tpl
+++ b/configs/upgrades/immutable/1.34.8-1.35.5/pre-distribution.sh.tpl
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+set -eu
+
+kubectlbin="{{ .paths.kubectl }}"
+
+# Pre-distribution upgrade hook — immutable 1.34.8 -> 1.35.5 (alpha).
+#
+# No distribution-module migration is required BEFORE re-applying the modules for
+# this transition. If a future {from}-{to} needs to transform or remove module
+# state before the new manifests apply (CRD rename, resource move, backend switch),
+# add the steps here, mirroring on-prem's
+# configs/upgrades/onpremises/<from>-<to>/pre-distribution.sh.tpl.
+#
+# On-prem pattern (remove stale resources so the new manifests apply clean):
+#   "$kubectlbin" delete <resource> -n <namespace> --ignore-not-found
+
+echo "immutable upgrade: no pre-distribution migration required for 1.34.8 -> 1.35.5 (kubectl: ${kubectlbin})"

--- a/configs/upgrades/immutable/1.34.8-1.35.5/pre-kubernetes.sh.tpl
+++ b/configs/upgrades/immutable/1.34.8-1.35.5/pre-kubernetes.sh.tpl
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+set -eu
+
+kubectlbin="{{ .paths.kubectl }}"
+
+{{- if index .spec "kubernetes" }}
+
+## etcd upgrade: align the etcd sysext + renew certificates. Group-targeted; the
+## playbook runs serial:1 (one node at a time, quorum preserved).
+ansible-playbook 54.upgrade-etcd.yaml --become
+
+## control-plane upgrade: sysext (kubernetes/kubeadm) + `kubeadm upgrade apply`
+## (apply-before-reboot) + OS stage/reboot. serial:1, one control plane at a time.
+ansible-playbook 55.upgrade-control-plane.yml --become
+
+{{- if ne .upgrade.skipNodesUpgrade true }}
+## worker upgrade: drain -> sysext + `kubeadm upgrade node` + OS reboot -> uncordon.
+## serial:1, one worker at a time.
+ansible-playbook 56.upgrade-worker-nodes.yml --become
+{{- end }}
+
+{{- end }}

--- a/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
@@ -54,7 +54,7 @@ func (k *Kubernetes) Exec(startFrom string, upgradeState *upgrade.State) error {
 	}
 
 	if k.upgradeNode != "" {
-		if _, err := k.ansibleRunner.Playbook("upgrade-worker-nodes.yml", "--limit", k.upgradeNode); err != nil {
+		if _, err := k.ansibleRunner.Playbook("56.upgrade-worker-nodes.yml", "--limit", k.upgradeNode); err != nil {
 			return fmt.Errorf("error upgrading node %s: %w", k.upgradeNode, err)
 		}
 


### PR DESCRIPTION
### Summary 💡

Wire the per-role Immutable upgrade orchestrator into `furyctl apply --upgrade`, so the numbered distribution playbooks run on an upgrade.

Closes:
Relates: sighupio/installer-immutable#6 (roles) + sighupio/distribution#529 (upgrade playbooks)

### Description 📝

- Add the `1.34.8-1.35.5` **pre-kubernetes upgrade orchestrator** script that runs the `54`/`55`/`56` playbooks, gated by `--skip-nodes-upgrade`.
- Add **pre/post-distribution upgrade hook stubs** for the same version pair (documented no-ops, so the hooks ship instead of being silently empty).
- Fix **`--upgrade-node` for Immutable**: invoke `56.upgrade-worker-nodes.yml` (the numeric prefix was missing, causing a file-not-found) and document `--upgrade-node` / `--skip-nodes-upgrade` for Immutable.

### Breaking Changes 💔

None. Upgrade orchestration only runs on `apply --upgrade`; the create path is unchanged.

### Tests performed 🧪

- [x] `go build` + the binary embeds the orchestrator + stubs (`strings` check)
- [x] Live upgrade 1.34.8 → 1.35.5 drove all 6 nodes through `54`/`55`/`56`
- [ ] `--upgrade-node <worker>` single-node path
- [ ] `mise run lint` + `mise run test-unit` (pre-existing unrelated failures aside)

### Future work 🔧

- Abstract `ansible.Runner` to an interface to enable a unit test for the `--upgrade-node` path.
