### PR TITLE
fix(immutable): pass raw node config to butane templates

### DIFF
--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
@@ -24,6 +24,7 @@ import (
 	iox "github.com/sighupio/furyctl/internal/x/io"
 	"github.com/sighupio/furyctl/pkg/template"
 	netx "github.com/sighupio/furyctl/pkg/x/net"
+	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
 )
 
 var (
@@ -32,7 +33,15 @@ var (
 	ErrFlatcarArtifactsNotFound  = errors.New("flatcar artifacts not found for architecture")
 	ErrButaneConversionFatal     = errors.New("butane conversion fatal errors")
 	ErrButaneFatalErrors         = errors.New("butane translation has fatal errors")
+	ErrImmutableConfigMalformed  = errors.New("immutable furyctl config is malformed")
 )
+
+// defaultNodeArch mirrors the schema default of spec.infrastructure.nodes[].arch
+// from the distribution's immutable JSON schema. Because furyctl does not apply
+// JSON-schema defaults before the butane phase, and the butane templates read the
+// node arch value unguarded, a node that omits arch would fail to render unless we
+// backfill the default here.
+const defaultNodeArch = "x86-64"
 
 type immutableManifest struct {
 	Kubernetes map[string]assets `yaml:"kubernetes"`
@@ -114,6 +123,74 @@ func (i *Infrastructure) getNodeRole(node string) string {
 	}
 
 	return "worker"
+}
+
+// rawNodesByHostname indexes the nodes from an already-parsed furyctl.yaml (as an
+// opaque map) by hostname.
+//
+// The butane node templates consume many free-form node sub-trees that furyctl
+// deliberately does not model in its curated config struct: network.ethernets,
+// storage.{files,links,directories,additionalDisks}, systemd.units and
+// passwd.{users,groups}. Marshaling the typed public.SpecInfrastructureNode back
+// to YAML would silently drop every unmodeled field (and error outright on the
+// unguarded .node.network.ethernets), so the butane phase feeds the template the
+// raw node instead and lets the distribution JSON schema stay the single source
+// of truth for the node shape.
+//
+// It is a free function (not a method) so it can be unit-tested without a full
+// Infrastructure value or a file on disk.
+func rawNodesByHostname(conf map[any]any) (map[string]any, error) {
+	spec, ok := conf["spec"].(map[any]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: missing spec", ErrImmutableConfigMalformed)
+	}
+
+	infra, ok := spec["infrastructure"].(map[any]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: missing spec.infrastructure", ErrImmutableConfigMalformed)
+	}
+
+	nodes, ok := infra["nodes"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: spec.infrastructure.nodes is not a list", ErrImmutableConfigMalformed)
+	}
+
+	byHostname := make(map[string]any, len(nodes))
+
+	for _, raw := range nodes {
+		node, ok := raw.(map[any]any)
+		if !ok {
+			return nil, fmt.Errorf("%w: a node entry is not a map", ErrImmutableConfigMalformed)
+		}
+
+		hostname, ok := node["hostname"].(string)
+		if !ok || hostname == "" {
+			return nil, fmt.Errorf("%w: a node is missing its hostname", ErrImmutableConfigMalformed)
+		}
+
+		// Backfill the schema default for arch, which the butane templates read
+		// unguarded. Treat an empty or blank value the same as an omitted one.
+		arch, ok := node["arch"].(string)
+		if !ok || strings.TrimSpace(arch) == "" {
+			node["arch"] = defaultNodeArch
+		}
+
+		byHostname[hostname] = node
+	}
+
+	return byHostname, nil
+}
+
+// loadRawNodes reads the furyctl.yaml from disk and indexes its nodes by hostname.
+// It is decoded with yaml.v2 to match the marshaling used when the template config
+// is later written out (see OperationPhase.CopyFromTemplate -> yamlx.MarshalV2).
+func (i *Infrastructure) loadRawNodes() (map[string]any, error) {
+	conf, err := yamlx.FromFileV2[map[any]any](i.paths.ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading furyctl config %s: %w", i.paths.ConfigPath, err)
+	}
+
+	return rawNodesByHostname(conf)
 }
 
 // Read the SSH public key file path specified in the configuration and return its content as a string.
@@ -285,9 +362,22 @@ func (i *Infrastructure) renderButaneTemplates() error {
 	// Use CopyFromTemplate to render templates.
 	targetPath := filepath.Join(i.Path, "butane", "node-config")
 
+	// The butane templates read free-form node sub-trees furyctl does not model
+	// (network, storage extras, systemd units, passwd, ...), so feed them the raw
+	// node from the furyctl.yaml rather than the lossy typed struct.
+	rawNodes, err := i.loadRawNodes()
+	if err != nil {
+		return fmt.Errorf("error loading node configuration: %w", err)
+	}
+
 	for _, node := range i.furyctlConf.Spec.Infrastructure.Nodes {
 		nodeRole := i.getNodeRole(node.Hostname)
 		normalizedMAC := strings.ToUpper(strings.ReplaceAll(string(node.MacAddress), ":", "-"))
+
+		rawNode, ok := rawNodes[node.Hostname]
+		if !ok {
+			return fmt.Errorf("%w: no configuration found for node %q", ErrImmutableConfigMalformed, node.Hostname)
+		}
 
 		sshPublicKeyContent, err := i.getSSHPublicKeyContent()
 		if err != nil {
@@ -327,7 +417,7 @@ func (i *Infrastructure) renderButaneTemplates() error {
 				"data": {
 					"SSHUser":        i.furyctlConf.Spec.Infrastructure.Ssh.Username,
 					"SSHPublicKey":   sshPublicKeyContent,
-					"node":           node,
+					"node":           rawNode,
 					"role":           nodeRole,
 					"flatcarVersion": immutableAssets.Flatcar.Version,
 					"ipxeServerURL":  i.furyctlConf.Spec.Infrastructure.IpxeServer.Url,

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package create
+
+import (
+	"errors"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// TestRawNodesByHostnamePassesThroughEveryField is the data-passthrough contract
+// for the butane phase: the raw node handed to the templates must carry every
+// sub-tree the templates read, including the free-form ones furyctl does not model
+// on its typed config struct (network.ethernets, storage.{files,links,directories,
+// additionalDisks}, systemd.units, passwd). If a future refactor reintroduces a
+// lossy typed round-trip, these assertions fail.
+func TestRawNodesByHostnamePassesThroughEveryField(t *testing.T) {
+	t.Parallel()
+
+	const sample = `
+spec:
+  infrastructure:
+    nodes:
+      - hostname: node01.example.com
+        macAddress: 52:54:00:10:00:01
+        arch: x86-64
+        kernelParameters:
+          - quiet
+        storage:
+          installDisk: /dev/sda
+          additionalDisks:
+            - device: /dev/sdb
+          files:
+            - path: /etc/example
+          links:
+            - path: /etc/link
+          directories:
+            - path: /etc/dir
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - 192.168.1.10/24
+        systemd:
+          units:
+            - name: example.service
+        passwd:
+          users:
+            - name: core
+`
+
+	var conf map[any]any
+	if err := yaml.Unmarshal([]byte(sample), &conf); err != nil {
+		t.Fatalf("unmarshal sample: %v", err)
+	}
+
+	nodes, err := rawNodesByHostname(conf)
+	if err != nil {
+		t.Fatalf("rawNodesByHostname: %v", err)
+	}
+
+	raw, ok := nodes["node01.example.com"].(map[any]any)
+	if !ok {
+		t.Fatalf("node not indexed by hostname, got %#v", nodes)
+	}
+
+	for _, key := range []string{"kernelParameters", "network", "systemd", "passwd", "storage"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("node sub-tree %q was not passed through", key)
+		}
+	}
+
+	network, ok := raw["network"].(map[any]any)
+	if !ok {
+		t.Fatalf("network is not a map, got %T", raw["network"])
+	}
+
+	if _, ok := network["ethernets"]; !ok {
+		t.Errorf("network.ethernets was not passed through")
+	}
+
+	storage, ok := raw["storage"].(map[any]any)
+	if !ok {
+		t.Fatalf("storage is not a map, got %T", raw["storage"])
+	}
+
+	for _, key := range []string{"installDisk", "additionalDisks", "files", "links", "directories"} {
+		if _, ok := storage[key]; !ok {
+			t.Errorf("storage.%s was not passed through", key)
+		}
+	}
+}
+
+// TestRawNodesByHostnameArchDefault guards the arch backfill: .node.arch is read
+// unguarded by the butane templates and the distribution schema defaults it to
+// x86-64, but furyctl does not apply JSON-schema defaults before this phase. A node
+// that omits arch (or leaves it blank) must come out as x86-64; an explicit arch
+// must be left untouched.
+func TestRawNodesByHostnameArchDefault(t *testing.T) {
+	t.Parallel()
+
+	const sample = `
+spec:
+  infrastructure:
+    nodes:
+      - hostname: omitted.example.com
+        storage:
+          installDisk: /dev/sda
+      - hostname: blank.example.com
+        arch: "  "
+        storage:
+          installDisk: /dev/sda
+      - hostname: explicit.example.com
+        arch: arm64
+        storage:
+          installDisk: /dev/sda
+`
+
+	var conf map[any]any
+	if err := yaml.Unmarshal([]byte(sample), &conf); err != nil {
+		t.Fatalf("unmarshal sample: %v", err)
+	}
+
+	nodes, err := rawNodesByHostname(conf)
+	if err != nil {
+		t.Fatalf("rawNodesByHostname: %v", err)
+	}
+
+	want := map[string]string{
+		"omitted.example.com":  defaultNodeArch,
+		"blank.example.com":    defaultNodeArch,
+		"explicit.example.com": "arm64",
+	}
+
+	for hostname, wantArch := range want {
+		node, ok := nodes[hostname].(map[any]any)
+		if !ok {
+			t.Fatalf("%s not indexed", hostname)
+		}
+
+		if got, _ := node["arch"].(string); got != wantArch {
+			t.Errorf("%s: arch = %q, want %q", hostname, got, wantArch)
+		}
+	}
+}
+
+func TestRawNodesByHostnameErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"missing spec":           `kind: Immutable`,
+		"missing infrastructure": "spec: {}",
+		"nodes not a list":       "spec:\n  infrastructure:\n    nodes: nope",
+		"node without hostname":  "spec:\n  infrastructure:\n    nodes:\n      - macAddress: x",
+	}
+
+	for name, sample := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var conf map[any]any
+			if err := yaml.Unmarshal([]byte(sample), &conf); err != nil {
+				t.Fatalf("unmarshal sample: %v", err)
+			}
+
+			if _, err := rawNodesByHostname(conf); !errors.Is(err, ErrImmutableConfigMalformed) {
+				t.Errorf("expected ErrImmutableConfigMalformed, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/apis/kfd/v1alpha2/immutable/public/schema.go
+++ b/internal/apis/kfd/v1alpha2/immutable/public/schema.go
@@ -44,6 +44,15 @@ type SpecInfrastructure struct {
 
 // SpecInfrastructureNode is referenced by name in furyctl (node ignition/boot
 // generation), so this type name must stay stable.
+//
+// Only the fields furyctl reads in Go are modeled here. The node butane templates
+// also consume several free-form sub-trees off the node (network.ethernets,
+// storage.{files,links,directories,additionalDisks}, systemd.units, passwd,
+// kernelParameters), but those are NOT modeled here on purpose: the butane phase
+// hands the templates the raw node decoded straight from the furyctl.yaml (see
+// create.rawNodesByHostname), so unmodeled fields reach the template intact.
+// Adding typed fields for them would just risk dropping their own sub-fields the
+// same way.
 type SpecInfrastructureNode struct {
 	Arch       Arch                          `yaml:"arch,omitempty"`
 	Hostname   string                        `yaml:"hostname"`

--- a/internal/apis/kfd/v1alpha2/immutable/public/schema_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/public/schema_test.go
@@ -14,7 +14,10 @@ import (
 
 // TestAntiDrift decodes a furyctl.yaml exercising the fields furyctl reads from
 // an Immutable config and asserts they decode (guards yaml-tag drift from the
-// distribution schema).
+// distribution schema). The free-form node sub-trees the butane templates consume
+// (network, storage extras, systemd and passwd) are intentionally not modeled on
+// this struct: they reach the templates via the raw furyctl.yaml handled by
+// create.rawNodesByHostname, so this test does not assert them.
 func TestAntiDrift(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Summary 💡

Pass raw node config to butane templates instead of the lossy typed struct

### Description 📝

The data-only schema refactor (#674) moved the config types into furyctl as a curated struct that models only the fields furyctl reads in Go.

The butane phase now feeds the templates the raw node decoded straight from furyctl.yaml instead of the typed struct, because they were relying on the full object.

The default arch (x86-64) for nodes that omit it is now being properly set so template rendering don't fail.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested Immutable cluster creation successfully that was previously failing with the following error:
```
error rendering butane templates: template: _helpers.tpl:52:32: executing "network" at <.node.network.ethernets>: map has no entry for key "network"
```

> [!NOTE]
> e2e are failing in CI because of terraform provider downloads timing out. Unrelated to this PR. The rest of the tests are OK.

### Future work 🔧

Make the nodes templates use the same features as the rest of the phases, so we can use _helpers, additional functions, etc.