### PR TITLE
fix(template): warn once for custom resources outside config dir

### DIFF
--- a/pkg/template/model.go
+++ b/pkg/template/model.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -30,6 +31,14 @@ var (
 	errSourceMustbeSet  = errors.New("source must be set")
 	errTargetMustbeSet  = errors.New("target must be set")
 	errTemplateNotFound = errors.New("no template found")
+
+	// Tracks custom resource paths that have already triggered an "outside the
+	// configuration directory" warning. Templates are rendered several times during
+	// a single furyctl run (preflight, preupgrade, the distribution phase, ...), so
+	// this keeps the warning to once per path per run.
+	//
+	//nolint:gochecknoglobals // process-wide dedupe set for a user-facing warning.
+	warnedResourcesOutsideConfDir sync.Map
 )
 
 type Model struct {
@@ -304,12 +313,14 @@ func (tm *Model) relativizeCustomResources(context map[string]map[any]any) {
 		}
 
 		if rel, err := filepath.Rel(furyctlConfDir, abs); err == nil && strings.HasPrefix(rel, "..") {
-			logrus.Warnf(
-				"custom resource %q resolves outside the furyctl configuration directory; "+
-					"the rendered path may differ between machines. Consider keeping custom "+
-					"resources inside the project directory.",
-				entry,
-			)
+			if _, warned := warnedResourcesOutsideConfDir.LoadOrStore(abs, struct{}{}); !warned {
+				logrus.Warnf(
+					"custom resource %q resolves outside the furyctl configuration directory; "+
+						"the rendered path may differ between machines. Consider keeping custom "+
+						"resources inside the project directory.",
+					entry,
+				)
+			}
 		}
 
 		rel, err := filepath.Rel(manifestsDir, abs)


### PR DESCRIPTION
### Summary 💡

Warn only once the user when customResources are pointing outside the config dir.

Relates:
- #685 

### Description 📝

The "custom resource resolves outside the furyctl configuration directory" warning was emitted on every template render pass. Since the distribution templates are rendered several times during a single apply (preflight, preupgrade, distribution phase), the same warning showed up multiple times.

Track already-warned paths in a process-wide set so each out-of-project custom resource warns at most once per run, keyed by resolved absolute path so distinct resources still get their own warning.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested apply and verified that the warning shows up only once.

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

