### PR TITLE
fix(compatibility): update immutable compatibility range

### DIFF
--- a/internal/distribution/compatibility.go
+++ b/internal/distribution/compatibility.go
@@ -87,7 +87,7 @@ func getKFDCompatibleRanges() []VersionRange {
 
 func getImmutableCompatibleRanges() []VersionRange {
 	return []VersionRange{
-		{"v1.34.1", "v1.34.2"},
+		{"v1.34.2", "v1.34.2"},
 		{"v1.35.0", "v1.35.0"},
 	}
 }

--- a/internal/distribution/compatibility_test.go
+++ b/internal/distribution/compatibility_test.go
@@ -571,9 +571,9 @@ func TestImmutableCheckIsCompatible(t *testing.T) {
 		expected            bool
 	}{
 		{
-			name:                "should return true if distribution version is 1.34.1",
+			name:                "should return false if distribution version is 1.34.1",
 			distributionVersion: "v1.34.1",
-			expected:            true,
+			expected:            false,
 		},
 		{
 			name:                "should return false if distribution version is less than 1.34.1",


### PR DESCRIPTION
### Summary 💡

Immutable compatibility will be introduced with SD version 1.35.0 (and sibling 1.34.2)


### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that furcytl get supported-versions does not list immutable compatible wiht 1.34.1 any more.
- [x] Unit tests are passing

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

