### PR TITLE
fix: don't report openvpn as found when OpenVPN binary is not checked

### DIFF
--- a/internal/apis/kfd/v1alpha2/ekscluster/tool.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/tool.go
@@ -26,17 +26,27 @@ func NewExtraToolsValidator(executor execx.Executor) *ExtraToolsValidator {
 }
 
 func (x *ExtraToolsValidator) Validate(confPath string) ([]string, []error) {
+	furyctlConf, err := yamlx.FromFileV3[private.EksclusterKfdV1Alpha2](confPath)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return x.validateConf(furyctlConf)
+}
+
+// validateConf contains the real validation logic separated from Validate so that tests can
+// exercise it against the parsed struct without writing throwaway YAML files.
+func (x *ExtraToolsValidator) validateConf(conf private.EksclusterKfdV1Alpha2) ([]string, []error) {
 	var (
 		oks  []string
 		errs []error
 	)
 
-	furyctlConf, err := yamlx.FromFileV3[private.EksclusterKfdV1Alpha2](confPath)
-	if err != nil {
-		return oks, append(errs, err)
+	if !vpnConfigured(conf) {
+		return oks, errs
 	}
 
-	if err := x.openVPN(furyctlConf); err != nil {
+	if err := x.openVPN(); err != nil {
 		errs = append(errs, err)
 	} else {
 		oks = append(oks, "openvpn")
@@ -45,11 +55,7 @@ func (x *ExtraToolsValidator) Validate(confPath string) ([]string, []error) {
 	return oks, errs
 }
 
-func (x *ExtraToolsValidator) openVPN(conf private.EksclusterKfdV1Alpha2) error {
-	if !vpnConfigured(conf) {
-		return nil
-	}
-
+func (x *ExtraToolsValidator) openVPN() error {
 	oRunner := openvpn.NewRunner(x.executor, openvpn.Paths{
 		Openvpn: "openvpn",
 	})

--- a/internal/apis/kfd/v1alpha2/ekscluster/tool_test.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/tool_test.go
@@ -17,66 +17,118 @@ import (
 	execx "github.com/sighupio/furyctl/internal/x/exec"
 )
 
+func vpnConf(instances int) private.EksclusterKfdV1Alpha2 {
+	return private.EksclusterKfdV1Alpha2{
+		Spec: private.Spec{
+			Infrastructure: &private.SpecInfrastructure{
+				Vpn: &private.SpecInfrastructureVpn{
+					Instances: &instances,
+				},
+			},
+		},
+	}
+}
+
+func vpnConfDefault() private.EksclusterKfdV1Alpha2 {
+	return private.EksclusterKfdV1Alpha2{
+		Spec: private.Spec{
+			Infrastructure: &private.SpecInfrastructure{
+				Vpn: &private.SpecInfrastructureVpn{},
+			},
+		},
+	}
+}
+
+func noVPNInfra() private.EksclusterKfdV1Alpha2 {
+	return private.EksclusterKfdV1Alpha2{
+		Spec: private.Spec{Infrastructure: &private.SpecInfrastructure{}},
+	}
+}
+
+func noInfra() private.EksclusterKfdV1Alpha2 {
+	return private.EksclusterKfdV1Alpha2{
+		Spec: private.Spec{},
+	}
+}
+
 func Test_ExtraToolsValidator_openVPN(t *testing.T) {
 	t.Parallel()
 
-	intPtr := func(i int) *int { return &i }
-
-	vpnConf := func(instances *int) private.EksclusterKfdV1Alpha2 {
-		return private.EksclusterKfdV1Alpha2{
-			Spec: private.Spec{
-				Infrastructure: &private.SpecInfrastructure{
-					Vpn: &private.SpecInfrastructureVpn{
-						Instances: instances,
-					},
-				},
-			},
-		}
+	testCases := []struct {
+		desc  string
+		fails bool
+	}{
+		{
+			desc: "openvpn installed returns no error",
+		},
+		{
+			desc:  "openvpn missing returns error",
+			fails: true,
+		},
 	}
 
-	noVPNInfra := private.EksclusterKfdV1Alpha2{
-		Spec: private.Spec{Infrastructure: &private.SpecInfrastructure{}},
-	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
 
-	noInfra := private.EksclusterKfdV1Alpha2{
-		Spec: private.Spec{},
+			helper := "TestHelperProcessOpenvpnOK"
+			if tC.fails {
+				helper = "TestHelperProcessOpenvpnMissing"
+			}
+
+			validator := NewExtraToolsValidator(execx.NewFakeExecutor(helper))
+
+			err := validator.openVPN()
+
+			if tC.fails {
+				require.ErrorIs(t, err, ErrOpenVPNNotInstalled)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
+}
+
+func Test_ExtraToolsValidator_validate(t *testing.T) {
+	t.Parallel()
 
 	testCases := []struct {
 		desc           string
 		conf           private.EksclusterKfdV1Alpha2
 		openvpnMissing bool
+		wantOks        []string
 		wantErr        bool
 	}{
 		{
-			desc: "vpn enabled with default instances and openvpn installed",
-			conf: vpnConf(nil),
+			desc:    "vpn enabled with default instances and openvpn installed adds openvpn to oks",
+			conf:    vpnConfDefault(),
+			wantOks: []string{"openvpn"},
 		},
 		{
-			desc:           "vpn enabled with default instances and openvpn missing (no auto-connect)",
-			conf:           vpnConf(nil),
+			desc:           "vpn enabled with default instances and openvpn missing reports error and no oks",
+			conf:           vpnConfDefault(),
 			openvpnMissing: true,
 			wantErr:        true,
 		},
 		{
-			desc:           "vpn enabled with positive instances and openvpn missing",
-			conf:           vpnConf(intPtr(2)),
+			desc:           "vpn enabled with positive instances and openvpn missing reports error and no oks",
+			conf:           vpnConf(2),
 			openvpnMissing: true,
 			wantErr:        true,
 		},
 		{
-			desc:           "vpn disabled with zero instances does not require openvpn",
-			conf:           vpnConf(intPtr(0)),
+			desc:           "vpn disabled with zero instances does not validate openvpn",
+			conf:           vpnConf(0),
 			openvpnMissing: true,
 		},
 		{
-			desc:           "no vpn configuration does not require openvpn",
-			conf:           noVPNInfra,
+			desc:           "no vpn configuration does not validate openvpn",
+			conf:           noVPNInfra(),
 			openvpnMissing: true,
 		},
 		{
-			desc:           "no infrastructure does not require openvpn",
-			conf:           noInfra,
+			desc:           "no infrastructure does not validate openvpn",
+			conf:           noInfra(),
 			openvpnMissing: true,
 		},
 	}
@@ -92,12 +144,15 @@ func Test_ExtraToolsValidator_openVPN(t *testing.T) {
 
 			validator := NewExtraToolsValidator(execx.NewFakeExecutor(helper))
 
-			err := validator.openVPN(tC.conf)
+			oks, errs := validator.validateConf(tC.conf)
+
+			require.Equal(t, tC.wantOks, oks)
 
 			if tC.wantErr {
-				require.ErrorIs(t, err, ErrOpenVPNNotInstalled)
+				require.Len(t, errs, 1)
+				require.ErrorIs(t, errs[0], ErrOpenVPNNotInstalled)
 			} else {
-				require.NoError(t, err)
+				require.Empty(t, errs)
 			}
 		})
 	}


### PR DESCRIPTION
### Summary 💡

`furyctl validated dependencies` is returning misleading output regarding the presence of the OpenVPN binary.
This PR aims to remove that log.

### Description 📝

In #697 we fixed the check for OpenVPN binary from the command `furyctl validated dependencies`.
The OpenVPN binary presence is not checked if not necessary.
The side-effect of that fix is that even if the check is not done, the command output is contradictory because it says that the binary is found but in reality the check is not done at all:
```
...
INFO furyagent: binary found in vendor folder     
INFO openvpn: binary found in vendor folder 
...
```

After this fix:
```
...
INFO furyagent: binary found in vendor folder  
...
```

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

Tested locally that the

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] ~I've updated the `docs/releases/unreleased.md` file (or equivalent)~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

