### PR TITLE
test(parser): fix flaky parsing http dynamic-value test

### DIFF
--- a/internal/parser/config_test.go
+++ b/internal/parser/config_test.go
@@ -8,11 +8,10 @@ package parser_test
 
 import (
 	"fmt"
-	"math/rand"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,33 +108,14 @@ func TestConfigParser_ParseDynamicValue(t *testing.T) {
 		{
 			name: "parsing http",
 			setup: func() (string, string, func()) {
-				// Get a random port between 1024 and 65535
-				port := rand.Intn(65535-1024) + 1024
-				server := &http.Server{Addr: fmt.Sprintf(":%d", port)}
-
-				wg := &sync.WaitGroup{}
-
-				wg.Add(1)
-
-				go func(t *testing.T) {
-					wg.Done()
-
-					if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-						t.Fatal(err)
-					}
-				}(t)
-
-				wg.Wait()
-
-				http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+				// httptest.NewServer binds its port synchronously and is ready to
+				// serve as soon as it returns, so there is no listener-readiness
+				// race and no random-port collision.
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					fmt.Fprint(w, "hello test")
-				})
+				}))
 
-				return "", fmt.Sprintf("{http://localhost:%d}", port), func() {
-					if err := server.Close(); err != nil {
-						t.Fatal(err)
-					}
-				}
+				return "", fmt.Sprintf("{%s}", server.URL), server.Close
 			},
 			expected: "hello test",
 		},


### PR DESCRIPTION
### Summary 💡

The `TestConfigParser_ParseDynamicValue/parsing http` unit test was flaky and occasionally failed in CI with `dial tcp [::1]:<port>: connect: connection refused`.

Closes:

Relates:

### Description 📝

The test spun up an `http.Server` in a goroutine and tried to synchronise on its readiness with a `sync.WaitGroup`, but `wg.Done()` was called at the very start of the goroutine, before `server.ListenAndServe()`. As a result `wg.Wait()` returned immediately and the test fired the HTTP request before the listener was actually accepting connections, which produced the intermittent connection-refused failures. The listening port was also picked at random with `rand.Intn`, so it could occasionally collide with an already-bound port.

The hand-rolled server, goroutine and `WaitGroup` are replaced with `httptest.NewServer`, which binds its port synchronously and is ready to serve as soon as it returns. This removes both the readiness race and the random-port collision, and lets the test use the server's own `URL` and `Close` instead of reconstructing them by hand. The now-unused `math/rand` and `sync` imports are dropped.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] `go test -tags=unit -run TestConfigParser_ParseDynamicValue -count=30 ./internal/parser/` — green across all runs
- [x] `mise run lint` — 0 violations
- [x] `mise run format-go`

### Future work 🔧

None.
