### PR TITLE
fix: check that openvpn binary is present even if vpn-auto-connect argument is not present

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -135,7 +135,7 @@ func NewApplyCmd() *cobra.Command {
 			// Init first half of collaborators.
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
-			depsvl := dependencies.NewValidator(executor, flags.BinPath, flags.FuryctlPath, flags.VpnAutoConnect)
+			depsvl := dependencies.NewValidator(executor, flags.BinPath, flags.FuryctlPath)
 
 			if flags.DistroLocation == "" {
 				distrodl = dist.NewCachingDownloader(client, flags.Outdir, flags.GitProtocol, flags.DistroPatchesLocation)

--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -121,7 +121,7 @@ func NewConfigCmd() *cobra.Command {
 			// Init collaborators.
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
-			depsvl := dependencies.NewValidator(executor, "", "", false)
+			depsvl := dependencies.NewValidator(executor, "", "")
 
 			if distroLocation == "" {
 				distrodl = dist.NewCachingDownloader(client, outDir, typedGitProtocol, absDistroPatchesLocation)

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -114,7 +114,7 @@ func NewClusterCmd() *cobra.Command {
 			// Init first half of collaborators.
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
-			depsvl := dependencies.NewValidator(executor, flags.BinPath, flags.FuryctlPath, flags.VpnAutoConnect)
+			depsvl := dependencies.NewValidator(executor, flags.BinPath, flags.FuryctlPath)
 
 			if flags.DistroLocation == "" {
 				distrodl = dist.NewCachingDownloader(client, outDir, flags.GitProtocol, flags.DistroPatchesLocation)

--- a/cmd/download/airgappedbundle.go
+++ b/cmd/download/airgappedbundle.go
@@ -146,7 +146,7 @@ func NewAirGappedBundleCmd() *cobra.Command {
 
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
-			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath, false)
+			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath)
 
 			var distrodl *dist.Downloader
 			if distroLocation == "" {

--- a/cmd/download/dependencies.go
+++ b/cmd/download/dependencies.go
@@ -97,7 +97,7 @@ func NewDependenciesCmd() *cobra.Command {
 
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
-			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath, false)
+			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath)
 
 			if distroLocation == "" {
 				distrodl = dist.NewCachingDownloader(client, outDir, typedGitProtocol, absDistroPatchesLocation)

--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -85,7 +85,7 @@ The command will dump into a 'distribution' folder in the working directory all 
 
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
-			depsvl := dependencies.NewValidator(executor, "", flags.FuryctlPath, false)
+			depsvl := dependencies.NewValidator(executor, "", flags.FuryctlPath)
 
 			if flags.DistroLocation == "" {
 				distrodl = dist.NewCachingDownloader(client, flags.Outdir, flags.GitProtocol, flags.DistroPatchesLocation)

--- a/cmd/get/kubeconfig.go
+++ b/cmd/get/kubeconfig.go
@@ -113,7 +113,7 @@ func NewKubeconfigCmd() *cobra.Command {
 			executor := execx.NewStdExecutor()
 
 			distrodl := &dist.Downloader{}
-			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath, false)
+			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath)
 
 			// Init first half of collaborators.
 			client := netx.NewGoGetterClient()

--- a/cmd/get/upgrade-paths.go
+++ b/cmd/get/upgrade-paths.go
@@ -133,7 +133,7 @@ func NewUpgradePathsCmd() *cobra.Command {
 				executor := execx.NewStdExecutor()
 
 				distrodl := &dist.Downloader{}
-				depsvl := dependencies.NewValidator(executor, binPath, furyctlPath, false)
+				depsvl := dependencies.NewValidator(executor, binPath, furyctlPath)
 
 				// Init first half of collaborators.
 				client := netx.NewGoGetterClient()

--- a/cmd/renew/certificates.go
+++ b/cmd/renew/certificates.go
@@ -110,7 +110,7 @@ func NewCertificatesCmd() *cobra.Command {
 			executor := execx.NewStdExecutor()
 
 			distrodl := &dist.Downloader{}
-			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath, false)
+			depsvl := dependencies.NewValidator(executor, binPath, furyctlPath)
 
 			// Init first half of collaborators.
 			client := netx.NewGoGetterClient()

--- a/cmd/validate/config.go
+++ b/cmd/validate/config.go
@@ -82,7 +82,7 @@ func NewConfigCmd() *cobra.Command {
 
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
-			depsvl := dependencies.NewValidator(executor, "", furyctlPath, false)
+			depsvl := dependencies.NewValidator(executor, "", furyctlPath)
 
 			if distroLocation == "" {
 				distrodl = dist.NewCachingDownloader(client, outDir, typedGitProtocol, absDistroPatchesLocation)

--- a/cmd/validate/dependencies.go
+++ b/cmd/validate/dependencies.go
@@ -95,7 +95,7 @@ func NewDependenciesCmd() *cobra.Command {
 
 			client := netx.NewGoGetterClient()
 			executor := execx.NewStdExecutor()
-			depsvl := dependencies.NewValidator(executor, "", furyctlPath, false)
+			depsvl := dependencies.NewValidator(executor, "", furyctlPath)
 
 			if distroLocation == "" {
 				distrodl = dist.NewCachingDownloader(client, outDir, typedGitProtocol, absDistroPatchesLocation)
@@ -126,7 +126,7 @@ func NewDependenciesCmd() *cobra.Command {
 				KFDVersion: dres.DistroManifest.Version,
 			})
 
-			toolsValidator := tools.NewValidator(executor, binPath, furyctlPath, false)
+			toolsValidator := tools.NewValidator(executor, binPath, furyctlPath)
 			envVarsValidator := envvars.NewValidator()
 			errs := make([]error, 0)
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,6 +9,7 @@ TBD
 ## Bug fixes 🐞
 
 - [[#695](https://github.com/sighupio/furyctl/pull/695)] Immutable: fixed a panic that may occur if the user pressed ENTER to while waiting the nodes to be provisioned and a node sent a status update in the 5 seconds shutdown window.
+- [[#697](https://github.com/sighupio/furyctl/pull/697)] EKSCluster: `openvpn` is now validated as a dependency whenever a VPN is configured (not only with `--vpn-auto-connect`), failing fast with a clear error instead of a silent furyagent retry loop; `--vpn-auto-connect` without a configured VPN is now rejected up front.
 
 ## Breaking Changes 💔
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/common/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/common/preflight.go
@@ -219,10 +219,7 @@ func (p *PreFlight) copyFromTemplate() error {
 
 func (p *PreFlight) IsVPNRequired() bool {
 	return p.FuryctlConf.Spec.Infrastructure != nil &&
-		p.FuryctlConf.Spec.Infrastructure.Vpn != nil &&
-		(p.FuryctlConf.Spec.Infrastructure.Vpn.Instances == nil ||
-			p.FuryctlConf.Spec.Infrastructure.Vpn.Instances != nil &&
-				*p.FuryctlConf.Spec.Infrastructure.Vpn.Instances > 0) &&
+		p.FuryctlConf.Spec.Infrastructure.Vpn.IsConfigured() &&
 		p.FuryctlConf.Spec.Kubernetes.ApiServer.PrivateAccess &&
 		!p.FuryctlConf.Spec.Kubernetes.ApiServer.PublicAccess
 }

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -217,7 +217,7 @@ func (v *ClusterCreator) Create(startFrom string, timeout, _ int) error {
 	}
 
 	if err := vpnConnector.ValidateConfig(); err != nil {
-		return fmt.Errorf("error while validating vpn configuration: %w", err)
+		return fmt.Errorf("error while validating VPN configuration: %w", err)
 	}
 
 	errCh := make(chan error)

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -216,6 +216,10 @@ func (v *ClusterCreator) Create(startFrom string, timeout, _ int) error {
 		return fmt.Errorf("error while creating vpn connector: %w", err)
 	}
 
+	if err := vpnConnector.ValidateConfig(); err != nil {
+		return fmt.Errorf("error while validating vpn configuration: %w", err)
+	}
+
 	errCh := make(chan error)
 	doneCh := make(chan bool)
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/deleter.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/deleter.go
@@ -132,7 +132,7 @@ func (d *ClusterDeleter) Delete() error {
 	}
 
 	if err := vpnConnector.ValidateConfig(); err != nil {
-		return fmt.Errorf("error while validating vpn configuration: %w", err)
+		return fmt.Errorf("error while validating VPN configuration: %w", err)
 	}
 
 	preflight, err := del.NewPreFlight(

--- a/internal/apis/kfd/v1alpha2/ekscluster/deleter.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/deleter.go
@@ -131,6 +131,10 @@ func (d *ClusterDeleter) Delete() error {
 		return fmt.Errorf("error while creating vpn connector: %w", err)
 	}
 
+	if err := vpnConnector.ValidateConfig(); err != nil {
+		return fmt.Errorf("error while validating vpn configuration: %w", err)
+	}
+
 	preflight, err := del.NewPreFlight(
 		d.furyctlConf,
 		d.kfdManifest,

--- a/internal/apis/kfd/v1alpha2/ekscluster/private/schema.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/private/schema.go
@@ -77,6 +77,16 @@ type SpecInfrastructureVpn struct {
 	Port                *TypesTcpPort `yaml:"port,omitempty"                json:"port,omitempty"`
 }
 
+// IsConfigured reports whether a VPN is requested. A nil receiver means no VPN
+// block; nil Instances defaults to one; otherwise configured when > 0.
+func (v *SpecInfrastructureVpn) IsConfigured() bool {
+	if v == nil {
+		return false
+	}
+
+	return v.Instances == nil || *v.Instances > 0
+}
+
 // --- kubernetes ---
 
 type SpecKubernetes struct {

--- a/internal/apis/kfd/v1alpha2/ekscluster/private/schema_test.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/private/schema_test.go
@@ -7,6 +7,7 @@ package private_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
@@ -177,4 +178,30 @@ func asMap(t *testing.T, m map[any]any, key string) map[any]any {
 	}
 
 	return mm
+}
+
+func TestSpecInfrastructureVpn_IsConfigured(t *testing.T) {
+	t.Parallel()
+
+	intPtr := func(i int) *int { return &i }
+
+	testCases := []struct {
+		desc string
+		vpn  *private.SpecInfrastructureVpn
+		want bool
+	}{
+		{desc: "nil vpn is not configured", vpn: nil, want: false},
+		{desc: "nil instances defaults to configured", vpn: &private.SpecInfrastructureVpn{}, want: true},
+		{desc: "positive instances is configured", vpn: &private.SpecInfrastructureVpn{Instances: intPtr(2)}, want: true},
+		{desc: "zero instances is not configured", vpn: &private.SpecInfrastructureVpn{Instances: intPtr(0)}, want: false},
+		{desc: "negative instances is not configured", vpn: &private.SpecInfrastructureVpn{Instances: intPtr(-1)}, want: false},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tC.want, tC.vpn.IsConfigured())
+		})
+	}
 }

--- a/internal/apis/kfd/v1alpha2/ekscluster/schema.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/schema.go
@@ -61,10 +61,7 @@ func (v *ExtraSchemaValidator) validateClusterName(furyctlConf *private.Eksclust
 func (*ExtraSchemaValidator) validateInfraVPNOverrides(furyctlConf *private.EksclusterKfdV1Alpha2) error {
 	//nolint:revive // ignore magic number linters
 	if len(furyctlConf.Metadata.Name) > 19 && furyctlConf.Spec.Infrastructure != nil &&
-		furyctlConf.Spec.Infrastructure.Vpn != nil &&
-		(furyctlConf.Spec.Infrastructure.Vpn.Instances == nil ||
-			(furyctlConf.Spec.Infrastructure.Vpn.Instances != nil &&
-				*furyctlConf.Spec.Infrastructure.Vpn.Instances > 0)) {
+		furyctlConf.Spec.Infrastructure.Vpn.IsConfigured() {
 		if furyctlConf.Spec.Infrastructure.Vpn.IamUserNameOverride == nil ||
 			(furyctlConf.Spec.Infrastructure.Vpn.IamUserNameOverride != nil &&
 				*furyctlConf.Spec.Infrastructure.Vpn.IamUserNameOverride == "") {

--- a/internal/apis/kfd/v1alpha2/ekscluster/tool.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/tool.go
@@ -16,14 +16,12 @@ import (
 var ErrOpenVPNNotInstalled = errors.New("openvpn is not installed")
 
 type ExtraToolsValidator struct {
-	executor    execx.Executor
-	autoConnect bool
+	executor execx.Executor
 }
 
-func NewExtraToolsValidator(executor execx.Executor, autoConnect bool) *ExtraToolsValidator {
+func NewExtraToolsValidator(executor execx.Executor) *ExtraToolsValidator {
 	return &ExtraToolsValidator{
-		executor:    executor,
-		autoConnect: autoConnect,
+		executor: executor,
 	}
 }
 
@@ -48,12 +46,12 @@ func (x *ExtraToolsValidator) Validate(confPath string) ([]string, []error) {
 }
 
 func (x *ExtraToolsValidator) openVPN(conf private.EksclusterKfdV1Alpha2) error {
-	if conf.Spec.Infrastructure != nil &&
+	vpnEnabled := conf.Spec.Infrastructure != nil &&
 		conf.Spec.Infrastructure.Vpn != nil &&
 		(conf.Spec.Infrastructure.Vpn.Instances == nil ||
-			(conf.Spec.Infrastructure.Vpn.Instances != nil &&
-				*conf.Spec.Infrastructure.Vpn.Instances > 0)) &&
-		x.autoConnect {
+			*conf.Spec.Infrastructure.Vpn.Instances > 0)
+
+	if vpnEnabled {
 		oRunner := openvpn.NewRunner(x.executor, openvpn.Paths{
 			Openvpn: "openvpn",
 		})

--- a/internal/apis/kfd/v1alpha2/ekscluster/tool.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/tool.go
@@ -46,20 +46,21 @@ func (x *ExtraToolsValidator) Validate(confPath string) ([]string, []error) {
 }
 
 func (x *ExtraToolsValidator) openVPN(conf private.EksclusterKfdV1Alpha2) error {
-	vpnEnabled := conf.Spec.Infrastructure != nil &&
-		conf.Spec.Infrastructure.Vpn != nil &&
-		(conf.Spec.Infrastructure.Vpn.Instances == nil ||
-			*conf.Spec.Infrastructure.Vpn.Instances > 0)
+	if !vpnConfigured(conf) {
+		return nil
+	}
 
-	if vpnEnabled {
-		oRunner := openvpn.NewRunner(x.executor, openvpn.Paths{
-			Openvpn: "openvpn",
-		})
+	oRunner := openvpn.NewRunner(x.executor, openvpn.Paths{
+		Openvpn: "openvpn",
+	})
 
-		if _, err := oRunner.Version(); err != nil {
-			return ErrOpenVPNNotInstalled
-		}
+	if _, err := oRunner.Version(); err != nil {
+		return ErrOpenVPNNotInstalled
 	}
 
 	return nil
+}
+
+func vpnConfigured(conf private.EksclusterKfdV1Alpha2) bool {
+	return conf.Spec.Infrastructure != nil && conf.Spec.Infrastructure.Vpn.IsConfigured()
 }

--- a/internal/apis/kfd/v1alpha2/ekscluster/tool_test.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/tool_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package ekscluster
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
+	execx "github.com/sighupio/furyctl/internal/x/exec"
+)
+
+func Test_ExtraToolsValidator_openVPN(t *testing.T) {
+	t.Parallel()
+
+	intPtr := func(i int) *int { return &i }
+
+	vpnConf := func(instances *int) private.EksclusterKfdV1Alpha2 {
+		return private.EksclusterKfdV1Alpha2{
+			Spec: private.Spec{
+				Infrastructure: &private.SpecInfrastructure{
+					Vpn: &private.SpecInfrastructureVpn{
+						Instances: instances,
+					},
+				},
+			},
+		}
+	}
+
+	noVPNInfra := private.EksclusterKfdV1Alpha2{
+		Spec: private.Spec{Infrastructure: &private.SpecInfrastructure{}},
+	}
+
+	noInfra := private.EksclusterKfdV1Alpha2{
+		Spec: private.Spec{},
+	}
+
+	testCases := []struct {
+		desc           string
+		conf           private.EksclusterKfdV1Alpha2
+		openvpnMissing bool
+		wantErr        bool
+	}{
+		{
+			desc: "vpn enabled with default instances and openvpn installed",
+			conf: vpnConf(nil),
+		},
+		{
+			desc:           "vpn enabled with default instances and openvpn missing (no auto-connect)",
+			conf:           vpnConf(nil),
+			openvpnMissing: true,
+			wantErr:        true,
+		},
+		{
+			desc:           "vpn enabled with positive instances and openvpn missing",
+			conf:           vpnConf(intPtr(2)),
+			openvpnMissing: true,
+			wantErr:        true,
+		},
+		{
+			desc:           "vpn disabled with zero instances does not require openvpn",
+			conf:           vpnConf(intPtr(0)),
+			openvpnMissing: true,
+		},
+		{
+			desc:           "no vpn configuration does not require openvpn",
+			conf:           noVPNInfra,
+			openvpnMissing: true,
+		},
+		{
+			desc:           "no infrastructure does not require openvpn",
+			conf:           noInfra,
+			openvpnMissing: true,
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			helper := "TestHelperProcessOpenvpnOK"
+			if tC.openvpnMissing {
+				helper = "TestHelperProcessOpenvpnMissing"
+			}
+
+			validator := NewExtraToolsValidator(execx.NewFakeExecutor(helper))
+
+			err := validator.openVPN(tC.conf)
+
+			if tC.wantErr {
+				require.ErrorIs(t, err, ErrOpenVPNNotInstalled)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestHelperProcessOpenvpnOK simulates a working `openvpn --version` invocation when spawned as a
+// subprocess by the fake executor; it is a no-op during a normal test run.
+func TestHelperProcessOpenvpnOK(t *testing.T) {
+	if len(os.Args) < 5 || os.Args[1] != "-test.run=TestHelperProcessOpenvpnOK" {
+		return
+	}
+
+	if os.Args[3] == "openvpn" && os.Args[4] == "--version" {
+		fmt.Fprint(os.Stdout, "OpenVPN 2.5.7 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4]\n")
+	}
+}
+
+// TestHelperProcessOpenvpnMissing simulates `exec: "openvpn": executable file not found in $PATH`
+// by exiting non-zero when spawned as a subprocess; it is a no-op during a normal test run.
+func TestHelperProcessOpenvpnMissing(t *testing.T) {
+	if len(os.Args) < 2 || os.Args[1] != "-test.run=TestHelperProcessOpenvpnMissing" {
+		return
+	}
+
+	os.Exit(1)
+}

--- a/internal/apis/kfd/v1alpha2/ekscluster/tool_test.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/tool_test.go
@@ -111,7 +111,8 @@ func TestHelperProcessOpenvpnOK(t *testing.T) {
 	}
 
 	if os.Args[3] == "openvpn" && os.Args[4] == "--version" {
-		fmt.Fprint(os.Stdout, "OpenVPN 2.5.7 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4]\n")
+		fmt.Fprint(os.Stdout, "OpenVPN 2.7.5 aarch64-apple-darwin25.4.0 [SSL (OpenSSL)] [LZO] [LZ4] [PKCS11] [MH/RECVDA] [AEAD]\n"+
+			"library versions: OpenSSL 3.5.0 8 Apr 2025, LZO 2.10\n")
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/vpn/connector.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/vpn/connector.go
@@ -159,17 +159,7 @@ func (v *Connector) writeOVPNFileToDisk(certName string, cert []byte) error {
 }
 
 func (v *Connector) IsConfigured() bool {
-	vpn := v.config
-	if vpn == nil {
-		return false
-	}
-
-	instances := v.config.Instances
-	if instances == nil {
-		return true
-	}
-
-	return *instances > 0
+	return v.config.IsConfigured()
 }
 
 func (v *Connector) GetKillMessage() (string, error) {

--- a/internal/apis/kfd/v1alpha2/ekscluster/vpn/connector.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/vpn/connector.go
@@ -83,11 +83,11 @@ func NewConnector(
 }
 
 func (v *Connector) Connect() error {
-	if v.autoconnect {
-		if !v.IsConfigured() {
-			return ErrAutoConnectWithoutVpn
-		}
+	if err := v.ValidateConfig(); err != nil {
+		return err
+	}
 
+	if v.autoconnect {
 		vpn, pid, err := v.checkExistingOpenVPN()
 		if err != nil {
 			return err
@@ -104,6 +104,17 @@ func (v *Connector) Connect() error {
 
 	if !v.skip {
 		return v.prompt()
+	}
+
+	return nil
+}
+
+// ValidateConfig returns an error when auto-connect is requested but no VPN is configured, since
+// there would be nothing to connect to. Connect calls it, and the creator/deleter call it early so
+// the misconfiguration fails fast instead of deep inside a phase or being silently ignored.
+func (v *Connector) ValidateConfig() error {
+	if v.autoconnect && !v.IsConfigured() {
+		return ErrAutoConnectWithoutVpn
 	}
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/ekscluster/vpn/connector_test.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/vpn/connector_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package vpn_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/vpn"
+)
+
+func TestConnector_ValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	intPtr := func(i int) *int { return &i }
+
+	testCases := []struct {
+		desc        string
+		autoConnect bool
+		config      *private.SpecInfrastructureVpn
+		wantErr     bool
+	}{
+		{
+			desc:        "no auto-connect and no vpn is valid",
+			autoConnect: false,
+			config:      nil,
+		},
+		{
+			desc:        "no auto-connect with vpn configured is valid",
+			autoConnect: false,
+			config:      &private.SpecInfrastructureVpn{Instances: intPtr(1)},
+		},
+		{
+			desc:        "auto-connect with vpn (default instances) is valid",
+			autoConnect: true,
+			config:      &private.SpecInfrastructureVpn{},
+		},
+		{
+			desc:        "auto-connect with positive vpn instances is valid",
+			autoConnect: true,
+			config:      &private.SpecInfrastructureVpn{Instances: intPtr(2)},
+		},
+		{
+			desc:        "auto-connect without any vpn configuration is rejected",
+			autoConnect: true,
+			config:      nil,
+			wantErr:     true,
+		},
+		{
+			desc:        "auto-connect with zero vpn instances is rejected",
+			autoConnect: true,
+			config:      &private.SpecInfrastructureVpn{Instances: intPtr(0)},
+			wantErr:     true,
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			connector, err := vpn.NewConnector(
+				"test-cluster",
+				"cert-dir",
+				"bin-path",
+				"0.3.0",
+				tC.autoConnect,
+				false,
+				tC.config,
+			)
+			require.NoError(t, err)
+
+			err = connector.ValidateConfig()
+
+			if tC.wantErr {
+				require.ErrorIs(t, err, vpn.ErrAutoConnectWithoutVpn)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/apis/tool.go
+++ b/internal/apis/tool.go
@@ -19,7 +19,6 @@ func NewExtraToolsValidatorFactory(
 	executor execx.Executor,
 	apiVersion,
 	kind string,
-	autoConnect bool,
 	kfdManifest config.KFD,
 	binPath string,
 ) ExtraToolsValidator {
@@ -27,7 +26,7 @@ func NewExtraToolsValidatorFactory(
 	case "kfd.sighup.io/v1alpha2":
 		switch kind {
 		case "EKSCluster":
-			return ekscluster.NewExtraToolsValidator(executor, autoConnect)
+			return ekscluster.NewExtraToolsValidator(executor)
 
 		case "OnPremises":
 			return onpremises.NewExtraToolsValidator(executor, kfdManifest, binPath)

--- a/internal/dependencies/tools/validator.go
+++ b/internal/dependencies/tools/validator.go
@@ -22,7 +22,7 @@ var (
 	ErrToolNotFound     = errors.New("tool not found in the toolFactory, possible fury-distribution version mismatch")
 )
 
-func NewValidator(executor execx.Executor, binPath, furyctlPath string, autoConnect bool) *Validator {
+func NewValidator(executor execx.Executor, binPath, furyctlPath string) *Validator {
 	return &Validator{
 		executor: executor,
 		toolFactory: NewFactory(executor, FactoryPaths{
@@ -30,7 +30,6 @@ func NewValidator(executor execx.Executor, binPath, furyctlPath string, autoConn
 		}),
 		binPath:     binPath,
 		furyctlPath: furyctlPath,
-		autoConnect: autoConnect,
 	}
 }
 
@@ -39,7 +38,6 @@ type Validator struct {
 	toolFactory *Factory
 	binPath     string
 	furyctlPath string
-	autoConnect bool
 }
 
 func (tv *Validator) ValidateBaseReqs() ([]string, []error) {
@@ -94,7 +92,6 @@ func (tv *Validator) Validate(kfdManifest config.KFD, miniConf config.Furyctl) (
 		tv.executor,
 		miniConf.APIVersion,
 		miniConf.Kind,
-		tv.autoConnect,
 		kfdManifest,
 		tv.binPath,
 	)

--- a/internal/dependencies/tools/validator_test.go
+++ b/internal/dependencies/tools/validator_test.go
@@ -161,7 +161,7 @@ func Test_Validator_Validate(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			furyctlPath := path.Join("test_data", "furyctl.yaml")
 
-			v := tools.NewValidator(execx.NewFakeExecutor("TestHelperProcess"), "test_data", furyctlPath, false)
+			v := tools.NewValidator(execx.NewFakeExecutor("TestHelperProcess"), "test_data", furyctlPath)
 
 			oks, errs := v.Validate(tC.manifest, tC.state)
 
@@ -210,7 +210,7 @@ func TestValidator_ValidateBaseReqs(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			furyctlPath := path.Join("test_data", "furyctl.yaml")
 
-			v := tools.NewValidator(execx.NewFakeExecutor("TestHelperProcess"), "test_data", furyctlPath, false)
+			v := tools.NewValidator(execx.NewFakeExecutor("TestHelperProcess"), "test_data", furyctlPath)
 
 			oks, errs := v.ValidateBaseReqs()
 

--- a/pkg/dependencies/validate.go
+++ b/pkg/dependencies/validate.go
@@ -19,9 +19,9 @@ var (
 	errValidatingEnv   = errors.New("errors validating env vars")
 )
 
-func NewValidator(executor execx.Executor, binPath, furyctlPath string, autoConnect bool) *Validator {
+func NewValidator(executor execx.Executor, binPath, furyctlPath string) *Validator {
 	return &Validator{
-		toolsValidator:   tools.NewValidator(executor, binPath, furyctlPath, autoConnect),
+		toolsValidator:   tools.NewValidator(executor, binPath, furyctlPath),
 		envVarsValidator: envvars.NewValidator(),
 	}
 }

--- a/test/data/e2e/validate/dependencies/correct/openvpn
+++ b/test/data/e2e/validate/dependencies/correct/openvpn
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cat <<EOF
+OpenVPN 2.7.5 aarch64-apple-darwin25.4.0 [SSL (OpenSSL)] [LZO] [LZ4] [PKCS11] [MH/RECVDA] [AEAD]
+library versions: OpenSSL 3.5.0 8 Apr 2025, LZO 2.10
+EOF


### PR DESCRIPTION
### Summary 💡

The openvpn binary is required to create VPN VM. But the presence of its binary is checked only if the --vpn-auto-connect flag is present.
If the binary is missing, the installation process will freeze indefinitely rather than failin.

### Description 📝

To prevent the installation from hanging, the installer now strictly validates the presence of the OpenVPN binary during the pre-flight checks, regardless of whether the `--vpn-auto-connect` argument is present.

Plus point: added units tests regarding the use of the `--vpn-auto-connect` flag.

---

### Before the fix
```
# spec.infrastructure.vpn configured and no --vpn-auto-connect flag
furyctl create cluster --outdir $PWD

{"level":"debug","action":"tofu apply -no-color -json plan/terraform.plan","msg":"{\"@level\":\"info\",\"@message\":\"module.vpn[0].null_resource.init: (local-exec): 2026-07-09 16:33:56.830115 I | openvpn.go:102: exec: \\\"openvpn\\\": executable file not found in $PATH\",\"@module\":\"tofu.ui\",\"@timestamp\":\"2026-07-09T16:33:56.830203+02:00\",\"hook\":{\"resource\":{\"addr\":\"module.vpn[0].null_resource.init\",\"module\":\"module.vpn[0]\",\"resource\":\"null_resource.init\",\"implied_provider\":\"null\",\"resource_type\":\"null_resource\",\"resource_name\":\"init\",\"resource_key\":null},\"provisioner\":\"local-exec\",\"output\":\"2026-07-09 16:33:56.830115 I | openvpn.go:102: exec: \\\"openvpn\\\": executable file not found in $PATH\"},\"type\":\"provision_progress\"}\n","time":"2026-07-09T16:30:13+02:00"}
{"level":"debug","action":"tofu apply -no-color -json plan/terraform.plan","msg":"{\"@level\":\"info\",\"@message\":\"module.vpn[0].null_resource.init: (local-exec): Retrying\",\"@module\":\"tofu.ui\",\"@timestamp\":\"2026-07-09T16:33:56.831413+02:00\",\"hook\":{\"resource\":{\"addr\":\"module.vpn[0].null_resource.init\",\"module\":\"module.vpn[0]\",\"resource\":\"null_resource.init\",\"implied_provider\":\"null\",\"resource_type\":\"null_resource\",\"resource_name\":\"init\",\"resource_key\":null},\"provisioner\":\"local-exec\",\"output\":\"Retrying\"},\"type\":\"provision_progress\"}\n","time":"2026-07-09T16:30:13+02:00"}
{"level":"debug","action":"tofu apply -no-color -json plan/terraform.plan","msg":"{\"@level\":\"info\",\"@message\":\"module.vpn[0].null_resource.init: (local-exec): 2026-07-09 16:34:27.295973 I | openvpn.go:102: exec: \\\"openvpn\\\": executable file not found in $PATH\",\"@module\":\"tofu.ui\",\"@timestamp\":\"2026-07-09T16:34:27.296052+02:00\",\"hook\":{\"resource\":{\"addr\":\"module.vpn[0].null_resource.init\",\"module\":\"module.vpn[0]\",\"resource\":\"null_resource.init\",\"implied_provider\":\"null\",\"resource_type\":\"null_resource\",\"resource_name\":\"init\",\"resource_key\":null},\"provisioner\":\"local-exec\",\"output\":\"2026-07-09 16:34:27.295973 I | openvpn.go:102: exec: \\\"openvpn\\\": executable file not found in $PATH\"},\"type\":\"provision_progress\"}\n","time":"2026-07-09T16:30:13+02:00"}
{"level":"debug","action":"tofu apply -no-color -json plan/terraform.plan","msg":"{\"@level\":\"info\",\"@message\":\"module.vpn[0].null_resource.init: (local-exec): Retrying\",\"@module\":\"tofu.ui\",\"@timestamp\":\"2026-07-09T16:34:27.297356+02:00\",\"hook\":{\"resource\":{\"addr\":\"module.vpn[0].null_resource.init\",\"module\":\"module.vpn[0]\",\"resource\":\"null_resource.init\",\"implied_provider\":\"null\",\"resource_type\":\"null_resource\",\"resource_name\":\"init\",\"resource_key\":null},\"provisioner\":\"local-exec\",\"output\":\"Retrying\"},\"type\":\"provision_progress\"}\n","time":"2026-07-09T16:30:13+02:00"}
```
```
# spec.infrastructure.vpn configured and --vpn-auto-connect flag defined
furyctl create cluster --outdir $PWD --vpn-auto-connect

ERRO error while validating dependencies: errors validating tools: [openvpn is not installed] 
```

### After the fix

```
# spec.infrastructure.vpn configured and no --vpn-auto-connect flag
furyctl create cluster --outdir $PWD

ERRO error while validating dependencies: errors validating tools: [openvpn is not installed] 
```
```
# spec.infrastructure.vpn configured and --vpn-auto-connect flag defined
furyctl create cluster --outdir $PWD --vpn-auto-connect

ERRO error while validating dependencies: errors validating tools: [openvpn is not installed] 
```

```
# spec.infrastructure.vpn not configured and --vpn-auto-connect flag defined
furyctl create cluster --outdir $PWD --vpn-auto-connect

ERRO error while creating cluster: error while validating vpn configuration: autoconnect is not supported without a VPN configuration 
```
---

It also fixes `furyctl validate dependencies` that, before the fix, was reporting `openvpn: binary found in vendor folder` even if not installed.
```
furyctl validate dependencies
INFO Downloading distribution...                  
INFO Validating tools...                          
INFO Validating environment variables...          
INFO Validating tools configuration...            
INFO kubectl: binary found in vendor folder       
INFO kustomize: binary found in vendor folder     
INFO yq: binary found in vendor folder            
INFO kapp: binary found in vendor folder          
INFO helm: binary found in vendor folder          
INFO helmfile: binary found in vendor folder      
INFO awscli: binary found in vendor folder        
INFO opentofu: binary found in vendor folder      
INFO furyagent: binary found in vendor folder     
ERRO openvpn is not installed
```

### Breaking Changes 💔

Not exactly a breaking change but if you use `furyctl appy` without VPN configured in the furyfile but passing the `--vpn-auto-connect` argument, it gets rejected.

### Tests performed 🧪

- Added unit tests
- Tested manually as described above
- CI: https://ci.sighup.io/sighupio/furyctl/3745

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

