### PR TITLE
feat(immutable): node status table

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -47,7 +47,7 @@ func NewServeCmd() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			nodes := map[string]string{}
 
-			return serve.Path(viper.GetString("address"), viper.GetString("port"), viper.GetString("path"), &nodes)
+			return serve.Path(viper.GetString("address"), viper.GetString("port"), viper.GetString("path"), nodes)
 		},
 	}
 

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -165,7 +165,7 @@ func Path(address, port, root string, nodesStatus map[string]string) error {
 		"port":    port,
 		"root":    root,
 	}).Warn("Assets server started. You can boot your machines now")
-	logrus.Info("Note: you can press ENTER to skip waiting for all nodes to boot and continue or CTRL+C to cancel and exit at any time")
+	logrus.Info("To skip waiting for all nodes to boot and continue press ENTER or CTRL+C to cancel and exit at any time")
 
 	// Draw the initial table so every node shows up (as "pending") the moment the server is ready.
 	table.Start()

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -168,7 +168,7 @@ func Path(address, port, root string, nodesStatus map[string]string) error {
 		"port":    port,
 		"root":    root,
 	}).Warn("Assets server started. You can boot your machines now")
-	logrus.Info("To skip waiting for all nodes to boot and continue press ENTER or CTRL+C to cancel and exit at any time")
+	logrus.Info("Press ENTER to skip waiting and continue, or CTRL+C to cancel and exit.")
 
 	// Draw the initial table so every node shows up (as "pending") the moment the server is ready.
 	table.Start()

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -49,19 +49,20 @@ func (lrw *loggingResponseWriter) Write(b []byte) (int, error) {
 }
 
 // Start an HTTP server serving a path in the file system on a custom address and port, logging each request.
-// The server is stopped when the user presses ENTER.
-// Note: Path traversal attacks, serving directory listings, dot files, and other security vulnerabilities should be addressed.
+// The server stops when the user presses ENTER or once every node reports "booted".
 func Path(address, port, root string, nodesStatus *map[string]string) error {
-	// Channel to signal user requested stop (ENTER).
-	inputCh := make(chan struct{})
-
-	// Context to cancel the input goroutine when all nodes are booted.
+	// ENTER and all-nodes-booted both cancel this context to stop the server; cancel() is
+	// idempotent, so the two paths can't race into a double-stop panic.
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	// Nodes POST their boot status concurrently; guard the shared map and make the all-booted stop idempotent.
+	// Nodes POST their boot status concurrently; guard the shared map.
 	var statusMu sync.Mutex
 
 	var bootedOnce sync.Once
+
+	// Own mux (not http.DefaultServeMux) so repeated Path calls can't panic on re-registration.
+	mux := http.NewServeMux()
 
 	fs := http.FileServer(http.Dir(root))
 
@@ -89,7 +90,7 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 		}).Debug("served asset request")
 	})
 
-	// Wrap the file server with a logging handler that logs each request.
+	// Serves the /status endpoint: GET returns the node status map, POST records an update.
 	statusHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Use package-level loggingResponseWriter.
 		lrw := &loggingResponseWriter{ResponseWriter: w}
@@ -157,7 +158,7 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 				logrus.Infof("Node %s is %s", node, status)
 			}
 
-			// Check if all nodes are in "booted" status and log if so.
+			// Check if all nodes are in "booted" status and stop the server if so.
 			statusMu.Lock()
 			allBooted := true
 
@@ -175,15 +176,14 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 			if allBooted {
 				bootedOnce.Do(func() {
 					logrus.Infof("All %d nodes reached 'booted' state. Stopping server and continuing...", nodeCount)
-					close(inputCh)
 					cancel()
 				})
 			}
 		}
 	})
 
-	http.Handle("/status", statusHandler)
-	http.Handle("/", typedHandler)
+	mux.Handle("/status", statusHandler)
+	mux.Handle("/", typedHandler)
 
 	listenAddr := strings.Join([]string{address, port}, ":")
 	logrus.WithFields(logrus.Fields{
@@ -191,49 +191,42 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 		"port":    port,
 		"root":    root,
 	}).Warn("Assets server started. You can boot your machines now")
-	logrus.Info("You can press ENTER to stop the server at any time and continue or CTRL+C to cancel and exit")
+	logrus.Info("Note: you can press ENTER to skip waiting for all nodes to boot and continue or CTRL+C to cancel and exit at any time")
 
 	const readHeaderTimeout = 5 * time.Second
 
 	// Create server so we can control shutdown and inspect errors.
-	srv := &http.Server{Addr: listenAddr, Handler: nil, ReadHeaderTimeout: readHeaderTimeout}
+	srv := &http.Server{Addr: listenAddr, Handler: mux, ReadHeaderTimeout: readHeaderTimeout}
 
 	// Channel to receive server errors.
 	errCh := make(chan error, 1)
 	go func() {
 		// ListenAndServe returns http.ErrServerClosed on graceful shutdown.
-		err := srv.ListenAndServe()
-		errCh <- err
+		errCh <- srv.ListenAndServe()
 	}()
+
+	// Stop the server when the operator presses ENTER. A read error (e.g. EOF on a
+	// non-interactive stdin) is not fatal: keep serving until all nodes have booted.
 	go func() {
-		done := make(chan struct{})
-		go func() {
-			_, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
-			if err != nil {
-				errCh <- err
-			}
+		if _, err := bufio.NewReader(os.Stdin).ReadBytes('\n'); err != nil {
+			logrus.Debugf("stopped watching stdin for the stop signal: %v", err)
 
-			close(done)
-		}()
-		select {
-		case <-ctx.Done():
-			// All nodes booted, stop waiting for user input.
 			return
-
-		case <-done:
-			close(inputCh)
 		}
+
+		cancel()
 	}()
 
-	// Wait for either user input or server error.
+	// Wait for either a stop request (ENTER / all nodes booted) or a server error.
 	select {
-	case <-inputCh:
+	case <-ctx.Done():
 		const shutdownTimeout = 5 * time.Second
-		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 
-		defer cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 
-		if err := srv.Shutdown(ctx); err != nil {
+		defer shutdownCancel()
+
+		if err := srv.Shutdown(shutdownCtx); err != nil {
 			return fmt.Errorf("error during server shutdown: %w", err)
 		}
 

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -50,14 +50,14 @@ func (lrw *loggingResponseWriter) Write(b []byte) (int, error) {
 
 // Start an HTTP server serving a path in the file system on a custom address and port, logging each request.
 // The server stops when the user presses ENTER or once every node reports "booted".
-func Path(address, port, root string, nodesStatus *map[string]string) error {
+func Path(address, port, root string, nodesStatus map[string]string) error {
 	// ENTER and all-nodes-booted both cancel this context to stop the server; cancel() is
 	// idempotent, so the two paths can't race into a double-stop panic.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Nodes POST their boot status concurrently; guard the shared map.
-	var statusMu sync.Mutex
+	// Live view of node bootstrap status; owns its own locking for concurrent status POSTs.
+	table := newNodeStatusTable(nodesStatus)
 
 	var bootedOnce sync.Once
 
@@ -100,10 +100,7 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 			lrw.WriteHeader(http.StatusOK)
 			encoder := json.NewEncoder(lrw)
 
-			statusMu.Lock()
-			err := encoder.Encode(*nodesStatus)
-			statusMu.Unlock()
-
+			err := encoder.Encode(table.Snapshot())
 			if err != nil {
 				logrus.Errorf("error while encoding response: %s", err)
 			} else {
@@ -136,11 +133,7 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 				return
 			}
 
-			statusMu.Lock()
-			(*nodesStatus)[node] = status
-			statusMu.Unlock()
-
-			// Log relevant request/response information.
+			// Debug log for the machine-readable history; the human-facing view is the table.
 			logrus.WithFields(logrus.Fields{
 				"remote":     r.RemoteAddr,
 				"user-agent": r.Header.Get("User-Agent"),
@@ -152,30 +145,11 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 				"nodeStatus": status,
 			}).Debug("received node status update")
 
-			if status == "installation-blocked" {
-				logrus.Errorf("Flatcar Installation on node %s is blocked because Flatcar is already installed on disk. Manual intervention required", node)
-			} else {
-				logrus.Infof("Node %s is %s", node, status)
-			}
+			table.Update(node, status)
 
-			// Check if all nodes are in "booted" status and stop the server if so.
-			statusMu.Lock()
-			allBooted := true
-
-			for _, s := range *nodesStatus {
-				if s != "booted" {
-					allBooted = false
-
-					break
-				}
-			}
-
-			nodeCount := len(*nodesStatus)
-			statusMu.Unlock()
-
-			if allBooted {
+			if table.AllBooted() {
 				bootedOnce.Do(func() {
-					logrus.Infof("All %d nodes reached 'booted' state. Stopping server and continuing...", nodeCount)
+					logrus.Infof("All %d nodes reached 'booted' state. Stopping server and continuing...", table.Len())
 					cancel()
 				})
 			}
@@ -192,6 +166,9 @@ func Path(address, port, root string, nodesStatus *map[string]string) error {
 		"root":    root,
 	}).Warn("Assets server started. You can boot your machines now")
 	logrus.Info("Note: you can press ENTER to skip waiting for all nodes to boot and continue or CTRL+C to cancel and exit at any time")
+
+	// Draw the initial table so every node shows up (as "pending") the moment the server is ready.
+	table.Start()
 
 	const readHeaderTimeout = 5 * time.Second
 

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -95,7 +95,8 @@ func Path(address, port, root string, nodesStatus map[string]string) error {
 		// Use package-level loggingResponseWriter.
 		lrw := &loggingResponseWriter{ResponseWriter: w}
 
-		if r.Method == http.MethodGet {
+		switch r.Method {
+		case http.MethodGet:
 			lrw.Header().Set("Content-Type", "application/json")
 			lrw.WriteHeader(http.StatusOK)
 			encoder := json.NewEncoder(lrw)
@@ -113,9 +114,8 @@ func Path(address, port, root string, nodesStatus map[string]string) error {
 					"bytes":      lrw.bytes,
 				}).Debug("served nodes status")
 			}
-		}
 
-		if r.Method == http.MethodPost {
+		case http.MethodPost:
 			lrw.WriteHeader(http.StatusNoContent)
 
 			// Update node status based on query parameters.
@@ -153,6 +153,9 @@ func Path(address, port, root string, nodesStatus map[string]string) error {
 					cancel()
 				})
 			}
+
+		default:
+			lrw.WriteHeader(http.StatusMethodNotAllowed)
 		}
 	})
 

--- a/cmd/serve/status_table.go
+++ b/cmd/serve/status_table.go
@@ -231,7 +231,7 @@ func (t *nodeStatusTable) lines() []string {
 	for _, node := range t.order {
 		if t.status[node] == statusInstallationBlocked {
 			lines = append(lines, "  ! "+node+
-				": installation blocked: Flatcar is already installed on disk. Manual intervention required.")
+				": Flatcar is already installed on disk. Manual intervention required.")
 		}
 	}
 

--- a/cmd/serve/status_table.go
+++ b/cmd/serve/status_table.go
@@ -22,6 +22,10 @@ import (
 )
 
 const (
+	// StatusPending is the initial status every node is seeded with before it reports in.
+	// Exported because the caller building the seed map produces it; the other statuses are
+	// reported by the nodes and only consumed here.
+	StatusPending = "pending"
 	// Terminal status a node reports once it has booted into the installed OS.
 	statusBooted = "booted"
 	// Reported when Flatcar is already installed on disk and the installer refuses to
@@ -43,7 +47,6 @@ type nodeStatusTable struct {
 	order     []string             // Node hostnames in stable (sorted) order.
 	status    map[string]string    // Hostname to last reported status.
 	updatedAt map[string]time.Time // Hostname to when that status last changed.
-	notes     map[string]string    // Hostname to attention line (blocked install); cleared on recovery.
 
 	linesDrawn int // Rows painted by the previous render, so the next one knows how far up to move.
 }
@@ -67,11 +70,10 @@ var newNodeStatusTable = func(initial map[string]string) *nodeStatusTable {
 
 	return &nodeStatusTable{
 		out:       f,
-		tty:       !execx.NoTTY && logrus.GetLevel() < logrus.DebugLevel && term.IsTerminal(int(f.Fd())),
+		tty:       execx.ShouldAnimate(f),
 		order:     order,
 		status:    status,
 		updatedAt: make(map[string]time.Time, len(initial)),
-		notes:     make(map[string]string, len(initial)),
 	}
 }
 
@@ -100,13 +102,6 @@ func (t *nodeStatusTable) Update(node, status string) {
 	t.status[node] = status
 	t.updatedAt[node] = time.Now()
 
-	if status == statusInstallationBlocked {
-		t.notes[node] = node + ": Flatcar is already installed on disk; installation blocked, manual intervention required."
-	} else {
-		// The node moved on from a blocked install: drop its stale attention note.
-		delete(t.notes, node)
-	}
-
 	if !t.tty {
 		if status == statusInstallationBlocked {
 			logrus.Errorf(
@@ -129,17 +124,7 @@ func (t *nodeStatusTable) AllBooted() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if len(t.order) == 0 {
-		return false
-	}
-
-	for _, st := range t.status {
-		if st != statusBooted {
-			return false
-		}
-	}
-
-	return true
+	return len(t.order) > 0 && t.bootedCount() == len(t.order)
 }
 
 // Len returns the number of tracked nodes.
@@ -234,17 +219,19 @@ func (t *nodeStatusTable) lines() []string {
 
 	_ = w.Flush()
 
-	lines := make([]string, 0, len(t.order)+len(t.notes))
+	lines := make([]string, 0, len(t.order)+1)
 	lines = append(lines, fmt.Sprintf("Nodes bootstrap status — %d/%d booted", t.bootedCount(), len(t.order)))
 
 	for _, row := range strings.Split(strings.TrimRight(sb.String(), "\n"), "\n") {
 		lines = append(lines, "  "+row)
 	}
 
-	// Draw notes in node order (stable), skipping nodes with none.
+	// Draw attention notes in node order (stable) for nodes with a blocked install; a node that
+	// later recovers is no longer blocked, so its note simply stops being emitted.
 	for _, node := range t.order {
-		if note, ok := t.notes[node]; ok {
-			lines = append(lines, "  ! "+note)
+		if t.status[node] == statusInstallationBlocked {
+			lines = append(lines, "  ! "+node+
+				": installation blocked: Flatcar is already installed on disk. Manual intervention required.")
 		}
 	}
 

--- a/cmd/serve/status_table.go
+++ b/cmd/serve/status_table.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package serve
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/term"
+
+	execx "github.com/sighupio/furyctl/internal/x/exec"
+)
+
+const (
+	// Terminal status a node reports once it has booted into the installed OS.
+	statusBooted = "booted"
+	// Reported when Flatcar is already installed on disk and the installer refuses to
+	// overwrite it; needs operator attention.
+	statusInstallationBlocked = "installation-blocked"
+
+	// Wall-clock format shown in the "UPDATED" column.
+	updatedTimeLayout = "15:04:05"
+)
+
+// nodeStatusTable renders a live, in-place table of node bootstrap status on a terminal
+// (cursor-up + clear-line repaint), falling back to one log line per update under --debug/--no-tty.
+type nodeStatusTable struct {
+	mu  sync.Mutex
+	out io.Writer
+	// True only when the table can be animated; false on non-terminals, --no-tty and --debug.
+	tty bool
+
+	order     []string             // Node hostnames in stable (sorted) order.
+	status    map[string]string    // Hostname to last reported status.
+	updatedAt map[string]time.Time // Hostname to when that status last changed.
+	notes     map[string]string    // Hostname to attention line (blocked install); cleared on recovery.
+
+	linesDrawn int // Rows painted by the previous render, so the next one knows how far up to move.
+}
+
+// newNodeStatusTable seeds the table from the initial hostname->status map (typically every node at
+// "pending"). It is a package var, not a plain func, so tests can swap in a buffer-backed table.
+//
+//nolint:gochecknoglobals // Overridable constructor so tests can inject a buffer-backed table.
+var newNodeStatusTable = func(initial map[string]string) *nodeStatusTable {
+	f := os.Stderr
+
+	order := make([]string, 0, len(initial))
+	status := make(map[string]string, len(initial))
+
+	for node, st := range initial {
+		order = append(order, node)
+		status[node] = st
+	}
+
+	sort.Strings(order)
+
+	return &nodeStatusTable{
+		out:       f,
+		tty:       !execx.NoTTY && logrus.GetLevel() < logrus.DebugLevel && term.IsTerminal(int(f.Fd())),
+		order:     order,
+		status:    status,
+		updatedAt: make(map[string]time.Time, len(initial)),
+		notes:     make(map[string]string, len(initial)),
+	}
+}
+
+// Start draws the initial table once, so the operator sees every node (as "pending") the moment the
+// server is ready. No-op when not animating.
+func (t *nodeStatusTable) Start() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.tty {
+		t.render()
+	}
+}
+
+// Update records a node's new status and repaints (TTY) or logs it (non-TTY).
+func (t *nodeStatusTable) Update(node, status string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if _, known := t.status[node]; !known {
+		// A node we didn't seed: keep it visible rather than dropping the update.
+		t.order = append(t.order, node)
+		sort.Strings(t.order)
+	}
+
+	t.status[node] = status
+	t.updatedAt[node] = time.Now()
+
+	if status == statusInstallationBlocked {
+		t.notes[node] = node + ": Flatcar is already installed on disk; installation blocked, manual intervention required."
+	} else {
+		// The node moved on from a blocked install: drop its stale attention note.
+		delete(t.notes, node)
+	}
+
+	if !t.tty {
+		if status == statusInstallationBlocked {
+			logrus.Errorf(
+				"Flatcar Installation on node %s is blocked because Flatcar is already installed on disk. "+
+					"Manual intervention required",
+				node,
+			)
+		} else {
+			logrus.Infof("Node %s is %s", node, status)
+		}
+
+		return
+	}
+
+	t.render()
+}
+
+// AllBooted reports whether every known node has reached the "booted" state.
+func (t *nodeStatusTable) AllBooted() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.order) == 0 {
+		return false
+	}
+
+	for _, st := range t.status {
+		if st != statusBooted {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Len returns the number of tracked nodes.
+func (t *nodeStatusTable) Len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return len(t.order)
+}
+
+// Snapshot returns a copy of the current hostname->status map for the /status GET endpoint.
+func (t *nodeStatusTable) Snapshot() map[string]string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	out := make(map[string]string, len(t.status))
+	for node, st := range t.status {
+		out[node] = st
+	}
+
+	return out
+}
+
+// bootedCount returns how many nodes are booted. Caller holds t.mu.
+func (t *nodeStatusTable) bootedCount() int {
+	n := 0
+
+	for _, st := range t.status {
+		if st == statusBooted {
+			n++
+		}
+	}
+
+	return n
+}
+
+// render repaints the table in place. Caller holds t.mu and t.tty is true.
+func (t *nodeStatusTable) render() {
+	lines := t.lines()
+	prev := t.linesDrawn
+	width := t.termWidth()
+
+	out := make([]string, 0, len(lines))
+
+	// Move the cursor back up to the first row of the previously drawn table.
+	if prev > 0 {
+		out = append(out, cursorUp(prev))
+	}
+
+	// \033[2K clears each row; truncate so a wrapped line can't desync the cursor math.
+	for _, line := range lines {
+		out = append(out, "\033[2K"+truncateLine(line, width)+"\n")
+	}
+
+	// The table can shrink when an attention note clears on recovery: erase the now-orphaned rows
+	// the previous, larger render left behind, then step back up to just below the current table.
+	if extra := prev - len(lines); extra > 0 {
+		out = append(out, strings.Repeat("\033[2K\n", extra), cursorUp(extra))
+	}
+
+	t.linesDrawn = len(lines)
+
+	_, _ = fmt.Fprint(t.out, strings.Join(out, ""))
+}
+
+// cursorUp returns the ANSI escape that moves the cursor up n rows.
+func cursorUp(n int) string {
+	return "\033[" + strconv.Itoa(n) + "A"
+}
+
+// lines builds the full table: a title, the tab-aligned node rows, then any attention notes.
+// Caller holds t.mu.
+func (t *nodeStatusTable) lines() []string {
+	const tabPadding = 2
+
+	// Let tabwriter align the columns; we split its output back into individual lines so the
+	// in-place repaint can clear and truncate each row.
+	var sb strings.Builder
+
+	w := tabwriter.NewWriter(&sb, 0, 0, tabPadding, ' ', 0)
+
+	_, _ = fmt.Fprintf(w, "NODE\tSTATUS\tUPDATED\n")
+
+	for _, node := range t.order {
+		updated := "—"
+		if ts, ok := t.updatedAt[node]; ok {
+			updated = ts.Format(updatedTimeLayout)
+		}
+
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", node, t.status[node], updated)
+	}
+
+	_ = w.Flush()
+
+	lines := make([]string, 0, len(t.order)+len(t.notes))
+	lines = append(lines, fmt.Sprintf("Nodes bootstrap status — %d/%d booted", t.bootedCount(), len(t.order)))
+
+	for _, row := range strings.Split(strings.TrimRight(sb.String(), "\n"), "\n") {
+		lines = append(lines, "  "+row)
+	}
+
+	// Draw notes in node order (stable), skipping nodes with none.
+	for _, node := range t.order {
+		if note, ok := t.notes[node]; ok {
+			lines = append(lines, "  ! "+note)
+		}
+	}
+
+	return lines
+}
+
+// termWidth returns the terminal width, or 0 when it can't be determined (meaning: don't truncate).
+func (t *nodeStatusTable) termWidth() int {
+	f, ok := t.out.(*os.File)
+	if !ok {
+		return 0
+	}
+
+	w, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || w <= 0 {
+		return 0
+	}
+
+	return w
+}
+
+// truncateLine clips a line to width runes so it can't wrap (a wrap would break the cursor-up count).
+func truncateLine(line string, width int) string {
+	if width <= 0 {
+		return line
+	}
+
+	r := []rune(line)
+	if len(r) <= width {
+		return line
+	}
+
+	if width <= 1 {
+		return string(r[:width])
+	}
+
+	return string(r[:width-1]) + "…"
+}

--- a/cmd/serve/status_table_test.go
+++ b/cmd/serve/status_table_test.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package serve
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// newTestTable builds a buffer-backed table with animation forced on, so tests can inspect the
+// exact bytes a terminal would receive.
+func newTestTable(buf *bytes.Buffer, initial map[string]string) *nodeStatusTable {
+	real := newNodeStatusTable(initial)
+	real.out = buf
+	real.tty = true
+
+	return real
+}
+
+func TestNodeStatusTableRendersRowsAndCounts(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	table := newTestTable(&buf, map[string]string{"cp1.flatcar": "pending", "cp2.flatcar": "pending"})
+
+	table.Start()
+
+	out := buf.String()
+	if !strings.Contains(out, "Nodes bootstrap status — 0/2 booted") {
+		t.Fatalf("initial render missing title with counts, got:\n%q", out)
+	}
+
+	for _, want := range []string{"NODE", "STATUS", "UPDATED", "cp1.flatcar", "cp2.flatcar", "pending", "—"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("initial render missing %q, got:\n%q", want, out)
+		}
+	}
+}
+
+func TestNodeStatusTableUpdateRepaintsInPlace(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	table := newTestTable(&buf, map[string]string{"cp1.flatcar": "pending", "cp2.flatcar": "pending"})
+
+	table.Start() // title + header + 2 rows = 4 lines.
+
+	buf.Reset()
+	table.Update("cp1.flatcar", statusBooted)
+
+	out := buf.String()
+
+	// The repaint must move the cursor up over the 4 previously drawn lines before redrawing.
+	if !strings.Contains(out, "\033[4A") {
+		t.Fatalf("repaint did not move cursor up 4 lines, got:\n%q", out)
+	}
+
+	if !strings.Contains(out, "Nodes bootstrap status — 1/2 booted") {
+		t.Fatalf("repaint did not update booted count, got:\n%q", out)
+	}
+
+	if !strings.Contains(out, "booted") {
+		t.Fatalf("repaint did not show booted status, got:\n%q", out)
+	}
+}
+
+func TestNodeStatusTableAllBooted(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	table := newTestTable(&buf, map[string]string{"cp1.flatcar": "pending", "cp2.flatcar": "pending"})
+
+	if table.AllBooted() {
+		t.Fatal("AllBooted must be false while nodes are pending")
+	}
+
+	table.Update("cp1.flatcar", statusBooted)
+
+	if table.AllBooted() {
+		t.Fatal("AllBooted must be false while one node is still pending")
+	}
+
+	table.Update("cp2.flatcar", statusBooted)
+
+	if !table.AllBooted() {
+		t.Fatal("AllBooted must be true once every node is booted")
+	}
+}
+
+func TestNodeStatusTableAllBootedEmpty(t *testing.T) {
+	t.Parallel()
+
+	table := newTestTable(&bytes.Buffer{}, map[string]string{})
+
+	if table.AllBooted() {
+		t.Fatal("AllBooted must be false with no nodes")
+	}
+}
+
+func TestNodeStatusTableBlockedInstallAddsNote(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	table := newTestTable(&buf, map[string]string{"cp1.flatcar": "pending"})
+
+	table.Start()
+	buf.Reset()
+	table.Update("cp1.flatcar", statusInstallationBlocked)
+
+	out := buf.String()
+	if !strings.Contains(out, "manual intervention required") {
+		t.Fatalf("blocked install did not surface an attention note, got:\n%q", out)
+	}
+}
+
+// replayANSI applies the subset of terminal control sequences the table emits (cursor-up "\033[nA",
+// clear-line "\033[2K", newline) to reconstruct the final visible screen, so tests can assert what a
+// terminal would actually show after a series of in-place repaints. Returns non-empty screen lines.
+func replayANSI(data string) []string {
+	var screen []string
+
+	row := 0
+
+	ensure := func(r int) {
+		for len(screen) <= r {
+			screen = append(screen, "")
+		}
+	}
+
+	for i := 0; i < len(data); {
+		switch {
+		case strings.HasPrefix(data[i:], "\033["):
+			j := i + 2
+			for j < len(data) && data[j] >= '0' && data[j] <= '9' {
+				j++
+			}
+
+			num := 0
+			if j > i+2 {
+				_, _ = fmt.Sscanf(data[i+2:j], "%d", &num)
+			}
+
+			switch data[j] {
+			case 'A':
+				if row -= num; row < 0 {
+					row = 0
+				}
+			case 'K':
+				ensure(row)
+				screen[row] = ""
+			}
+
+			i = j + 1
+
+		case data[i] == '\n':
+			row++
+
+			ensure(row)
+
+			i++
+
+		default:
+			k := i
+			for k < len(data) && data[k] != '\n' && data[k] != '\033' {
+				k++
+			}
+
+			ensure(row)
+
+			screen[row] += data[i:k]
+			i = k
+		}
+	}
+
+	out := make([]string, 0, len(screen))
+
+	for _, line := range screen {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+
+	return out
+}
+
+func TestNodeStatusTableShrinksCleanlyWithMultipleNotes(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	table := newTestTable(&buf, map[string]string{
+		"cp1.flatcar": "pending", "cp2.flatcar": "pending", "cp3.flatcar": "pending",
+		"node1.flatcar": "pending", "node2.flatcar": "pending",
+	})
+
+	table.Start()
+
+	// Two nodes hit the blocked state, then both are intervened on and boot.
+	table.Update("cp1.flatcar", statusInstallationBlocked)
+	table.Update("node1.flatcar", statusInstallationBlocked)
+
+	// Reproduce the reported bug: after the notes appear, replay the full stream and confirm both.
+	if blocked := countLinesContaining(replayANSI(buf.String()), "manual intervention required"); blocked != 2 {
+		t.Fatalf("expected 2 distinct attention notes while blocked, got %d", blocked)
+	}
+
+	table.Update("cp1.flatcar", statusBooted)
+	table.Update("node1.flatcar", statusBooted)
+
+	screen := replayANSI(buf.String())
+
+	if blocked := countLinesContaining(screen, "manual intervention required"); blocked != 0 {
+		t.Fatalf("attention notes lingered after both nodes recovered:\n%s", strings.Join(screen, "\n"))
+	}
+
+	// No node row must be duplicated on the final screen.
+	if dup := countLinesContaining(screen, "node1.flatcar"); dup != 1 {
+		t.Fatalf("node1.flatcar row appears %d times, expected exactly 1:\n%s", dup, strings.Join(screen, "\n"))
+	}
+}
+
+func countLinesContaining(lines []string, sub string) int {
+	n := 0
+
+	for _, line := range lines {
+		if strings.Contains(line, sub) {
+			n++
+		}
+	}
+
+	return n
+}
+
+func TestNodeStatusTableNoteClearedOnRecovery(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	table := newTestTable(&buf, map[string]string{"cp1.flatcar": "pending"})
+
+	table.Update("cp1.flatcar", statusInstallationBlocked)
+
+	// The node was intervened on and now boots: its attention note must disappear.
+	buf.Reset()
+	table.Update("cp1.flatcar", statusBooted)
+
+	if out := buf.String(); strings.Contains(out, "manual intervention required") {
+		t.Fatalf("attention note lingered after the node recovered, got:\n%q", out)
+	}
+}
+
+func TestNodeStatusTableSnapshotIsACopy(t *testing.T) {
+	t.Parallel()
+
+	table := newTestTable(&bytes.Buffer{}, map[string]string{"cp1.flatcar": "pending"})
+
+	snap := table.Snapshot()
+	snap["cp1.flatcar"] = "tampered"
+
+	if again := table.Snapshot(); again["cp1.flatcar"] != "pending" {
+		t.Fatalf("Snapshot must return an independent copy, got %q", again["cp1.flatcar"])
+	}
+}
+
+func TestTruncateLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		line  string
+		width int
+		want  string
+	}{
+		{"no truncation when width is zero", "hello world", 0, "hello world"},
+		{"no truncation when it fits", "hello", 10, "hello"},
+		{"truncates with ellipsis", "hello world", 5, "hell…"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := truncateLine(tt.line, tt.width); got != tt.want {
+				t.Fatalf("truncateLine(%q, %d) = %q, want %q", tt.line, tt.width, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/serve/status_table_test.go
+++ b/cmd/serve/status_table_test.go
@@ -118,7 +118,7 @@ func TestNodeStatusTableBlockedInstallAddsNote(t *testing.T) {
 	table.Update("cp1.flatcar", statusInstallationBlocked)
 
 	out := buf.String()
-	if !strings.Contains(out, "manual intervention required") {
+	if !strings.Contains(out, "Manual intervention required") {
 		t.Fatalf("blocked install did not surface an attention note, got:\n%q", out)
 	}
 }
@@ -210,7 +210,7 @@ func TestNodeStatusTableShrinksCleanlyWithMultipleNotes(t *testing.T) {
 	table.Update("node1.flatcar", statusInstallationBlocked)
 
 	// Reproduce the reported bug: after the notes appear, replay the full stream and confirm both.
-	if blocked := countLinesContaining(replayANSI(buf.String()), "manual intervention required"); blocked != 2 {
+	if blocked := countLinesContaining(replayANSI(buf.String()), "Manual intervention required"); blocked != 2 {
 		t.Fatalf("expected 2 distinct attention notes while blocked, got %d", blocked)
 	}
 
@@ -219,7 +219,7 @@ func TestNodeStatusTableShrinksCleanlyWithMultipleNotes(t *testing.T) {
 
 	screen := replayANSI(buf.String())
 
-	if blocked := countLinesContaining(screen, "manual intervention required"); blocked != 0 {
+	if blocked := countLinesContaining(screen, "Manual intervention required"); blocked != 0 {
 		t.Fatalf("attention notes lingered after both nodes recovered:\n%s", strings.Join(screen, "\n"))
 	}
 
@@ -254,7 +254,7 @@ func TestNodeStatusTableNoteClearedOnRecovery(t *testing.T) {
 	buf.Reset()
 	table.Update("cp1.flatcar", statusBooted)
 
-	if out := buf.String(); strings.Contains(out, "manual intervention required") {
+	if out := buf.String(); strings.Contains(out, "Manual intervention required") {
 		t.Fatalf("attention note lingered after the node recovered, got:\n%q", out)
 	}
 }

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,15 @@
+# furyctl release vTBD
+
+Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
+
+## New features 🌟
+
+TBD
+
+## Bug fixes 🐞
+
+- [[#695](https://github.com/sighupio/furyctl/pull/695)] Immutable: fixed a panic that may occur if the user pressed ENTER to while waiting the nodes to be provisioned and a node sent a status update in the 5 seconds shutdown window.
+
+## Breaking Changes 💔
+
+TBD

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -4,7 +4,7 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 
 ## New features 🌟
 
-TBD
+- [[#696](https://github.com/sighupio/furyctl/pull/696)] Immutable: show a dynamic table for the nodes provisioning phase instead of single line logs so the user does not need to mentally track the status of the nodes.
 
 ## Bug fixes 🐞
 

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
@@ -180,7 +180,7 @@ func (i *Infrastructure) Exec(_ string, upgradeState *upgrade.State) error {
 		ipxeServerPort = ipxeServer.Port()
 	}
 
-	if err := serve.Path(ipxeServerHost, ipxeServerPort, filepath.Join(i.Path, "server"), &nodeStatus); err != nil {
+	if err := serve.Path(ipxeServerHost, ipxeServerPort, filepath.Join(i.Path, "server"), nodeStatus); err != nil {
 		return fmt.Errorf("serving assets failed: %w", err)
 	}
 

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
@@ -156,7 +156,7 @@ func (i *Infrastructure) Exec(_ string, upgradeState *upgrade.State) error {
 	// Struct to keep each node's bootstrap status.
 	nodeStatus := make(map[string]string, len(i.furyctlConf.Spec.Infrastructure.Nodes))
 	for _, node := range i.furyctlConf.Spec.Infrastructure.Nodes {
-		nodeStatus[node.Hostname] = "pending"
+		nodeStatus[node.Hostname] = serve.StatusPending
 	}
 
 	// Serve the downloaded assets to the machines.

--- a/internal/x/exec/tty.go
+++ b/internal/x/exec/tty.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package execx
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/term"
+)
+
+// AnimationDisabled reports whether live, in-place terminal output has been turned off — either
+// explicitly by the operator (--no-tty) or implicitly by debug logging, where raw log lines are
+// preferred over an animated repaint. It does not consider whether output is a terminal; callers
+// drawing to a specific file should use ShouldAnimate instead.
+func AnimationDisabled() bool {
+	return NoTTY || logrus.GetLevel() >= logrus.DebugLevel
+}
+
+// ShouldAnimate reports whether f can carry animated, in-place terminal output: animation must not
+// be disabled (see AnimationDisabled) and f must be a real terminal.
+func ShouldAnimate(f *os.File) bool {
+	return !AnimationDisabled() && term.IsTerminal(int(f.Fd()))
+}

--- a/pkg/dependencies/download.go
+++ b/pkg/dependencies/download.go
@@ -386,7 +386,7 @@ func (dd *Downloader) DownloadTools(kfd config.KFD, kind string) ([]string, erro
 
 	// Stream mise's install progress into an ephemeral terminal region (TTY only); on debug or
 	// --no-tty the region stays disabled and mise output is captured to the log file as usual.
-	progress := iox.NewLiveRegion(os.Stderr, execx.NoTTY || logrus.GetLevel() >= logrus.DebugLevel)
+	progress := iox.NewLiveRegion(os.Stderr, execx.AnimationDisabled())
 
 	if err := runner.Install(progress); err != nil {
 		progress.Clear()

--- a/pkg/x/net/progress.go
+++ b/pkg/x/net/progress.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/term"
 
 	execx "github.com/sighupio/furyctl/internal/x/exec"
 )
@@ -49,7 +48,7 @@ var newProgressTracker = func() *downloadProgressTracker {
 		// Animate only on a terminal; under --no-tty/--debug fall back to logs, as the dependency
 		// downloader does for its live region.
 		out: f,
-		tty: !execx.NoTTY && logrus.GetLevel() < logrus.DebugLevel && term.IsTerminal(int(f.Fd())),
+		tty: execx.ShouldAnimate(f),
 	}
 }
 


### PR DESCRIPTION
### Summary 💡

Replaces the scrolling per-node status log lines with a single, always-current table so operators can see the overall bootstrap state of every node at a glance.

Relates:
- #695 

### Description 📝

This PR changes the single line INFO logs with status updates from the nodes during the provisioning in the Immutable infrastructure phase for a dynamic table that shows all the nodes, their current status and the last time the status was updated.

Example (interactive terminal):

```
...
INFO Assets download completed successfully
WARN Assets server started. You can boot your machines now  address=furyctl.flatcar port=8080 root=/Users/ramiroalgozino/src/lab/flatcar/furyctl/.furyctl/flatcar-dev/infrastructure/server
INFO Press ENTER to skip waiting and continue, or CTRL+C to cancel and exit.
Nodes bootstrap status — 1/5 booted
  NODE           STATUS                UPDATED
  cp1.flatcar    booted                10:11:46
  cp2.flatcar    rebooting             10:11:44
  cp3.flatcar    installing            10:10:51
  node1.flatcar  pending               —
  node2.flatcar  installation-blocked  10:10:49
  ! node2.flatcar: Flatcar is already installed on disk. Manual intervention required.
```

Note:
- Per-node attention notes for `installation-blocked`, cleared automatically once the node recovers.
- Falls back to one concise log line per update under `--debug` / `--no-tty` / non-terminal, preserving full machine-readable history.

#### Code quality 🧹

Alongside the feature, a small refactoring pass:

- The `/status` handler now uses a `switch` on the method and returns `405` for anything other than `GET`/`POST`.
- Extracted the "should we animate the terminal?" policy (`--no-tty` / debug / is-a-TTY), which was duplicated verbatim in three places, into shared `execx.ShouldAnimate` / `execx.AnimationDisabled` helpers.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested an Immutable cluster creation and that the table shows the right information.
- [x] Tested an Immutable cluster creation with `--no-tty` set and checked that the logs with the nodes status update show up.
- [x] Tested an Immutable cluster creation with nodes that go into `installation-blocked` status and that the table shows the right attention notes and they are cleared when the node is manually restored.

### Future work 🔧

Optional: a live "elapsed" timer in the table (would require a background ticker) instead of the timestamp of the last status update.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

