### PR TITLE
chore(docs): remove wrong version entry in COMPATIBILITY_MATRIX.md

### DIFF
--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -69,7 +69,6 @@
 | furyctl / Providers |     EKSCluster     |  KFDDistribution   |     OnPremises     |     Immutable      |
 |:--------------------|:------------------:|:------------------:|:------------------:|:------------------:|
 | >=0.35.0            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| >=0.34.2            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | >=0.29.6            | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |
 | 0.29.5              |        :x:         |        :x:         |        :x:         |                    |
 | 0.29.4              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |


### PR DESCRIPTION
### Summary 💡

chore(docs): remove wrong version entry in COMPATIBILITY_MATRIX.md

### Description 📝

0.34.2 does not exists.
Immutable is supported from 0.35.0

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

Not necessary

### Future work 🔧

<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [ ] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

