### PR TITLE
chore: migrate tempo memcached resources

### DIFF
--- a/configs/upgrades/ekscluster/1.34.1-1.35.0/pre-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.34.1-1.35.0/pre-distribution.sh.tpl
@@ -8,3 +8,9 @@ kubectlbin="{{ .paths.kubectl }}"
 {{- if eq .spec.distribution.modules.policy.type "gatekeeper" }}
 $kubectlbin delete --ignore-not-found=true validatingwebhookconfiguration gatekeeper-validating-webhook-configuration
 {{- end }}
+
+# Migrate Tempo memcached resources for tracing module
+{{- if eq .spec.distribution.modules.tracing.type "tempo" }}
+$kubectlbin -n tracing delete --ignore-not-found=true service --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)'
+$kubectlbin -n tracing delete --ignore-not-found=true statefulset --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)' --cascade=orphan
+{{- end }}

--- a/configs/upgrades/ekscluster/1.34.2-1.35.0/pre-distribution.sh.tpl
+++ b/configs/upgrades/ekscluster/1.34.2-1.35.0/pre-distribution.sh.tpl
@@ -8,3 +8,9 @@ kubectlbin="{{ .paths.kubectl }}"
 {{- if eq .spec.distribution.modules.policy.type "gatekeeper" }}
 $kubectlbin delete --ignore-not-found=true validatingwebhookconfiguration gatekeeper-validating-webhook-configuration
 {{- end }}
+
+# Migrate Tempo memcached resources for tracing module
+{{- if eq .spec.distribution.modules.tracing.type "tempo" }}
+$kubectlbin -n tracing delete --ignore-not-found=true service --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)'
+$kubectlbin -n tracing delete --ignore-not-found=true statefulset --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)' --cascade=orphan
+{{- end }}

--- a/configs/upgrades/kfddistribution/1.34.1-1.35.0/pre-distribution.sh.tpl
+++ b/configs/upgrades/kfddistribution/1.34.1-1.35.0/pre-distribution.sh.tpl
@@ -8,3 +8,9 @@ kubectlbin="{{ .paths.kubectl }}"
 {{- if eq .spec.distribution.modules.policy.type "gatekeeper" }}
 $kubectlbin delete --ignore-not-found=true validatingwebhookconfiguration gatekeeper-validating-webhook-configuration
 {{- end }}
+
+# Migrate Tempo memcached resources for tracing module
+{{- if eq .spec.distribution.modules.tracing.type "tempo" }}
+$kubectlbin -n tracing delete --ignore-not-found=true service --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)'
+$kubectlbin -n tracing delete --ignore-not-found=true statefulset --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)' --cascade=orphan
+{{- end }}

--- a/configs/upgrades/kfddistribution/1.34.2-1.35.0/pre-distribution.sh.tpl
+++ b/configs/upgrades/kfddistribution/1.34.2-1.35.0/pre-distribution.sh.tpl
@@ -8,3 +8,9 @@ kubectlbin="{{ .paths.kubectl }}"
 {{- if eq .spec.distribution.modules.policy.type "gatekeeper" }}
 $kubectlbin delete --ignore-not-found=true validatingwebhookconfiguration gatekeeper-validating-webhook-configuration
 {{- end }}
+
+# Migrate Tempo memcached resources for tracing module
+{{- if eq .spec.distribution.modules.tracing.type "tempo" }}
+$kubectlbin -n tracing delete --ignore-not-found=true service --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)'
+$kubectlbin -n tracing delete --ignore-not-found=true statefulset --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)' --cascade=orphan
+{{- end }}

--- a/configs/upgrades/onpremises/1.34.1-1.35.0/pre-distribution.sh.tpl
+++ b/configs/upgrades/onpremises/1.34.1-1.35.0/pre-distribution.sh.tpl
@@ -8,3 +8,9 @@ kubectlbin="{{ .paths.kubectl }}"
 {{- if eq .spec.distribution.modules.policy.type "gatekeeper" }}
 $kubectlbin delete --ignore-not-found=true validatingwebhookconfiguration gatekeeper-validating-webhook-configuration
 {{- end }}
+
+# Migrate Tempo memcached resources for tracing module
+{{- if eq .spec.distribution.modules.tracing.type "tempo" }}
+$kubectlbin -n tracing delete --ignore-not-found=true service --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)'
+$kubectlbin -n tracing delete --ignore-not-found=true statefulset --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)' --cascade=orphan
+{{- end }}

--- a/configs/upgrades/onpremises/1.34.2-1.35.0/pre-distribution.sh.tpl
+++ b/configs/upgrades/onpremises/1.34.2-1.35.0/pre-distribution.sh.tpl
@@ -8,3 +8,9 @@ kubectlbin="{{ .paths.kubectl }}"
 {{- if eq .spec.distribution.modules.policy.type "gatekeeper" }}
 $kubectlbin delete --ignore-not-found=true validatingwebhookconfiguration gatekeeper-validating-webhook-configuration
 {{- end }}
+
+# Migrate Tempo memcached resources for tracing module
+{{- if eq .spec.distribution.modules.tracing.type "tempo" }}
+$kubectlbin -n tracing delete --ignore-not-found=true service --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)'
+$kubectlbin -n tracing delete --ignore-not-found=true statefulset --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)' --cascade=orphan
+{{- end }}


### PR DESCRIPTION
### Summary 💡

Add migrations steps for module tracing in case of tempo.


### Description 📝

https://github.com/sighupio/module-tracing/blob/main/docs/releases/v1.5.0.md#update-guide-

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

Tested the upgrade from 1.34.2 to [1.35](https://github.com/sighupio/distribution/tree/feat/release-v1.35.0):
```
{"level":"info","msg":"Running pre-distribution upgrade from v1.34.1 to v1.35.0...","time":"2026-06-26T11:09:07+02:00"}
{"level":"debug","action":"sh /Users/marco.paggioro/Projects/clusters/.furyctl/multipass/upgrades/1.34.1-1.35.0/pre-distribution.sh","msg":"service \"tempo-distributed-memcached\" deleted from tracing namespace\n","time":"2026-06-26T11:09:07+02:00"}
{"level":"debug","action":"sh /Users/marco.paggioro/Projects/clusters/.furyctl/multipass/upgrades/1.34.1-1.35.0/pre-distribution.sh","msg":"statefulset.apps \"tempo-distributed-memcached\" deleted from tracing namespace\n","time":"2026-06-26T11:09:07+02:00"}
```

### Future work 🔧

Not planned.