### PR TITLE
feat(immutable): skip node boostrap when upgrading

### DIFF
--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
@@ -27,6 +27,7 @@ type Infrastructure struct {
 	*cluster.OperationPhase
 	paths         cluster.CreatorPaths
 	upgrade       *upgrade.Upgrade
+	upgradeNode   string
 	kfdManifest   config.KFD
 	furyctlConf   public.ImmutableKfdV1Alpha2
 	dryRun        bool
@@ -40,6 +41,7 @@ func NewInfrastructure(
 	configPath string,
 	distroPath string,
 	upgr *upgrade.Upgrade,
+	upgradeNode string,
 	furyctlConf public.ImmutableKfdV1Alpha2,
 	kfdManifest config.KFD,
 	paths cluster.CreatorPaths,
@@ -53,6 +55,7 @@ func NewInfrastructure(
 			DistroPath: distroPath,
 		},
 		upgrade:     upgr,
+		upgradeNode: upgradeNode,
 		furyctlConf: furyctlConf,
 		kfdManifest: kfdManifest,
 		dryRun:      dryRun,
@@ -70,6 +73,22 @@ func NewInfrastructure(
 
 // Exec executes the infrastructure phase.
 func (i *Infrastructure) Exec(_ string, upgradeState *upgrade.State) error {
+	if i.upgradeNode != "" {
+		logrus.Debug("node upgrade requested, skipping nodes bootstrap...")
+		logrus.Warn("Upgrade for Infrastructure phase (load balancers) not implemented yet...")
+
+		return nil
+	}
+
+	if i.upgrade.Enabled {
+		logrus.Debug("running an upgrade, skipping nodes bootstrap...")
+		logrus.Warn("Upgrade for Infrastructure phase not implemented yet")
+
+		upgradeState.Phases.Infrastructure.Status = upgrade.PhaseStatusSuccess
+
+		return nil
+	}
+
 	if err := i.BootstrapNodes(); err != nil {
 		return fmt.Errorf("preparing for infrastructure phase failed: %w", err)
 	}
@@ -162,12 +181,8 @@ func (i *Infrastructure) Exec(_ string, upgradeState *upgrade.State) error {
 	logrus.Info("Applying nodes configuration...")
 
 	// Run apply playbook.
-	if !i.upgrade.Enabled {
-		if _, err := i.ansibleRunner.Playbook("apply.yaml"); err != nil {
-			return fmt.Errorf("error applying playbook: %w", err)
-		}
-	} else {
-		upgradeState.Phases.Kubernetes.Status = upgrade.PhaseStatusSuccess
+	if _, err := i.ansibleRunner.Playbook("apply.yaml"); err != nil {
+		return fmt.Errorf("error applying playbook: %w", err)
 	}
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/immutable/creator.go
+++ b/internal/apis/kfd/v1alpha2/immutable/creator.go
@@ -172,6 +172,7 @@ func createInfrastructurePhase(c *ClusterCreator, upgr *upgrade.Upgrade) *create
 		c.paths.ConfigPath,
 		c.paths.DistroPath,
 		upgr,
+		c.upgradeNode,
 		c.furyctlConf,
 		c.kfdManifest,
 		c.paths,
@@ -617,6 +618,7 @@ func (c *ClusterCreator) extraPhases(
 func (*ClusterCreator) initUpgradeState() *upgrade.State {
 	return &upgrade.State{
 		Phases: upgrade.Phases{
+			Infrastructure:   &upgrade.Phase{Status: upgrade.PhaseStatusPending},
 			PreKubernetes:    &upgrade.Phase{Status: upgrade.PhaseStatusPending},
 			Kubernetes:       &upgrade.Phase{Status: upgrade.PhaseStatusPending},
 			PostKubernetes:   &upgrade.Phase{Status: upgrade.PhaseStatusPending},


### PR DESCRIPTION
### Summary 💡

Skip nodes bootstrap steps in the infrastructure phase when performing a whole cluster upgrade or a specific node upgrade.

### Description 📝

The nodes bootstrap and PXE Server steps are not currently needed while performing a cluster (or single node) upgrade. So we skip these steps in this case.

WARN the user that the upgrades for infrastructure phase are not yet implemented.

Also, we were setting the kubernetes phase upgrade as completed from the infrastructure phase. This has been fixed too.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Apply still works and runs the node bootstrap steps.
- [x] Upgrade and node upgrade skips the node bootstrap steps.

### Future work 🔧

Launch the upgrade playbooks for the infrastructure phase.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~ N.A.
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

