### PR TITLE
fix: drop the incoherent download dependencies --offline flag

### DIFF
--- a/cmd/download/dependencies.go
+++ b/cmd/download/dependencies.go
@@ -129,7 +129,6 @@ func NewDependenciesCmd() *cobra.Command {
 			basePath := filepath.Join(outDir, ".furyctl", dres.MinimalConf.Metadata.Name)
 
 			depsdl := dependencies.NewCachingDownloader(client, outDir, basePath, binPath, typedGitProtocol)
-			depsdl.SetOffline(viper.GetBool("offline"))
 
 			logrus.Info("Downloading dependencies...")
 
@@ -173,13 +172,6 @@ func NewDependenciesCmd() *cobra.Command {
 		"c",
 		"furyctl.yaml",
 		"Path to the configuration file",
-	)
-
-	dependenciesCmd.Flags().Bool(
-		"offline",
-		false,
-		"Resolve tools from the already-populated mise data dir without any network access "+
-			"(air-gapped re-runs). Requires the dependencies to have been downloaded beforehand",
 	)
 
 	dependenciesCmd.Flags().StringP(

--- a/internal/flags/types.go
+++ b/internal/flags/types.go
@@ -199,7 +199,6 @@ func GetSupportedFlags() SupportedFlags {
 			"binPath":        {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
 			"distroLocation": {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
 			"distroPatches":  {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
-			"offline":        {Type: FlagTypeBool, DefaultValue: false, Description: "Resolve tools offline"},
 			"bundleOutput":   {Type: FlagTypeString, DefaultValue: "", Description: "Bundle tarball output path"},
 		},
 		Connect: map[string]FlagInfo{},

--- a/internal/tool/mise/mise.go
+++ b/internal/tool/mise/mise.go
@@ -134,29 +134,22 @@ type Paths struct {
 type Runner struct {
 	executor execx.Executor
 	paths    Paths
-	offline  bool
 }
 
-func NewRunner(executor execx.Executor, paths Paths, offline bool) *Runner {
-	return &Runner{executor: executor, paths: paths, offline: offline}
+func NewRunner(executor execx.Executor, paths Paths) *Runner {
+	return &Runner{executor: executor, paths: paths}
 }
 
-// hermeticEnv isolates our mise from the user's: dedicated data/cache/config, auto-confirm, trusted
-// config path (no prompt), and offline when requested.
+// hermeticEnv isolates our mise from the user's: dedicated data/cache/config, auto-confirm and a
+// trusted config path (no prompt).
 func (r *Runner) hermeticEnv() []string {
-	env := []string{
+	return []string{
 		"MISE_DATA_DIR=" + r.paths.DataDir,
 		"MISE_CACHE_DIR=" + r.paths.CacheDir,
 		"MISE_GLOBAL_CONFIG_FILE=" + r.paths.ConfigFile,
 		"MISE_TRUSTED_CONFIG_PATHS=" + filepath.Dir(r.paths.ConfigFile),
 		"MISE_YES=1",
 	}
-
-	if r.offline {
-		env = append(env, "MISE_OFFLINE=1")
-	}
-
-	return env
 }
 
 // newCmd builds a mise invocation: always `--cd <isolated workdir>` so config discovery can't pick
@@ -180,7 +173,7 @@ func (r *Runner) newCmdOut(progress io.Writer, args ...string) *execx.Cmd {
 }
 
 // Install installs all tools declared in the (hermetic) global config into DataDir, teeing mise's
-// progress output to progress (may be nil). No-op offline if already installed.
+// progress output to progress (may be nil). No-op if they are already installed.
 func (r *Runner) Install(progress io.Writer) error {
 	if _, err := execx.CombinedOutput(r.newCmdOut(progress, "install")); err != nil {
 		return fmt.Errorf("error running mise install: %w", err)

--- a/pkg/dependencies/download.go
+++ b/pkg/dependencies/download.go
@@ -62,14 +62,6 @@ type Downloader struct {
 	basePath    string
 	binPath     string
 	gitProtocol git.Protocol
-	// When true, drives mise with MISE_OFFLINE for air-gapped runs (false by default).
-	offline bool
-}
-
-// SetOffline toggles offline mode: mise is driven with MISE_OFFLINE so it resolves tools from the
-// already-populated data dir without any network access (air-gapped re-runs).
-func (dd *Downloader) SetOffline(offline bool) {
-	dd.offline = offline
 }
 
 func (dd *Downloader) DownloadAll(kfd config.KFD, kind string) ([]error, []string) {
@@ -363,8 +355,8 @@ func (dd *Downloader) DownloadTools(kfd config.KFD, kind string) ([]string, erro
 	}
 
 	// The mise dir lives under binPath (next to the mise binary), NOT under vendor: vendor is wiped
-	// on every DownloadAll, so keeping the installed tools here lets them cache across runs (and makes
-	// --offline / air-gapped reuse work).
+	// on every DownloadAll, so keeping the installed tools here lets them cache across runs (and keeps
+	// them around for air-gapped reuse).
 	miseDir := filepath.Join(dd.binPath, "mise")
 	configFile := filepath.Join(miseDir, "mise.toml")
 
@@ -389,7 +381,7 @@ func (dd *Downloader) DownloadTools(kfd config.KFD, kind string) ([]string, erro
 		CacheDir:   filepath.Join(miseDir, "cache"),
 		ConfigFile: configFile,
 		WorkDir:    workDir,
-	}, dd.offline)
+	})
 
 	// Stream mise's install progress into an ephemeral terminal region (TTY only); on debug or
 	// --no-tty the region stays disabled and mise output is captured to the log file as usual.

--- a/test/utils/testutils.go
+++ b/test/utils/testutils.go
@@ -168,7 +168,7 @@ func Download(toolName, version string) string {
 		CacheDir:   filepath.Join(base, "cache"),
 		ConfigFile: cfg,
 		WorkDir:    work,
-	}, false)
+	})
 
 	Must0(runner.Install(nil))
 


### PR DESCRIPTION
### Summary 💡

Remove the `--offline` flag from `furyctl download dependencies` — it never actually made the command run offline, it only confused people.

### Description 📝

`download dependencies` always pulls the distribution, modules and installers from git (and wipes the vendor dir first), so it inherently needs the network. The `--offline` flag only switched the mise *tools* step to `MISE_OFFLINE`, leaving everything else online — so the command still required connectivity and the help text ended up contradicting itself ("requires the dependencies to have been downloaded beforehand").

It was just a leftover from before the air-gapped work landed. The real offline story is `--airgap-bundle`: it extracts a prebuilt bundle and implies `--skip-deps-download`, so mise is never even invoked at runtime. With that in place, `--offline` here has no reason to exist, so this removes the flag and the now-dead `offline`/`MISE_OFFLINE` plumbing behind it.

### Tests performed 🧪

- [x] `mise run format-go && mise run lint` (0 issues), `mise run test-unit`, `go build ./...`
- [x] `furyctl download dependencies --help` no longer lists `--offline`; `download air-gapped-bundle` and `--airgap-bundle` on the consuming commands still work
