### PR TITLE
fix(immutable): skip infrastructure phase on dry-run

### DIFF
--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
@@ -73,6 +73,12 @@ func NewInfrastructure(
 
 // Exec executes the infrastructure phase.
 func (i *Infrastructure) Exec(_ string, upgradeState *upgrade.State) error {
+	if i.dryRun {
+		logrus.Info("Infrastructure configured successfully (dry-run mode)")
+
+		return nil
+	}
+
 	if i.upgradeNode != "" {
 		logrus.Debug("node upgrade requested, skipping nodes bootstrap...")
 		logrus.Warn("Upgrade for Infrastructure phase (load balancers) not implemented yet...")


### PR DESCRIPTION
### Summary 💡

`furyctl apply --upgrade --dry-run` panics on `immutable`. The infra phase's upgrade
branch writes `upgradeState.Phases.Infrastructure.Status`, but in dry-run that pointer
is never allocated (`initUpgradeState()` runs only when `upgr.Enabled && !dryRun`), so
it dereferences nil at `infrastructure.go:87`. 

Closes:

Relates:

### Description 📝

Adds an early `if i.dryRun { return nil }` at the top of `Infrastructure.Exec`,
matching the guard the kubernetes (`kubernetes.go:50`) and distribution
(`distribution.go:60`) phases already have. Non-dry-run upgrade path unchanged.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] `golangci-lint` + gofmt/gofumpt/goimports/gci clean.
