### PR TITLE
feat(onpremises): enforce reducer-less unsupported rules + run migration playbooks in the kubernetes phase

### DIFF
--- a/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
@@ -373,15 +373,15 @@ func (p *PreFlight) CheckReducersDiffs(d r3diff.Changelog, diffChecker diffs.Che
 
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers("infrastructure"), d),
+		r.GetUnsupportedRules("infrastructure"),
 	)...)
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers("kubernetes"), d),
+		r.GetUnsupportedRules("kubernetes"),
 	)...)
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers("distribution"), d),
+		r.GetUnsupportedRules("distribution"),
 	)...)
 
 	if len(errs) > 0 {

--- a/internal/apis/kfd/v1alpha2/immutable/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/preflight.go
@@ -315,16 +315,16 @@ func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Chec
 
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers(cluster.OperationPhaseInfrastructure), d),
+		r.GetUnsupportedRules(cluster.OperationPhaseInfrastructure),
 	)...)
 
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers(cluster.OperationPhaseKubernetes), d),
+		r.GetUnsupportedRules(cluster.OperationPhaseKubernetes),
 	)...)
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers(cluster.OperationPhaseDistribution), d),
+		r.GetUnsupportedRules(cluster.OperationPhaseDistribution),
 	)...)
 
 	if len(errs) > 0 {

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
@@ -275,7 +275,7 @@ func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Chec
 
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers("distribution"), d),
+		r.GetUnsupportedRules("distribution"),
 	)...)
 
 	if len(errs) > 0 {

--- a/internal/apis/kfd/v1alpha2/onpremises/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/kubernetes.go
@@ -6,6 +6,7 @@ package create
 
 import (
 	"fmt"
+	"os"
 	"path"
 
 	"github.com/sirupsen/logrus"
@@ -16,8 +17,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/ansible"
 	"github.com/sighupio/furyctl/internal/upgrade"
 	execx "github.com/sighupio/furyctl/internal/x/exec"
+	iox "github.com/sighupio/furyctl/internal/x/io"
 	kubex "github.com/sighupio/furyctl/internal/x/kube"
+	"github.com/sighupio/furyctl/pkg/reducers"
 	"github.com/sighupio/furyctl/pkg/template"
+	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
 )
 
 const FromSecondsToHalfMinuteRetries = 30
@@ -40,7 +44,7 @@ func (k *Kubernetes) Self() *cluster.OperationPhase {
 	return k.OperationPhase
 }
 
-func (k *Kubernetes) Exec(startFrom string, upgradeState *upgrade.State) error {
+func (k *Kubernetes) Exec(rdcs reducers.Reducers, startFrom string, upgradeState *upgrade.State) error {
 	logrus.Info("Configuring SIGHUP Distribution cluster...")
 
 	if err := k.prepare(); err != nil {
@@ -69,11 +73,65 @@ func (k *Kubernetes) Exec(startFrom string, upgradeState *upgrade.State) error {
 		return fmt.Errorf("error running core kubernetes phase: %w", err)
 	}
 
+	if err := k.runMigrations(rdcs); err != nil {
+		return fmt.Errorf("error running kubernetes migrations: %w", err)
+	}
+
 	if err := k.postKubernetes(upgradeState); err != nil {
 		return fmt.Errorf("error running post-kubernetes phase: %w", err)
 	}
 
 	logrus.Info("Kubernetes cluster created successfully")
+
+	return nil
+}
+
+// runMigrations runs, for each reducer lifecycle present, the matching migration
+// playbook rendered under `migrations/<lifecycle>.yaml`, passing the reducers
+// (with their from/to values) as ansible extra-vars. This is the kubernetes-phase
+// analogue of the distribution phase's `scripts/<lifecycle>.sh`: the trigger is
+// fully driven by the rules (a rule with a `reducers` block), so adding a new
+// migration needs only a new rule + a new playbook, no Go changes.
+func (k *Kubernetes) runMigrations(rdcs reducers.Reducers) error {
+	if len(rdcs) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+
+	for _, r := range rdcs {
+		if r == nil {
+			continue
+		}
+
+		lifecycle := r.GetLifecycle()
+		if lifecycle == "" || seen[lifecycle] {
+			continue
+		}
+
+		seen[lifecycle] = true
+
+		varsData := rdcs.ByLifecycle(lifecycle).Combine(map[string]map[any]any{}, "reducers")
+
+		varsYaml, err := yamlx.MarshalV2(varsData)
+		if err != nil {
+			return fmt.Errorf("error marshalling migration vars: %w", err)
+		}
+
+		varsFile := "migration-vars-" + lifecycle + ".yaml"
+		if err := os.WriteFile(path.Join(k.Path, varsFile), varsYaml, iox.FullRWPermAccess); err != nil {
+			return fmt.Errorf("error writing migration vars file: %w", err)
+		}
+
+		logrus.Infof("Running migration playbook for lifecycle %q...", lifecycle)
+
+		if _, err := k.ansibleRunner.Playbook(
+			path.Join("migrations", lifecycle+".yaml"),
+			"-e", "@"+varsFile,
+		); err != nil {
+			return fmt.Errorf("error running migration playbook for lifecycle %s: %w", lifecycle, err)
+		}
+	}
 
 	return nil
 }

--- a/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
@@ -307,11 +307,11 @@ func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Chec
 
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers("kubernetes"), d),
+		r.GetUnsupportedRules("kubernetes"),
 	)...)
 	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
 		d,
-		r.UnsupportedReducerRulesByDiffs(r.GetReducers("distribution"), d),
+		r.GetUnsupportedRules("distribution"),
 	)...)
 
 	if len(errs) > 0 {

--- a/internal/apis/kfd/v1alpha2/onpremises/creator.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/creator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sighupio/furyctl/internal/distribution"
 	"github.com/sighupio/furyctl/internal/state"
 	"github.com/sighupio/furyctl/internal/upgrade"
+	"github.com/sighupio/furyctl/pkg/diffs"
 	"github.com/sighupio/furyctl/pkg/reducers"
 	premrules "github.com/sighupio/furyctl/pkg/rulesextractor"
 	"github.com/sighupio/furyctl/pkg/template"
@@ -171,7 +172,7 @@ func (*ClusterCreator) GetPhasePath(phase string) (string, error) {
 func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int) error {
 	upgr := upgrade.New(c.paths, string(c.furyctlConf.Kind))
 
-	kubernetesPhase := upgrade.NewOperatorPhaseDecorator(
+	kubernetesPhase := upgrade.NewReducerOperatorPhaseDecorator[reducers.Reducers](
 		c.upgradeStateStore,
 		create.NewKubernetes(
 			c.furyctlConf,
@@ -241,11 +242,28 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 		cluster.OperationPhaseDistribution,
 	)
 
+	// The kube-proxy.type field can be added to a config that never had it (the
+	// parent object is born), so the diff lands on the parent path. Expand it to
+	// per-leaf changes so reducers targeting the leaf (e.g. kubeProxy.type) match
+	// nil -> value transitions too.
+	kubeRdcs := reducers.Build(
+		diffs.ExpandMapChanges(status.Diffs),
+		r,
+		cluster.OperationPhaseKubernetes,
+	)
+
 	unsafeReducers := r.UnsafeReducerRulesByDiffs(
 		r.GetReducers(
 			cluster.OperationPhaseDistribution,
 		),
 		status.Diffs,
+	)
+
+	unsafeKubeReducers := r.UnsafeReducerRulesByDiffs(
+		r.GetReducers(
+			cluster.OperationPhaseKubernetes,
+		),
+		diffs.ExpandMapChanges(status.Diffs),
 	)
 
 	if len(rdcs) > 0 {
@@ -275,6 +293,17 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 
 	switch c.phase {
 	case cluster.OperationPhaseKubernetes:
+		if len(kubeRdcs) > 0 && len(unsafeKubeReducers) > 0 {
+			confirm, err := cluster.AskConfirmation(cluster.IsForceEnabledForFeature(c.force, cluster.ForceFeatureMigrations))
+			if err != nil {
+				return fmt.Errorf("error while asking for confirmation: %w", err)
+			}
+
+			if !confirm {
+				return ErrAbortedByUser
+			}
+		}
+
 		upgradeState := upgrade.State{
 			Phases: upgrade.Phases{
 				PreKubernetes:  &upgrade.Phase{Status: upgrade.PhaseStatusPending},
@@ -283,7 +312,7 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 			},
 		}
 
-		if err := kubernetesPhase.Exec(StartFromFlagNotSet, &upgradeState); err != nil {
+		if err := kubernetesPhase.Exec(kubeRdcs, StartFromFlagNotSet, &upgradeState); err != nil {
 			return fmt.Errorf("error while executing kubernetes phase: %w", err)
 		}
 
@@ -327,7 +356,9 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 			distributionPhase,
 			pluginsPhase,
 			upgr,
+			kubeRdcs,
 			rdcs,
+			unsafeKubeReducers,
 			unsafeReducers,
 		); err != nil {
 			return fmt.Errorf("error while executing cluster creation: %w", err)
@@ -360,11 +391,13 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 
 func (c *ClusterCreator) allPhases(
 	startFrom string,
-	kubernetesPhase upgrade.OperatorPhase,
+	kubernetesPhase upgrade.ReducersOperatorPhase[reducers.Reducers],
 	distributionPhase upgrade.ReducersOperatorPhase[reducers.Reducers],
 	pluginsPhase *commcreate.Plugins,
 	upgr *upgrade.Upgrade,
+	kubeRdcs reducers.Reducers,
 	rdcs reducers.Reducers,
+	unsafeKubeReducers []premrules.Rule,
 	unsafeReducers []premrules.Rule,
 ) error {
 	upgradeState := &upgrade.State{}
@@ -401,7 +434,18 @@ func (c *ClusterCreator) allPhases(
 		startFrom != cluster.OperationPhaseDistribution &&
 		startFrom != cluster.OperationSubPhasePostDistribution &&
 		startFrom != cluster.OperationPhasePlugins {
-		if err := kubernetesPhase.Exec(c.getKubernetesSubPhase(startFrom), upgradeState); err != nil {
+		if len(kubeRdcs) > 0 && len(unsafeKubeReducers) > 0 {
+			confirm, err := cluster.AskConfirmation(cluster.IsForceEnabledForFeature(c.force, cluster.ForceFeatureMigrations))
+			if err != nil {
+				return fmt.Errorf("error while asking for confirmation: %w", err)
+			}
+
+			if !confirm {
+				return ErrAbortedByUser
+			}
+		}
+
+		if err := kubernetesPhase.Exec(kubeRdcs, c.getKubernetesSubPhase(startFrom), upgradeState); err != nil {
 			return fmt.Errorf("error while executing kubernetes phase: %w", err)
 		}
 
@@ -451,7 +495,7 @@ func (c *ClusterCreator) allPhases(
 }
 
 func (c *ClusterCreator) extraPhases(
-	kubernetesPhase upgrade.OperatorPhase,
+	kubernetesPhase upgrade.ReducersOperatorPhase[reducers.Reducers],
 	distributionPhase upgrade.ReducersOperatorPhase[reducers.Reducers],
 	pluginsPhase *commcreate.Plugins,
 	upgr *upgrade.Upgrade,
@@ -468,7 +512,7 @@ func (c *ClusterCreator) extraPhases(
 		case cluster.OperationPhaseKubernetes:
 			kubernetesPhase.SetUpgrade(false)
 
-			if err := kubernetesPhase.Exec(StartFromFlagNotSet, upgradeState); err != nil {
+			if err := kubernetesPhase.Exec(nil, StartFromFlagNotSet, upgradeState); err != nil {
 				return fmt.Errorf("error while executing kubernetes phase: %w", err)
 			}
 

--- a/pkg/diffs/checker.go
+++ b/pkg/diffs/checker.go
@@ -118,6 +118,13 @@ func (*BaseChecker) AssertReducerUnsupportedViolations(diffs r3diff.Changelog, r
 		return nil
 	}
 
+	// When a nested object is added or removed wholesale (e.g. the optional
+	// `kubeProxy` object goes from absent to `{type: none}`), r3diff emits a
+	// single change at the parent path carrying a map value. Expand those into
+	// per-leaf changes so that leaf-targeted rules (e.g. `...kubeProxy.type`)
+	// catch nil -> value (and value -> nil) transitions too.
+	diffs = expandMapChanges(diffs)
+
 	for _, diff := range diffs {
 		for _, rule := range reducerRules {
 			joinedPath := "." + strings.Join(diff.Path, ".")
@@ -162,6 +169,63 @@ func isDiffUnsupported(diff r3diff.Change, conditions []rules.Unsupported) (stri
 	}
 
 	return reason, false
+}
+
+// expandMapChanges expands changes whose value is a nested map (a whole object
+// added or removed) into one change per leaf, preserving the change type. This
+// makes leaf-targeted rules match transitions where the parent object was
+// previously absent (nil -> value) or is being removed (value -> nil). Changes
+// that do not carry a map value are returned unchanged.
+func expandMapChanges(changelog r3diff.Changelog) r3diff.Changelog {
+	expanded := make(r3diff.Changelog, 0, len(changelog))
+
+	for _, c := range changelog {
+		expanded = append(expanded, expandChange(c)...)
+	}
+
+	return expanded
+}
+
+func expandChange(c r3diff.Change) []r3diff.Change {
+	// Object added wholesale: To is a map, From is nil.
+	if m, ok := c.To.(map[string]any); ok && len(m) > 0 {
+		var res []r3diff.Change
+		for k, v := range m {
+			res = append(res, expandChange(r3diff.Change{
+				Type: c.Type,
+				Path: childPath(c.Path, k),
+				From: nil,
+				To:   v,
+			})...)
+		}
+
+		return res
+	}
+
+	// Object removed wholesale: From is a map, To is nil.
+	if m, ok := c.From.(map[string]any); ok && len(m) > 0 {
+		var res []r3diff.Change
+		for k, v := range m {
+			res = append(res, expandChange(r3diff.Change{
+				Type: c.Type,
+				Path: childPath(c.Path, k),
+				From: v,
+				To:   nil,
+			})...)
+		}
+
+		return res
+	}
+
+	return []r3diff.Change{c}
+}
+
+func childPath(parent []string, key string) []string {
+	child := make([]string, 0, len(parent)+1)
+	child = append(child, parent...)
+	child = append(child, key)
+
+	return child
 }
 
 func isImmutablePathChanged(change r3diff.Change, immutables []string) bool {

--- a/pkg/diffs/checker.go
+++ b/pkg/diffs/checker.go
@@ -123,7 +123,7 @@ func (*BaseChecker) AssertReducerUnsupportedViolations(diffs r3diff.Changelog, r
 	// single change at the parent path carrying a map value. Expand those into
 	// per-leaf changes so that leaf-targeted rules (e.g. `...kubeProxy.type`)
 	// catch nil -> value (and value -> nil) transitions too.
-	diffs = expandMapChanges(diffs)
+	diffs = ExpandMapChanges(diffs)
 
 	for _, diff := range diffs {
 		for _, rule := range reducerRules {
@@ -171,12 +171,12 @@ func isDiffUnsupported(diff r3diff.Change, conditions []rules.Unsupported) (stri
 	return reason, false
 }
 
-// expandMapChanges expands changes whose value is a nested map (a whole object
+// ExpandMapChanges expands changes whose value is a nested map (a whole object
 // added or removed) into one change per leaf, preserving the change type. This
 // makes leaf-targeted rules match transitions where the parent object was
 // previously absent (nil -> value) or is being removed (value -> nil). Changes
 // that do not carry a map value are returned unchanged.
-func expandMapChanges(changelog r3diff.Changelog) r3diff.Changelog {
+func ExpandMapChanges(changelog r3diff.Changelog) r3diff.Changelog {
 	expanded := make(r3diff.Changelog, 0, len(changelog))
 
 	for _, c := range changelog {

--- a/pkg/diffs/checker_test.go
+++ b/pkg/diffs/checker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sighupio/furyctl/pkg/diffs"
+	rules "github.com/sighupio/furyctl/pkg/rulesextractor"
 )
 
 func TestBaseChecker_GenerateDiff(t *testing.T) {
@@ -178,6 +179,78 @@ func TestBaseChecker_AssertImmutableViolations(t *testing.T) {
 
 			for i, err := range errs {
 				assert.Equal(t, tC.expectedErrs[i].Error(), err.Error())
+			}
+		})
+	}
+}
+
+func ptrAny(v any) *any { return &v }
+
+func ptrStr(s string) *string { return &s }
+
+// onpremKubeCfg builds a minimal on-prem-like config; pass nil to omit the
+// kubeProxy object entirely (so the parent is absent).
+func onpremKubeCfg(kubeProxy map[string]any) map[string]any {
+	advanced := map[string]any{}
+	if kubeProxy != nil {
+		advanced["kubeProxy"] = kubeProxy
+	}
+
+	return map[string]any{
+		"spec": map[string]any{
+			"kubernetes": map[string]any{
+				"advanced": advanced,
+			},
+		},
+	}
+}
+
+// TestBaseChecker_AssertReducerUnsupportedViolations_WithoutReducers guards the
+// fix for unsupported transitions declared on a rule that has NO reducers
+// (e.g. .spec.kubernetes.advanced.kubeProxy.type), including the nil -> value
+// and value -> nil cases where the parent object is added/removed wholesale.
+func TestBaseChecker_AssertReducerUnsupportedViolations_WithoutReducers(t *testing.T) {
+	t.Parallel()
+
+	// Rule with only `unsupported` (no reducers) — the case the fix enables.
+	rule := rules.Rule{
+		Path: ".spec.kubernetes.advanced.kubeProxy.type",
+		Unsupported: &[]rules.Unsupported{
+			{To: ptrAny("none"), Reason: ptrStr("disabling kube-proxy on an existing cluster is not supported")},
+			{From: ptrAny("none"), Reason: ptrStr("enabling kube-proxy where it was never installed is not supported")},
+		},
+	}
+
+	testCases := []struct {
+		desc        string
+		current     map[string]any
+		next        map[string]any
+		wantBlocked bool
+	}{
+		{"nil -> none (kubeProxy object absent before)", onpremKubeCfg(nil), onpremKubeCfg(map[string]any{"type": "none"}), true},
+		{"nil -> none (kubeProxy present, type added)", onpremKubeCfg(map[string]any{}), onpremKubeCfg(map[string]any{"type": "none"}), true},
+		{"ipvs -> none", onpremKubeCfg(map[string]any{"type": "ipvs"}), onpremKubeCfg(map[string]any{"type": "none"}), true},
+		{"none -> ipvs", onpremKubeCfg(map[string]any{"type": "none"}), onpremKubeCfg(map[string]any{"type": "ipvs"}), true},
+		{"none -> nil (kubeProxy object removed)", onpremKubeCfg(map[string]any{"type": "none"}), onpremKubeCfg(nil), true},
+		{"ipvs -> nftables (allowed)", onpremKubeCfg(map[string]any{"type": "ipvs"}), onpremKubeCfg(map[string]any{"type": "nftables"}), false},
+		{"no change", onpremKubeCfg(map[string]any{"type": "ipvs"}), onpremKubeCfg(map[string]any{"type": "ipvs"}), false},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			checker := diffs.NewBaseChecker(tC.current, tC.next)
+
+			changelog, err := checker.GenerateDiff()
+			require.NoError(t, err)
+
+			errs := checker.AssertReducerUnsupportedViolations(changelog, []rules.Rule{rule})
+
+			if tC.wantBlocked {
+				assert.NotEmpty(t, errs, "expected an unsupported-transition violation")
+			} else {
+				assert.Empty(t, errs, "expected no violation")
 			}
 		})
 	}

--- a/pkg/diffs/checker_test.go
+++ b/pkg/diffs/checker_test.go
@@ -255,3 +255,53 @@ func TestBaseChecker_AssertReducerUnsupportedViolations_WithoutReducers(t *testi
 		})
 	}
 }
+
+// TestExpandMapChanges verifies that a wholesale object create/delete (a change
+// whose value is a nested map) is expanded into one change per leaf, so that
+// leaf-targeted rules/reducers match nil->value and value->nil transitions.
+func TestExpandMapChanges(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parent created -> per-leaf change with nil From", func(t *testing.T) {
+		t.Parallel()
+
+		in := diffx.Changelog{
+			{Type: "create", Path: []string{"spec", "kubernetes", "advanced", "kubeProxy"}, From: nil, To: map[string]any{"type": "nftables"}},
+		}
+
+		out := diffs.ExpandMapChanges(in)
+
+		require.Len(t, out, 1)
+		assert.Equal(t, []string{"spec", "kubernetes", "advanced", "kubeProxy", "type"}, out[0].Path)
+		assert.Nil(t, out[0].From)
+		assert.Equal(t, "nftables", out[0].To)
+	})
+
+	t.Run("parent deleted -> per-leaf change with nil To", func(t *testing.T) {
+		t.Parallel()
+
+		in := diffx.Changelog{
+			{Type: "delete", Path: []string{"spec", "kubernetes", "advanced", "kubeProxy"}, From: map[string]any{"type": "ipvs"}, To: nil},
+		}
+
+		out := diffs.ExpandMapChanges(in)
+
+		require.Len(t, out, 1)
+		assert.Equal(t, []string{"spec", "kubernetes", "advanced", "kubeProxy", "type"}, out[0].Path)
+		assert.Equal(t, "ipvs", out[0].From)
+		assert.Nil(t, out[0].To)
+	})
+
+	t.Run("leaf change is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		in := diffx.Changelog{
+			{Type: "update", Path: []string{"spec", "kubernetes", "advanced", "kubeProxy", "type"}, From: "ipvs", To: "nftables"},
+		}
+
+		out := diffs.ExpandMapChanges(in)
+
+		require.Len(t, out, 1)
+		assert.Equal(t, in[0], out[0])
+	})
+}

--- a/pkg/reducers/builder_test.go
+++ b/pkg/reducers/builder_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package reducers_test
+
+import (
+	"testing"
+
+	r3diff "github.com/r3labs/diff/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/pkg/diffs"
+	"github.com/sighupio/furyctl/pkg/reducers"
+	rules "github.com/sighupio/furyctl/pkg/rulesextractor"
+)
+
+// kubeProxyExtractor returns a BaseExtractor with a single kubernetes-phase rule
+// carrying a reducer on .spec.kubernetes.advanced.kubeProxy.type (mirrors the
+// onpremises rules for kube-proxy migration).
+func kubeProxyExtractor() rules.Extractor {
+	return rules.NewBaseExtractor(rules.Spec{
+		Kubernetes: &[]rules.Rule{
+			{
+				Path: ".spec.kubernetes.advanced.kubeProxy.type",
+				Reducers: &[]rules.Reducer{
+					{Key: "kubeProxyType", Lifecycle: "post-kubernetes"},
+				},
+			},
+		},
+	})
+}
+
+// TestBuild_KubeProxyType_NilToNftables guards the nil->value case: when the
+// whole kubeProxy object is added (the field is new, e.g. on a pre-1.35 cluster),
+// r3diff emits the change on the parent path. Without expanding it to per-leaf
+// changes the reducer would not match, so the migration would silently not run.
+func TestBuild_KubeProxyType_NilToNftables(t *testing.T) {
+	t.Parallel()
+
+	parentCreate := r3diff.Changelog{
+		{Type: "create", Path: []string{"spec", "kubernetes", "advanced", "kubeProxy"}, From: nil, To: map[string]any{"type": "nftables"}},
+	}
+
+	// Without expansion the parent-level change does not match the leaf rule.
+	rawRdcs := reducers.Build(parentCreate, kubeProxyExtractor(), "kubernetes")
+	assert.Empty(t, filterNonNil(rawRdcs), "raw parent-level change should not match the leaf reducer")
+
+	// With expansion the leaf change matches and carries from=nil, to=nftables.
+	rdcs := filterNonNil(reducers.Build(diffs.ExpandMapChanges(parentCreate), kubeProxyExtractor(), "kubernetes"))
+	require.Len(t, rdcs, 1)
+	assert.Equal(t, "kubeProxyType", rdcs[0].GetKey())
+	assert.Equal(t, "post-kubernetes", rdcs[0].GetLifecycle())
+	assert.Nil(t, rdcs[0].GetFrom())
+	assert.Equal(t, "nftables", rdcs[0].GetTo())
+}
+
+// TestBuild_KubeProxyType_IpvsToNftables covers the plain leaf transition.
+func TestBuild_KubeProxyType_IpvsToNftables(t *testing.T) {
+	t.Parallel()
+
+	cl := r3diff.Changelog{
+		{Type: "update", Path: []string{"spec", "kubernetes", "advanced", "kubeProxy", "type"}, From: "ipvs", To: "nftables"},
+	}
+
+	rdcs := filterNonNil(reducers.Build(diffs.ExpandMapChanges(cl), kubeProxyExtractor(), "kubernetes"))
+	require.Len(t, rdcs, 1)
+	assert.Equal(t, "kubeProxyType", rdcs[0].GetKey())
+	assert.Equal(t, "ipvs", rdcs[0].GetFrom())
+	assert.Equal(t, "nftables", rdcs[0].GetTo())
+}
+
+func filterNonNil(rs reducers.Reducers) reducers.Reducers {
+	out := reducers.Reducers{}
+
+	for _, r := range rs {
+		if r != nil {
+			out = append(out, r)
+		}
+	}
+
+	return out
+}

--- a/pkg/rulesextractor/ekscluster.go
+++ b/pkg/rulesextractor/ekscluster.go
@@ -116,6 +116,34 @@ func (r *EKSExtractor) GetReducers(phase string) []Rule {
 	}
 }
 
+func (r *EKSExtractor) GetUnsupportedRules(phase string) []Rule {
+	switch phase {
+	case cluster.OperationPhaseInfrastructure:
+		if r.Spec.Infrastructure == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Infrastructure)
+
+	case cluster.OperationPhaseKubernetes:
+		if r.Spec.Kubernetes == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Kubernetes)
+
+	case cluster.OperationPhaseDistribution:
+		if r.Spec.Distribution == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Distribution)
+
+	default:
+		return []Rule{}
+	}
+}
+
 func (r *EKSExtractor) ReducerRulesByDiffs(rls []Rule, ds diff.Changelog) []Rule {
 	return r.BaseExtractor.ReducerRulesByDiffs(rls, ds)
 }

--- a/pkg/rulesextractor/extractor.go
+++ b/pkg/rulesextractor/extractor.go
@@ -95,6 +95,7 @@ type Extractor interface {
 	GetImmutableRules(phase string) []Rule
 	FilterSafeImmutableRules(rules []Rule, ds diff.Changelog) []Rule
 	GetReducers(phase string) []Rule
+	GetUnsupportedRules(phase string) []Rule
 	ReducerRulesByDiffs(reducers []Rule, ds diff.Changelog) []Rule
 	UnsupportedReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule
 	UnsafeReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule
@@ -377,6 +378,27 @@ func (b *BaseExtractor) GetReducers(_ string) []Rule {
 	return reducers
 }
 
+// GetUnsupportedRules returns all the rules that declare unsupported transitions,
+// regardless of whether they also define reducers. This is what drives the
+// "unsupported transition" validation, which must not depend on reducers being set.
+func (b *BaseExtractor) GetUnsupportedRules(_ string) []Rule {
+	var unsupported []Rule
+
+	if b.Spec.Infrastructure != nil {
+		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Infrastructure)...)
+	}
+
+	if b.Spec.Kubernetes != nil {
+		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Kubernetes)...)
+	}
+
+	if b.Spec.Distribution != nil {
+		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Distribution)...)
+	}
+
+	return unsupported
+}
+
 func (*BaseExtractor) ReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule {
 	filteredRules := make([]Rule, 0)
 
@@ -492,4 +514,20 @@ func (*BaseExtractor) ExtractReducerRules(rls []Rule) []Rule {
 	}
 
 	return reducers
+}
+
+// ExtractUnsupportedRules returns the rules that declare at least one unsupported
+// transition, regardless of whether they also define reducers. Unsupported
+// transitions are enforced independently from reducers (see
+// diffs.AssertReducerUnsupportedViolations).
+func (*BaseExtractor) ExtractUnsupportedRules(rls []Rule) []Rule {
+	unsupported := make([]Rule, 0)
+
+	for _, rule := range rls {
+		if rule.Unsupported != nil && len(*rule.Unsupported) > 0 {
+			unsupported = append(unsupported, rule)
+		}
+	}
+
+	return unsupported
 }

--- a/pkg/rulesextractor/extractor_test.go
+++ b/pkg/rulesextractor/extractor_test.go
@@ -252,6 +252,51 @@ func TestBaseExtractor_GetReducers(t *testing.T) {
 	}
 }
 
+func TestBaseExtractor_GetUnsupportedRules(t *testing.T) {
+	t.Parallel()
+
+	noneVal := any("none")
+
+	unsupportedNoReducers := rules.Rule{
+		Path:        ".spec.kubernetes.advanced.kubeProxy.type",
+		Unsupported: &[]rules.Unsupported{{To: &noneVal}},
+	}
+	reducersOnly := rules.Rule{
+		Path:     ".foo",
+		Reducers: &[]rules.Reducer{{From: "a", To: "b"}},
+	}
+	plain := rules.Rule{Path: ".bar"}
+
+	testCases := []struct {
+		name string
+		spec rules.Spec
+		want []rules.Rule
+	}{
+		{
+			name: "should return empty slice if no rules",
+			spec: rules.Spec{},
+			want: nil,
+		},
+		{
+			name: "returns unsupported-only rules and ignores reducer-only/plain ones",
+			spec: rules.Spec{
+				Kubernetes: &[]rules.Rule{unsupportedNoReducers, reducersOnly, plain},
+			},
+			want: []rules.Rule{unsupportedNoReducers},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			x := rules.NewBaseExtractor(tc.spec)
+
+			got := x.GetUnsupportedRules("")
+
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestBaseExtractor_ReducerRulesByDiffs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/rulesextractor/immutable.go
+++ b/pkg/rulesextractor/immutable.go
@@ -123,6 +123,34 @@ func (r *ImmutableExtractor) GetReducers(phase string) []Rule {
 	}
 }
 
+func (r *ImmutableExtractor) GetUnsupportedRules(phase string) []Rule {
+	switch phase {
+	case cluster.OperationPhaseInfrastructure:
+		if r.Spec.Infrastructure == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Infrastructure)
+
+	case cluster.OperationPhaseKubernetes:
+		if r.Spec.Kubernetes == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Kubernetes)
+
+	case cluster.OperationPhaseDistribution:
+		if r.Spec.Distribution == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Distribution)
+
+	default:
+		return []Rule{}
+	}
+}
+
 func (r *ImmutableExtractor) ReducerRulesByDiffs(rls []Rule, ds diff.Changelog) []Rule {
 	return r.BaseExtractor.ReducerRulesByDiffs(rls, ds)
 }

--- a/pkg/rulesextractor/kfddistribution.go
+++ b/pkg/rulesextractor/kfddistribution.go
@@ -77,6 +77,20 @@ func (r *DistroExtractor) GetReducers(phase string) []Rule {
 	}
 }
 
+func (r *DistroExtractor) GetUnsupportedRules(phase string) []Rule {
+	switch phase {
+	case cluster.OperationPhaseDistribution:
+		if r.Spec.Distribution == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Distribution)
+
+	default:
+		return []Rule{}
+	}
+}
+
 func (r *DistroExtractor) ReducerRulesByDiffs(rls []Rule, ds diff.Changelog) []Rule {
 	return r.BaseExtractor.ReducerRulesByDiffs(rls, ds)
 }

--- a/pkg/rulesextractor/onpremises.go
+++ b/pkg/rulesextractor/onpremises.go
@@ -96,6 +96,27 @@ func (r *OnPremExtractor) GetReducers(phase string) []Rule {
 	}
 }
 
+func (r *OnPremExtractor) GetUnsupportedRules(phase string) []Rule {
+	switch phase {
+	case cluster.OperationPhaseKubernetes:
+		if r.Spec.Kubernetes == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Kubernetes)
+
+	case cluster.OperationPhaseDistribution:
+		if r.Spec.Distribution == nil {
+			return []Rule{}
+		}
+
+		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Distribution)
+
+	default:
+		return []Rule{}
+	}
+}
+
 func (r *OnPremExtractor) ReducerRulesByDiffs(rls []Rule, ds diff.Changelog) []Rule {
 	return r.BaseExtractor.ReducerRulesByDiffs(rls, ds)
 }


### PR DESCRIPTION
### Summary 💡

Let the rules engine enforce `unsupported` transitions on rules without a reducer, and run migration playbooks from the onpremises kubernetes phase, so a config change is actually applied to a running cluster, not just validated. Enables the kube-proxy `ipvs/nil → nftables` migration (distribution side: sighupio/distribution#505).

### Description 📝

The `unsupported` check only looked at rules with a reducer, so a rule with only `unsupported` (like `kubeProxy.type`) was never enforced, forcing a fake reducer. Now `GetUnsupportedRules` feeds the preflight check in every provider, independent of reducers. It also exports `diffs.ExpandMapChanges` so `nil → value` transitions (a new field whose parent is born in the diff) still match leaf-targeted rules.

It also extends the reducer mechanism, until now distribution-only (`scripts/<lifecycle>.sh`), to the onpremises kubernetes phase, where it runs `migrations/<lifecycle>.yaml` via the ansible runner with the reducers' `from`/`to` as extra-vars. The distribution drives the migration entirely from the rules, no furyctl changes. As in the distribution phase, it prompts for confirmation before an unsafe migration (`--force migrations` to skip).

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Unit tests (`pkg/diffs`, `pkg/reducers`) incl. `nil → value`; full suite green, lint clean.
- [x] e2e on a real onprem 1.35 cluster: `ipvs → nftables` applied (kube-proxy + Calico on nftables), idempotent re-apply, `→ ipvs`/`→ none` blocked.
- [x] Confirmation prompt verified e2e.

### Future work 🔧

None.
