### PR TITLE
feat: relative path for customResources

### DIFF
--- a/pkg/template/model.go
+++ b/pkg/template/model.go
@@ -12,12 +12,18 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
 	iox "github.com/sighupio/furyctl/internal/x/io"
 	"github.com/sighupio/furyctl/pkg/template/mapper"
 	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
 )
+
+// distributionManifestsDir is the subdirectory of the distribution render target
+// where the main kustomization.yaml is written. Entries of
+// spec.distribution.customPatches.resources are resolved relative to it.
+const distributionManifestsDir = "manifests"
 
 var (
 	ErrTargetIsNotEmpty = errors.New("target directory is not empty")
@@ -128,6 +134,8 @@ func (tm *Model) Generate() error {
 	if err != nil {
 		return fmt.Errorf("error mapping dynamic values: %w", err)
 	}
+
+	tm.relativizeCustomResources(context)
 
 	tm.Context = context
 
@@ -249,4 +257,87 @@ func (tm *Model) generateContext() (map[string]map[any]any, error) {
 	}
 
 	return context, nil
+}
+
+// relativizeCustomResources rewrites spec.distribution.customResources so that
+// local filesystem paths are expressed relative to the rendered manifests
+// directory, which is what kustomize expects.
+//
+// By the time this runs, the mapper has already turned user-supplied relative paths
+// (e.g. "./foo") into absolute paths anchored at the furyctl config directory.
+// Kustomize, however, rejects absolute paths in its resources list and resolves
+// relative ones against the kustomization.yaml that declares them. We therefore
+// convert each local path into one relative to <TargetPath>/manifests, leaving the
+// referenced files in place so kustomize bases can still compose with their own
+// relative references (the distribution apply script builds with
+// --load-restrictor LoadRestrictionsNone).
+//
+// Remote resources (git/URL references) and entries that don't point to an existing
+// local file or directory are left untouched so kustomize can fetch or resolve them
+// itself. Emitting a path relative to the config directory (rather than an absolute
+// one) keeps the rendered output deterministic across machines, matching the
+// behaviour of relativeVendorPath.
+func (tm *Model) relativizeCustomResources(context map[string]map[any]any) {
+	resources, ok := customResources(context)
+	if !ok {
+		return
+	}
+
+	manifestsDir := filepath.Join(tm.TargetPath, distributionManifestsDir)
+	furyctlConfDir := filepath.Dir(tm.FuryctlConfPath)
+
+	for i, raw := range resources {
+		entry, ok := raw.(string)
+		if !ok || entry == "" {
+			continue
+		}
+
+		abs := entry
+		if !filepath.IsAbs(abs) {
+			abs = filepath.Join(furyctlConfDir, abs)
+		}
+
+		if _, err := os.Stat(abs); err != nil {
+			// Remote resource (git/URL) or non-existent path: leave it untouched
+			// so kustomize can fetch or resolve it.
+			continue
+		}
+
+		if rel, err := filepath.Rel(furyctlConfDir, abs); err == nil && strings.HasPrefix(rel, "..") {
+			logrus.Warnf(
+				"custom resource %q resolves outside the furyctl configuration directory; "+
+					"the rendered path may differ between machines. Consider keeping custom "+
+					"resources inside the project directory.",
+				entry,
+			)
+		}
+
+		rel, err := filepath.Rel(manifestsDir, abs)
+		if err != nil {
+			continue
+		}
+
+		resources[i] = rel
+	}
+}
+
+// customResources safely navigates to spec.distribution.customResources in the
+// template context and returns the underlying slice (mutable in place) when present.
+func customResources(context map[string]map[any]any) ([]any, bool) {
+	spec, ok := context["spec"]
+	if !ok {
+		return nil, false
+	}
+
+	distribution, ok := spec["distribution"].(map[any]any)
+	if !ok {
+		return nil, false
+	}
+
+	resources, ok := distribution["customResources"].([]any)
+	if !ok {
+		return nil, false
+	}
+
+	return resources, true
 }

--- a/pkg/template/model_test.go
+++ b/pkg/template/model_test.go
@@ -8,9 +8,11 @@ package template_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
 	"github.com/sighupio/furyctl/pkg/template"
@@ -53,3 +55,79 @@ func TestNewTemplateModel(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, tm)
 }
+
+func TestGenerate_RelativizesCustomResources(t *testing.T) {
+	root := t.TempDir()
+
+	// The furyctl config dir is the anchor for user-supplied relative paths.
+	furyctlConfPath := filepath.Join(root, "furyctl.yaml")
+	require.NoError(t, os.WriteFile(furyctlConfPath, []byte("apiVersion: test\n"), os.ModePerm))
+
+	// A local kustomize base sitting next to furyctl.yaml.
+	localBase := filepath.Join(root, "gapi-calico")
+	require.NoError(t, os.MkdirAll(localBase, os.ModePerm))
+
+	// The distribution render target; the kustomization lives under manifests/.
+	target := filepath.Join(root, ".furyctl", "cluster", "distribution")
+	manifestsDir := filepath.Join(target, distributionManifestsDirForTest)
+
+	remote := "github.com/sighupio/distribution//modules/auth?ref=v1.0.0"
+
+	conf := map[string]any{
+		"data": map[string]any{
+			"spec": map[string]any{
+				"distribution": map[string]any{
+					"customResources": []any{
+						"./gapi-calico",
+						remote,
+					},
+				},
+			},
+		},
+	}
+
+	confYaml, err := yaml.Marshal(conf)
+	require.NoError(t, err)
+
+	source := filepath.Join(root, "source", "manifests")
+	require.NoError(t, os.MkdirAll(source, os.ModePerm))
+
+	tpl := "resources:\n" +
+		"{{- range .spec.distribution.customResources }}\n" +
+		"  - {{ . }}\n" +
+		"{{- end }}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(source, "kustomization.yaml.tpl"), []byte(tpl), os.ModePerm))
+
+	configPath := filepath.Join(root, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, confYaml, os.ModePerm))
+
+	tm, err := template.NewTemplateModel(
+		filepath.Join(root, "source"),
+		target,
+		configPath,
+		root,
+		furyctlConfPath,
+		".tpl",
+		false,
+		false,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, tm.Generate())
+
+	rendered, err := os.ReadFile(filepath.Join(manifestsDir, "kustomization.yaml"))
+	require.NoError(t, err)
+
+	expectedRel, err := filepath.Rel(manifestsDir, localBase)
+	require.NoError(t, err)
+
+	// Local base is rewritten to a path relative to the manifests dir...
+	assert.Contains(t, string(rendered), "- "+expectedRel)
+	assert.NotContains(t, string(rendered), localBase) // ...not an absolute path.
+	// Remote resources pass through untouched.
+	assert.Contains(t, string(rendered), "- "+remote)
+}
+
+// distributionManifestsDirForTest mirrors the unexported constant in the package
+// under test; kept here so the external test does not depend on its value leaking.
+const distributionManifestsDirForTest = "manifests"


### PR DESCRIPTION
### Summary 💡

Add support for a new `spec.distribution.customResources` field that lets users inject extra Kustomize resources (local files, local kustomize bases, or remote git/URL references) into the distribution phase's main `kustomization.yaml`.

furyctl rewrites local resource paths so they are relative to the rendered manifests directory before templating, because `kustomize build` rejects absolute paths in its `resources` list (`new root ... cannot be absolute`).

Closes:

Relates:
- https://github.com/sighupio/distribution/pull/543

### Description 📝

`customResources` is a first-class sibling of `customPatches` under `spec.distribution` (I originally consider adding new field under `customPatches` but resources aren't patches, so they don't belong there). It is a flat array of strings, mirroring kustomize's own top-level `resources:` list:

```yaml
spec:
  distribution:
    customResources:
      - ./gapi-calico                          # local base, relative to furyctl.yaml
      - ../../plugins/kustomize/localstorage   # local base outside the project (warns)
      - github.com/org/repo//modules/x?ref=v1  # remote ref
```

The furyctl-side change is a single post-mapping step in the template engine, `relativizeCustomResources` in `pkg/template/model.go`, called in `Generate()` right after `MapDynamicValuesAndPaths()`. For each entry of `spec.distribution.customResources`:

- Local file/dir (resolves to an existing path) → rewritten to a path relative to `<TargetPath>/manifests` via `filepath.Rel`. The referenced files are left in place so kustomize bases keep composing with their own relative references (the distribution `apply.sh` already uses `--load-restrictor LoadRestrictionsNone`).
- Remote resource (git/URL) or non-existent path → left untouched so kustomize can fetch/resolve it itself.
- Path outside the furyctl config directory → still rewritten, but a warning is logged because the resulting relative path may differ between machines.

#### Design notes for reviewers

- The rewrite runs _after_ the mapper on purpose: the mapper has already turned the user's `./foo` inputs into absolute paths, and `TargetPath` (the render output location) is only known on the Model, never in the template context — so a custom template function could not have computed this.
- Local-vs-remote is classified with `os.Stat` rather than by parsing kustomize's git/URL grammar: existing paths are rewritten, everything else passes through.
- Emitting a path relative to the config directory (instead of an absolute one) keeps the rendered output deterministic across machines. Is up to the user to check those folder into git if applicable.
- I also considered copying the whole target directory into a `custom-resources` folder near the rest of the manifests inside the outdir, like we do for the `vendor`ed modules. This approach has several downsides:
  1. It "breaks" when the target folder relies on other folders as bases/resources. We would need to consider that and parse somehow to detect it and copy that too.
  2. We could have name collisions, so we would have to add some kind of hash that probably would've changed between machines.
  3. We could run a kustomize build of that folder and save it into an "`out.yaml`" file but it did not feel right.

### Breaking Changes 💔

None, new optional field.

### Tests performed 🧪

- [x] Tested adding custom resources: local files, local kustomize folders, remote files, remote git repos
- [x] Tested apply still works not setting the new field

### Future work 🔧

None