### PR TITLE
chore: update golangci-lint to 2.0.2

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -442,9 +442,6 @@ linters:
     paths:
       - .*\.gen\.go$
       - file_getter.go
-      - third_party$
-      - builtin$
-      - examples$
 issues:
   max-issues-per-linter: 50
   max-same-issues: 3

--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -7,7 +7,6 @@
 
 # Options for analysis running.
 run:
-  timeout: 5m
   modules-download-mode: readonly
   go: "1.24.13"
   concurrency: 2

--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -11,7 +11,6 @@ run:
   modules-download-mode: readonly
   go: "1.24.13"
   concurrency: 2
-  memory-limit: 1024
 
 # output configuration options
 output:

--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -2,606 +2,480 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This file contains all available configuration options
-# with their default values (in comments).
-
-# Options for analysis running.
+version: "2"
 run:
-  modules-download-mode: readonly
-  go: "1.24.13"
   concurrency: 2
-
-# output configuration options
-output:
-  sort-results: true
+  go: 1.24.13
+  modules-download-mode: readonly
 
 linters:
-  # Enable all available linters.
-  # Default: false
-  enable-all: true
-  # Disable specific linter
-  # https://golangci-lint.run/usage/linters/#disabled-by-default-linters--e--enable
+  default: all
   disable:
-    # unsupported
-    - rowserrcheck
-    - sqlclosecheck
-    - wastedassign
-    - ireturn # not working with generics https://github.com/butuzov/ireturn/issues/37
-    - varnamelen # not useful
-    # unused
+    - depguard
     - exhaustruct
     - forbidigo
-    - depguard
+    - ireturn
     - maintidx
-    - tenv
-
-linters-settings:
-  decorder:
-    disable-init-func-first-check: false
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-    disable-default-exclusions: false
-    exclude-functions: []
-  errchkjson:
-    check-error-free-encoding: false
-    report-no-exported: true
-  errorlint:
-    errorf: false
-    errorf-multi: true
-    asserts: true
-    comparison: true
-  exhaustive:
-    check-generated: true
-    default-signifies-exhaustive: true
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/sighupio) # Custom section: groups all imports with the specified Prefix.
-    skip-generated: true
-    custom-order: true
-  cyclop:
-    max-complexity: 80
-  funlen:
-    lines: 400
-    statements: 182
-  gocognit:
-    min-complexity: 210
-  godot:
-    scope: all
-    exclude:
-      - "^fixme:"
-      - "^todo:"
-    capital: true
-    period: true
-  gofumpt:
-    extra-rules: true
-  goimports:
-    local-prefixes: github.com/sighupio
-  gomoddirectives:
-    # we need to use replace to be able to use Internal Kubernetes libraries
-    # needed for the create PKI feature.
-    replace-allow-list:
-      - k8s.io/api
-      - k8s.io/apiextensions-apiserver
-      - k8s.io/apimachinery
-      - k8s.io/apiserver
-      - k8s.io/cli-runtime
-      - k8s.io/client-go
-      - k8s.io/cloud-provider
-      - k8s.io/cluster-bootstrap
-      - k8s.io/code-generator
-      - k8s.io/component-base
-      - k8s.io/component-helpers
-      - k8s.io/controller-manager
-      - k8s.io/cri-api
-      - k8s.io/csi-translation-lib
-      - k8s.io/dynamic-resource-allocation
-      - k8s.io/endpointslice
-      - k8s.io/kms
-      - k8s.io/kube-aggregator
-      - k8s.io/kube-controller-manager
-      - k8s.io/kube-proxy
-      - k8s.io/kube-scheduler
-      - k8s.io/kubectl
-      - k8s.io/kubelet
-      - k8s.io/legacy-cloud-providers
-      - k8s.io/metrics
-      - k8s.io/mount-utils
-      - k8s.io/pod-security-admission
-      - k8s.io/sample-apiserver
-      - k8s.io/sample-cli-plugin
-      - k8s.io/sample-controller
-  gosec:
-    excludes:
-      - G204
-      - G101
-  grouper:
-    const-require-single-const: true
-    const-require-grouping: false
-    import-require-single-import: true
-    import-require-grouping: false
-    var-require-single-var: true
-    var-require-grouping: false
-  nestif:
-    min-complexity: 60
-  nolintlint:
-    require-explanation: true
-    require-specific: true
-  revive:
-    enable-all-rules: true
+    - rowserrcheck
+    - sqlclosecheck
+    - varnamelen
+    - wastedassign
+  settings:
+    cyclop:
+      max-complexity: 80
+    decorder:
+      disable-init-func-first-check: false
+    errcheck:
+      disable-default-exclusions: false
+      check-type-assertions: true
+      check-blank: true
+    errchkjson:
+      check-error-free-encoding: false
+      report-no-exported: true
+    errorlint:
+      errorf: false
+      errorf-multi: true
+      asserts: true
+      comparison: true
+    exhaustive:
+      default-signifies-exhaustive: true
+    funlen:
+      lines: 400
+      statements: 182
+    gocognit:
+      min-complexity: 210
+    godot:
+      scope: all
+      exclude:
+        - '^fixme:'
+        - '^todo:'
+      capital: true
+      period: true
+    gomoddirectives:
+      # we need to use replace to be able to use Internal Kubernetes libraries
+      # needed for the create PKI feature.
+      replace-allow-list:
+        - k8s.io/api
+        - k8s.io/apiextensions-apiserver
+        - k8s.io/apimachinery
+        - k8s.io/apiserver
+        - k8s.io/cli-runtime
+        - k8s.io/client-go
+        - k8s.io/cloud-provider
+        - k8s.io/cluster-bootstrap
+        - k8s.io/code-generator
+        - k8s.io/component-base
+        - k8s.io/component-helpers
+        - k8s.io/controller-manager
+        - k8s.io/cri-api
+        - k8s.io/csi-translation-lib
+        - k8s.io/dynamic-resource-allocation
+        - k8s.io/endpointslice
+        - k8s.io/kms
+        - k8s.io/kube-aggregator
+        - k8s.io/kube-controller-manager
+        - k8s.io/kube-proxy
+        - k8s.io/kube-scheduler
+        - k8s.io/kubectl
+        - k8s.io/kubelet
+        - k8s.io/legacy-cloud-providers
+        - k8s.io/metrics
+        - k8s.io/mount-utils
+        - k8s.io/pod-security-admission
+        - k8s.io/sample-apiserver
+        - k8s.io/sample-cli-plugin
+        - k8s.io/sample-controller
+    gosec:
+      excludes:
+        - G204
+        - G101
+    grouper:
+      const-require-single-const: true
+      const-require-grouping: false
+      import-require-single-import: true
+      import-require-grouping: false
+      var-require-single-var: true
+      var-require-grouping: false
+    nestif:
+      min-complexity: 60
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+    revive:
+      enable-all-rules: true
+      rules:
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
+        - name: add-constant
+          arguments:
+            - allowFloats: 0.0,0.,1.0,1.,2.0,2.
+              allowInts: 0,1,2
+              allowStrs: '""'
+              maxLitCount: "15"
+          severity: warning
+          disabled: false
+        - name: argument-limit
+          arguments:
+            - 10
+          severity: warning
+          disabled: false
+        - name: atomic
+          severity: warning
+          disabled: false
+        - name: banned-characters
+          arguments:
+            - Ω
+            - Σ
+            - σ
+            - "7"
+          severity: warning
+          disabled: false
+        - name: bare-return
+          severity: warning
+          disabled: false
+        - name: blank-imports
+          severity: warning
+          disabled: true
+        - name: bool-literal-in-expr
+          severity: warning
+          disabled: false
+        - name: call-to-gc
+          severity: warning
+          disabled: false
+        - name: cognitive-complexity
+          arguments:
+            - 210
+          severity: warning
+          disabled: false
+        - name: comment-spacings
+          arguments:
+            - nolint
+          severity: warning
+          disabled: false
+        - name: confusing-naming
+          severity: warning
+          disabled: false
+        - name: confusing-results
+          severity: warning
+          disabled: true
+        - name: constant-logical-expr
+          severity: warning
+          disabled: false
+        - name: context-as-argument
+          severity: warning
+          disabled: false
+        - name: context-keys-type
+          severity: warning
+          disabled: false
+        - name: cyclomatic
+          arguments:
+            - 80
+          severity: warning
+          disabled: false
+        - name: datarace
+          severity: warning
+          disabled: false
+        - name: deep-exit
+          severity: warning
+          disabled: false
+        - name: defer
+          arguments:
+            - - call-chain
+              - loop
+          severity: warning
+          disabled: false
+        - name: dot-imports
+          severity: warning
+          disabled: false
+        - name: duplicated-imports
+          severity: warning
+          disabled: false
+        - name: early-return
+          severity: warning
+          disabled: false
+        - name: empty-block
+          severity: warning
+          disabled: false
+        - name: empty-lines
+          severity: warning
+          disabled: false
+        - name: error-naming
+          severity: warning
+          disabled: false
+        - name: error-return
+          severity: warning
+          disabled: false
+        - name: error-strings
+          severity: warning
+          disabled: false
+        - name: errorf
+          severity: warning
+          disabled: false
+        - name: exported
+          arguments:
+            - checkPrivateReceivers
+            - sayRepetitiveInsteadOfStutters
+          severity: warning
+          disabled: false
+        - name: file-header
+          arguments:
+            - This is the text that must appear at the top of source files.
+          severity: warning
+          disabled: true
+        - name: flag-parameter
+          severity: warning
+          disabled: false
+        - name: function-result-limit
+          arguments:
+            - 4
+          severity: warning
+          disabled: false
+        - name: function-length
+          arguments:
+            - 200
+            - 0
+          severity: warning
+          disabled: false
+        - name: get-return
+          severity: warning
+          disabled: false
+        - name: identical-branches
+          severity: warning
+          disabled: false
+        - name: if-return
+          severity: warning
+          disabled: false
+        - name: increment-decrement
+          severity: warning
+          disabled: false
+        - name: indent-error-flow
+          severity: warning
+          disabled: false
+        - name: imports-blocklist
+          arguments:
+            - crypto/md5
+            - crypto/sha1
+          severity: warning
+          disabled: false
+        - name: import-shadowing
+          severity: warning
+          disabled: false
+        - name: line-length-limit
+          arguments:
+            - 140
+          severity: warning
+          disabled: true
+        - name: max-public-structs
+          arguments:
+            - 10
+          severity: warning
+          disabled: false
+        - name: modifies-parameter
+          severity: warning
+          disabled: false
+        - name: modifies-value-receiver
+          severity: warning
+          disabled: false
+        - name: nested-structs
+          severity: warning
+          disabled: false
+        - name: optimize-operands-order
+          severity: warning
+          disabled: false
+        - name: package-comments
+          severity: warning
+          disabled: false
+        - name: range
+          severity: warning
+          disabled: false
+        - name: range-val-in-closure
+          severity: warning
+          disabled: false
+        - name: range-val-address
+          severity: warning
+          disabled: false
+        - name: receiver-naming
+          severity: warning
+          disabled: false
+        - name: redefines-builtin-id
+          severity: warning
+          disabled: false
+        - name: string-of-int
+          severity: warning
+          disabled: false
+        - name: string-format
+          arguments:
+            - - core.WriteError[1].Message
+              - /^([^A-Z]|$)/
+              - must not start with a capital letter
+            - - fmt.Errorf[0]
+              - /(^|[^\.!?])$/
+              - must not end in punctuation
+            - - panic
+              - /^[^\n]*$/
+              - must not contain line breaks
+          severity: warning
+          disabled: false
+        - name: struct-tag
+          severity: warning
+          disabled: false
+        - name: superfluous-else
+          severity: warning
+          disabled: false
+        - name: time-equal
+          severity: warning
+          disabled: false
+        - name: time-naming
+          severity: warning
+          disabled: false
+        - name: var-naming
+          arguments:
+            - - ID
+            - - VM
+          severity: warning
+          disabled: false
+        - name: var-declaration
+          severity: warning
+          disabled: false
+        - name: unconditional-recursion
+          severity: warning
+          disabled: false
+        - name: unexported-naming
+          severity: warning
+          disabled: false
+        - name: unexported-return
+          severity: warning
+          disabled: false
+        - name: unhandled-error
+          arguments:
+            - fmt.Printf
+            - myFunction
+          severity: warning
+          disabled: false
+        - name: unnecessary-stmt
+          severity: warning
+          disabled: false
+        - name: unreachable-code
+          severity: warning
+          disabled: false
+        - name: unused-parameter
+          severity: warning
+          disabled: false
+        - name: unused-receiver
+          severity: warning
+          disabled: false
+        - name: useless-break
+          severity: warning
+          disabled: false
+        - name: waitgroup-by-value
+          severity: warning
+          disabled: false
+    varnamelen:
+      check-receiver: true
+      check-return: true
+      check-type-param: false
+      ignore-names:
+        - err
+      ignore-type-assert-ok: true
+      ignore-map-index-ok: true
+      ignore-chan-recv-ok: true
+      ignore-decls:
+        - c echo.Context
+        - t testing.T
+        - e error
+        - i int
+        - const C
+        - T any
+        - m map[string]int
+    wsl:
+      allow-multiline-assign: true
+      force-case-trailing-whitespace: 1
+      allow-separated-leading-comment: false
+      allow-cuddle-declarations: false
+      force-err-cuddling: true
+  exclusions:
+    generated: disable
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
-      - name: add-constant
-        severity: warning
-        disabled: false
-        arguments:
-          - maxLitCount: "15"
-            allowStrs: '""'
-            allowInts: "0,1,2"
-            allowFloats: "0.0,0.,1.0,1.,2.0,2."
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#argument-limit
-      - name: argument-limit
-        severity: warning
-        disabled: false
-        arguments: [10]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#atomic
-      - name: atomic
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#banned-characters
-      - name: banned-characters
-        severity: warning
-        disabled: false
-        arguments: ["Ω", "Σ", "σ", "7"]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bare-return
-      - name: bare-return
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#blank-imports
-      - name: blank-imports
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-      - name: bool-literal-in-expr
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#call-to-gc
-      - name: call-to-gc
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
-      - name: cognitive-complexity
-        severity: warning
-        disabled: false
-        arguments: [210]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings
-      - name: comment-spacings
-        severity: warning
-        disabled: false
-        arguments: ["nolint"]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming
-      - name: confusing-naming
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-results
-      - name: confusing-results
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#constant-logical-expr
-      - name: constant-logical-expr
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
-      - name: context-as-argument
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-keys-type
-      - name: context-keys-type
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
-      - name: cyclomatic
-        severity: warning
-        disabled: false
-        arguments: [80]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#datarace
-      - name: datarace
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#deep-exit
-      - name: deep-exit
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
-      - name: defer
-        severity: warning
-        disabled: false
-        arguments:
-          - ["call-chain", "loop"]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
-      - name: dot-imports
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
-      - name: duplicated-imports
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
-      - name: early-return
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-block
-      - name: empty-block
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
-      - name: empty-lines
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-naming
-      - name: error-naming
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-return
-      - name: error-return
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
-      - name: error-strings
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#errorf
-      - name: errorf
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
-      - name: exported
-        severity: warning
-        disabled: false
-        arguments:
-          - "checkPrivateReceivers"
-          - "sayRepetitiveInsteadOfStutters"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#file-header
-      - name: file-header
-        severity: warning
-        disabled: true
-        arguments:
-          - This is the text that must appear at the top of source files.
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
-      - name: flag-parameter
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-result-limit
-      - name: function-result-limit
-        severity: warning
-        disabled: false
-        arguments: [4]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-length
-      - name: function-length
-        severity: warning
-        disabled: false
-        arguments: [200, 0]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#get-return
-      - name: get-return
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#identical-branches
-      - name: identical-branches
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
-      - name: if-return
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#increment-decrement
-      - name: increment-decrement
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
-      - name: indent-error-flow
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#imports-blacklist
-      - name: imports-blocklist
-        severity: warning
-        disabled: false
-        arguments:
-          - "crypto/md5"
-          - "crypto/sha1"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
-      - name: import-shadowing
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
-      - name: line-length-limit
-        severity: warning
-        disabled: true
-        arguments: [140]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
-      - name: max-public-structs
-        severity: warning
-        disabled: false
-        arguments: [10]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-parameter
-      - name: modifies-parameter
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-value-receiver
-      - name: modifies-value-receiver
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#nested-structs
-      - name: nested-structs
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#optimize-operands-order
-      - name: optimize-operands-order
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
-      - name: package-comments
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range
-      - name: range
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-in-closure
-      - name: range-val-in-closure
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
-      - name: range-val-address
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#receiver-naming
-      - name: receiver-naming
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redefines-builtin-id
-      - name: redefines-builtin-id
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-of-int
-      - name: string-of-int
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
-      - name: string-format
-        severity: warning
-        disabled: false
-        arguments:
-          - - "core.WriteError[1].Message"
-            - "/^([^A-Z]|$)/"
-            - must not start with a capital letter
-          - - "fmt.Errorf[0]"
-            - '/(^|[^\.!?])$/'
-            - must not end in punctuation
-          - - panic
-            - '/^[^\n]*$/'
-            - must not contain line breaks
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
-      - name: struct-tag
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
-      - name: superfluous-else
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
-      - name: time-equal
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-naming
-      - name: time-naming
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
-      - name: var-naming
-        severity: warning
-        disabled: false
-        arguments:
-          - ["ID"] # AllowList
-          - ["VM"] # DenyList
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-declaration
-      - name: var-declaration
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unconditional-recursion
-      - name: unconditional-recursion
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-naming
-      - name: unexported-naming
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
-      - name: unexported-return
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
-      - name: unhandled-error
-        severity: warning
-        disabled: false
-        arguments:
-          - "fmt.Printf"
-          - "myFunction"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt
-      - name: unnecessary-stmt
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code
-      - name: unreachable-code
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
-      - name: unused-parameter
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
-      - name: unused-receiver
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
-      - name: useless-break
-        severity: warning
-        disabled: false
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#waitgroup-by-value
-      - name: waitgroup-by-value
-        severity: warning
-        disabled: false
-  varnamelen:
-    check-receiver: true
-    check-return: true
-    check-type-param: false
-    ignore-type-assert-ok: true
-    ignore-map-index-ok: true
-    ignore-chan-recv-ok: true
-    ignore-names:
-      - err
-    ignore-decls:
-      - c echo.Context
-      - t testing.T
-      - e error
-      - i int
-      - const C
-      - T any
-      - m map[string]int
-  wsl:
-    allow-cuddle-declarations: false
-    allow-multiline-assign: true
-    allow-separated-leading-comment: false
-    force-case-trailing-whitespace: 1
-    force-err-cuddling: true
+      - path: _test\.go
+        linters:
+          - cyclop
+          - dupl
+          - err113
+          - errcheck
+          - forcetypeassert
+          - funlen
+          - gochecknoglobals
+          - goconst
+          - gocyclo
+          - gosec
+          - lll
+          - maintidx
+          - revive
+      - path: main\.go
+        linters:
+          - gochecknoglobals
+      - path: cmd
+        linters:
+          - lll
+      - path: internal/apis/kfd/v1alpha2/.*/(public|private)/schema\.go
+        linters:
+          - godot
+          - lll
+          - revive
+          - staticcheck
+          - tagalign
+          - tagliatelle
+      - path: internal/apis/config/
+        linters:
+          - exptostd
+          - gochecknoglobals
+          - godot
+          - revive
+          - staticcheck
+          - tagalign
+          - tagliatelle
+
+    paths:
+      - .*\.gen\.go$
+      - file_getter.go
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # List of regexps of issue texts to exclude.
-  #
-  # But independently of this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`.
-  # To list all excluded by default patterns execute `golangci-lint run --help`
-  #
-  # Default: []
-  exclude: []
-
-  exclude-files:
-    - ".*\\.gen\\.go$"
-    - "file_getter.go"
-
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gochecknoglobals
-        - cyclop
-        - dupl
-        - errcheck
-        - forcetypeassert
-        - funlen
-        - goconst
-        - gocyclo
-        - goerr113
-        - gosec
-        - lll
-        - maintidx
-        - revive
-    - path: main\.go
-      linters:
-        - gochecknoglobals
-    - path: cmd
-      linters:
-        - lll
-    # Hand-maintained config "mirror" types. Field and yaml-tag names
-    # intentionally follow the distribution JSON schema / furyctl.yaml keys, so
-    # the structs read like a furyctl.yaml and the tags match the real keys
-    # (renaming them to Go style would break unmarshaling). These replace the
-    # types that used to be code-generated (and thus auto-excluded from lint),
-    # so they are excluded from the naming/style linters.
-    - path: internal/apis/kfd/v1alpha2/.*/(public|private)/schema\.go
-      linters:
-        - revive
-        - stylecheck
-        - tagliatelle
-        - tagalign
-        - godot
-        - lll
-    - path: internal/apis/config/
-      linters:
-        - revive
-        - stylecheck
-        - tagliatelle
-        - tagalign
-        - godot
-        - gochecknoglobals
-        - exptostd
-  # Independently of option `exclude` we use default exclude patterns,
-  # it can be disabled by this option.
-  # To list all excluded by default patterns execute `golangci-lint run --help`.
-  # Default: true.
-  exclude-use-default: true
-
-  # If set to true exclude and exclude-rules regular expressions become case-sensitive.
-  # Default: false
-  exclude-case-sensitive: false
-
-  # The list of ids of default excludes to include or disable.
-  # Default: []
-  include: []
-
-  # Maximum issues count per one linter.
-  # Set to 0 to disable.
-  # Default: 50
   max-issues-per-linter: 50
-
-  # Maximum count of issues with the same text.
-  # Set to 0 to disable.
-  # Default: 3
   max-same-issues: 3
-
-  # Show only new issues: if there are unstaged changes or untracked files,
-  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
-  # It's a super-useful option for integration of golangci-lint into existing large codebase.
-  # It's not practical to fix all existing issues at the moment of integration:
-  # much better don't allow issues in new code.
-  #
-  # Default: false.
   new: false
-
-  # Show only new issues created after git revision `REV`.
-  # new-from-rev: HEAD
-
-  # Show only new issues created in git patch with set file path.
-  # new-from-patch: path/to/patch/file
-
-  # Fix found issues (if it's supported by the linter).
   fix: false
-
 severity:
-  # Set the default severity for issues.
-  #
-  # If severity rules are defined and the issues do not match or no severity is provided to the rule
-  # this will be the default severity applied.
-  # Severities should match the supported severity names of the selected out format.
-  # - Code climate: https://docs.codeclimate.com/docs/issues#issue-severity
-  # - Checkstyle: https://checkstyle.sourceforge.io/property_types.html#severity
-  # - GitHub: https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
-  #
-  # Default value is an empty string.
-  default-severity: error
-
-  # If set to true `severity-rules` regular expressions become case-sensitive.
-  # Default: false
-  case-sensitive: true
-
-  # When a list of severity rules are provided, severity information will be added to lint issues.
-  # Severity rules have the same filtering capability as exclude rules
-  # except you are allowed to specify one matcher per severity rule.
-  # Only affects out formats that support setting severity information.
-  #
-  # Default: []
+  default: error
   rules:
     - linters:
         - dupl
       severity: info
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/sighupio)
+      custom-order: true
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/sighupio
+  exclusions:
+    generated: disable
+    paths:
+      - .*\.gen\.go$
+      - file_getter.go

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -283,7 +283,7 @@ func NewApplyCmd() *cobra.Command {
 
 			if err := clusterCreator.Create(
 				flags.StartFrom,
-				flags.Timeouts.ProcessTimeout,
+				flags.ProcessTimeout,
 				flags.PodRunningCheckTimeout,
 			); err != nil {
 				cmdEvent.AddErrorMessage(err)

--- a/cmd/dump/cmd-to-md.go
+++ b/cmd/dump/cmd-to-md.go
@@ -110,13 +110,13 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	}
 
 	if cmd.Runnable() {
-		if _, err := buf.WriteString(fmt.Sprintf("## Usage\n\n```bash\n%s\n```\n\n", strings.ReplaceAll(cmd.UseLine(), "\t", "  "))); err != nil {
+		if _, err := fmt.Fprintf(buf, "## Usage\n\n```bash\n%s\n```\n\n", strings.ReplaceAll(cmd.UseLine(), "\t", "  ")); err != nil {
 			return fmt.Errorf("error while writing to buffer: %w", err)
 		}
 	}
 
 	if len(cmd.Example) > 0 {
-		if _, err := buf.WriteString(fmt.Sprintf("## Examples\n\n```bash\n%s\n```\n\n", strings.ReplaceAll(cmd.Example, "\t", "  "))); err != nil {
+		if _, err := fmt.Fprintf(buf, "## Examples\n\n```bash\n%s\n```\n\n", strings.ReplaceAll(cmd.Example, "\t", "  ")); err != nil {
 			return fmt.Errorf("error while writing to buffer: %w", err)
 		}
 	}
@@ -136,7 +136,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			link := pname + markdownExtension
 			link = strings.ReplaceAll(link, " ", "_")
 
-			if _, err := buf.WriteString(fmt.Sprintf("* [%s](%s) - %s\n", pname, linkHandler(link), parent.Short)); err != nil {
+			if _, err := fmt.Fprintf(buf, "* [%s](%s) - %s\n", pname, linkHandler(link), parent.Short); err != nil {
 				return fmt.Errorf("error while writing to buffer: %w", err)
 			}
 
@@ -161,7 +161,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			link := cname + markdownExtension
 			link = strings.ReplaceAll(link, " ", "_")
 
-			if _, err := buf.WriteString(fmt.Sprintf("* [%s](%s) - %s\n", cname, linkHandler(link), child.Short)); err != nil {
+			if _, err := fmt.Fprintf(buf, "* [%s](%s) - %s\n", cname, linkHandler(link), child.Short); err != nil {
 				return fmt.Errorf("error while writing to buffer: %w", err)
 			}
 		}

--- a/internal/apis/kfd/v1alpha2/immutable/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/distribution.go
@@ -85,8 +85,8 @@ func (d *Distribution) prepare() (template.Config, error) {
 		return template.Config{}, fmt.Errorf("error creating distribution phase folder: %w", err)
 	}
 
-	if _, err := os.Stat(path.Join(d.OperationPhase.Path, "manifests")); os.IsNotExist(err) {
-		if err := os.Mkdir(path.Join(d.OperationPhase.Path, "manifests"), iox.FullPermAccess); err != nil {
+	if _, err := os.Stat(path.Join(d.Path, "manifests")); os.IsNotExist(err) {
+		if err := os.Mkdir(path.Join(d.Path, "manifests"), iox.FullPermAccess); err != nil {
 			return template.Config{}, fmt.Errorf("error creating manifests folder: %w", err)
 		}
 	}

--- a/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
@@ -186,11 +186,11 @@ func (k *Kubernetes) coreKubernetes(
 			upgradeState.Phases.Kubernetes.Status = upgrade.PhaseStatusSuccess
 		}
 
-		if err := kubex.SetConfigEnv(path.Join(k.OperationPhase.Path, "admin.conf")); err != nil {
+		if err := kubex.SetConfigEnv(path.Join(k.Path, "admin.conf")); err != nil {
 			return fmt.Errorf("error setting kubeconfig env: %w", err)
 		}
 
-		if err := kubex.CopyToWorkDir(path.Join(k.OperationPhase.Path, "admin.conf"), "kubeconfig"); err != nil {
+		if err := kubex.CopyToWorkDir(path.Join(k.Path, "admin.conf"), "kubeconfig"); err != nil {
 			return fmt.Errorf("error copying kubeconfig: %w", err)
 		}
 
@@ -198,7 +198,7 @@ func (k *Kubernetes) coreKubernetes(
 			for _, username := range k.furyctlConf.Spec.Kubernetes.Advanced.Users.Names {
 				if err := kubex.CopyToWorkDir(
 					path.Join(
-						k.OperationPhase.Path,
+						k.Path,
 						username+".kubeconfig",
 					),
 					username+".kubeconfig",

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/distribution.go
@@ -143,8 +143,8 @@ func (d *Distribution) prepare() (template.Config, error) {
 		return template.Config{}, fmt.Errorf("error creating distribution phase folder: %w", err)
 	}
 
-	if _, err := os.Stat(path.Join(d.OperationPhase.Path, "manifests")); os.IsNotExist(err) {
-		if err := os.Mkdir(path.Join(d.OperationPhase.Path, "manifests"), iox.FullPermAccess); err != nil {
+	if _, err := os.Stat(path.Join(d.Path, "manifests")); os.IsNotExist(err) {
+		if err := os.Mkdir(path.Join(d.Path, "manifests"), iox.FullPermAccess); err != nil {
 			return template.Config{}, fmt.Errorf("error creating manifests folder: %w", err)
 		}
 	}

--- a/internal/apis/kfd/v1alpha2/kfddistribution/delete/distribution.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/delete/distribution.go
@@ -90,8 +90,8 @@ func (d *Distribution) Exec() error {
 		return fmt.Errorf("error creating distribution phase folder: %w", err)
 	}
 
-	if _, err := os.Stat(path.Join(d.OperationPhase.Path, "manifests")); os.IsNotExist(err) {
-		if err := os.Mkdir(path.Join(d.OperationPhase.Path, "manifests"), iox.FullPermAccess); err != nil {
+	if _, err := os.Stat(path.Join(d.Path, "manifests")); os.IsNotExist(err) {
+		if err := os.Mkdir(path.Join(d.Path, "manifests"), iox.FullPermAccess); err != nil {
 			return fmt.Errorf("error creating manifests folder: %w", err)
 		}
 	}

--- a/internal/apis/kfd/v1alpha2/onpremises/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/distribution.go
@@ -85,8 +85,8 @@ func (d *Distribution) prepare() (template.Config, error) {
 		return template.Config{}, fmt.Errorf("error creating distribution phase folder: %w", err)
 	}
 
-	if _, err := os.Stat(path.Join(d.OperationPhase.Path, "manifests")); os.IsNotExist(err) {
-		if err := os.Mkdir(path.Join(d.OperationPhase.Path, "manifests"), iox.FullPermAccess); err != nil {
+	if _, err := os.Stat(path.Join(d.Path, "manifests")); os.IsNotExist(err) {
+		if err := os.Mkdir(path.Join(d.Path, "manifests"), iox.FullPermAccess); err != nil {
 			return template.Config{}, fmt.Errorf("error creating manifests folder: %w", err)
 		}
 	}

--- a/internal/apis/kfd/v1alpha2/onpremises/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/kubernetes.go
@@ -228,11 +228,11 @@ func (k *Kubernetes) coreKubernetes(
 			upgradeState.Phases.Kubernetes.Status = upgrade.PhaseStatusSuccess
 		}
 
-		if err := kubex.SetConfigEnv(path.Join(k.OperationPhase.Path, "admin.conf")); err != nil {
+		if err := kubex.SetConfigEnv(path.Join(k.Path, "admin.conf")); err != nil {
 			return fmt.Errorf("error setting kubeconfig env: %w", err)
 		}
 
-		if err := kubex.CopyToWorkDir(path.Join(k.OperationPhase.Path, "admin.conf"), "kubeconfig"); err != nil {
+		if err := kubex.CopyToWorkDir(path.Join(k.Path, "admin.conf"), "kubeconfig"); err != nil {
 			return fmt.Errorf("error copying kubeconfig: %w", err)
 		}
 
@@ -240,7 +240,7 @@ func (k *Kubernetes) coreKubernetes(
 			for _, username := range k.furyctlConf.Spec.Kubernetes.Advanced.Users.Names {
 				if err := kubex.CopyToWorkDir(
 					path.Join(
-						k.OperationPhase.Path,
+						k.Path,
 						username+".kubeconfig",
 					),
 					username+".kubeconfig",

--- a/internal/apis/kfd/v1alpha2/onpremises/delete/distribution.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/delete/distribution.go
@@ -43,8 +43,8 @@ func (d *Distribution) Exec() error {
 		return fmt.Errorf("error creating distribution phase folder: %w", err)
 	}
 
-	if _, err := os.Stat(path.Join(d.OperationPhase.Path, "manifests")); os.IsNotExist(err) {
-		if err := os.Mkdir(path.Join(d.OperationPhase.Path, "manifests"), iox.FullPermAccess); err != nil {
+	if _, err := os.Stat(path.Join(d.Path, "manifests")); os.IsNotExist(err) {
+		if err := os.Mkdir(path.Join(d.Path, "manifests"), iox.FullPermAccess); err != nil {
 			return fmt.Errorf("error creating manifests folder: %w", err)
 		}
 	}

--- a/internal/x/exec/cmd.go
+++ b/internal/x/exec/cmd.go
@@ -138,29 +138,28 @@ func (c *Cmd) RunWithTimeout(timeout time.Duration) error {
 
 	defer cancel()
 
-	if len(c.Cmd.Args) == 1 {
-		cmdCtx = exec.CommandContext(ctx, c.Cmd.Path)
+	if len(c.Args) == 1 {
+		cmdCtx = exec.CommandContext(ctx, c.Path)
 	} else {
-		args := c.Cmd.Args[1:]
-
-		cmdCtx = exec.CommandContext(ctx, c.Cmd.Path, args...)
+		args := c.Args[1:]
+		cmdCtx = exec.CommandContext(ctx, c.Path, args...)
 	}
 
-	cmdCtx.Dir = c.Cmd.Dir
-	cmdCtx.Env = c.Cmd.Env
-	cmdCtx.Stdout = c.Cmd.Stdout
-	cmdCtx.Stderr = c.Cmd.Stderr
+	cmdCtx.Dir = c.Dir
+	cmdCtx.Env = c.Env
+	cmdCtx.Stdout = c.Stdout
+	cmdCtx.Stderr = c.Stderr
 
 	err := cmdCtx.Run()
 
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return fmt.Errorf(
-			"%w after %s: %s %s", ErrCmdTimeout, timeout, c.Cmd.Path, strings.Join(c.Cmd.Args, " "),
+			"%w after %s: %s %s", ErrCmdTimeout, timeout, c.Path, strings.Join(c.Args, " "),
 		)
 	}
 
 	if err != nil {
-		return NewErrCmdFailed(c.Cmd.Path, c.Cmd.Args, err, c.Log)
+		return NewErrCmdFailed(c.Path, c.Args, err, c.Log)
 	}
 
 	return nil
@@ -192,12 +191,12 @@ func CombinedOutput(cmd *Cmd) (string, error) {
 	errOut := cmd.Log.Err.String()
 
 	if cmd.Sensitive {
-		outB, ok := cmd.Cmd.Stdout.(*bytes.Buffer)
+		outB, ok := cmd.Stdout.(*bytes.Buffer)
 		if !ok {
 			return "", ErrCastingToBuffer
 		}
 
-		errOutB, ok := cmd.Cmd.Stderr.(*bytes.Buffer)
+		errOutB, ok := cmd.Stderr.(*bytes.Buffer)
 		if !ok {
 			return "", ErrCastingToBuffer
 		}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-#golangci-lint = "1.64.8"
+golangci-lint = "1.64.8"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"
@@ -123,13 +123,13 @@ run = [
   "mise run formattag",
 ]
 
-#[tasks.lint]
-#description = "run linting with golangci-lint"
-#run = "golangci-lint -v run --color=always --max-same-issues 25 --config=.rules/.golangci.yml ./..."
+[tasks.lint]
+description = "run linting with golangci-lint"
+run = "golangci-lint -v run --color=always --max-same-issues 25 --config=.rules/.golangci.yml ./..."
 
-#[tasks.lint-go-common]
-#description = "run common linting rules without config"
-#run = "golangci-lint run --no-config -E godot -E wsl -E nlreturn -E grouper --color=always --max-same-issues 25 ./..."
+[tasks.lint-go-common]
+description = "run common linting rules without config"
+run = "golangci-lint run --no-config -E godot -E wsl -E nlreturn -E grouper --color=always --max-same-issues 25 ./..."
 
 [tasks.test-unit]
 description = "run unit tests"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "1.64.8"
+golangci-lint = "2.0.2"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"

--- a/mise.toml
+++ b/mise.toml
@@ -126,7 +126,7 @@ run = [
 [tasks.lint]
 description = "run linting with golangci-lint"
 env = { GOMEMLIMIT = "1GiB" }
-run = "golangci-lint -v run --color=always --max-same-issues 25 --config=.rules/.golangci.yml ./..."
+run = "golangci-lint -v run --timeout=5m --color=always --max-same-issues 25 --config=.rules/.golangci.yml ./..."
 
 [tasks.lint-go-common]
 description = "run common linting rules without config"

--- a/mise.toml
+++ b/mise.toml
@@ -125,6 +125,7 @@ run = [
 
 [tasks.lint]
 description = "run linting with golangci-lint"
+env = { GOMEMLIMIT = "1GiB" }
 run = "golangci-lint -v run --color=always --max-same-issues 25 --config=.rules/.golangci.yml ./..."
 
 [tasks.lint-go-common]

--- a/pkg/rulesextractor/ekscluster.go
+++ b/pkg/rulesextractor/ekscluster.go
@@ -31,7 +31,7 @@ func NewEKSClusterRulesExtractor(distributionPath string, renderedConfig map[str
 
 	builder.Spec = spec
 	builder.BaseExtractor = NewBaseExtractor(spec)
-	builder.BaseExtractor.RenderedConfig = renderedConfig
+	builder.RenderedConfig = renderedConfig
 
 	return &builder, nil
 }
@@ -95,21 +95,21 @@ func (r *EKSExtractor) GetReducers(phase string) []Rule {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Infrastructure)
+		return r.ExtractReducerRules(*r.Spec.Infrastructure)
 
 	case cluster.OperationPhaseKubernetes:
 		if r.Spec.Kubernetes == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Kubernetes)
+		return r.ExtractReducerRules(*r.Spec.Kubernetes)
 
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Distribution)
+		return r.ExtractReducerRules(*r.Spec.Distribution)
 
 	default:
 		return []Rule{}
@@ -123,21 +123,21 @@ func (r *EKSExtractor) GetUnsupportedRules(phase string) []Rule {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Infrastructure)
+		return r.ExtractUnsupportedRules(*r.Spec.Infrastructure)
 
 	case cluster.OperationPhaseKubernetes:
 		if r.Spec.Kubernetes == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Kubernetes)
+		return r.ExtractUnsupportedRules(*r.Spec.Kubernetes)
 
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Distribution)
+		return r.ExtractUnsupportedRules(*r.Spec.Distribution)
 
 	default:
 		return []Rule{}

--- a/pkg/rulesextractor/immutable.go
+++ b/pkg/rulesextractor/immutable.go
@@ -38,7 +38,7 @@ func NewImmutableClusterRulesExtractor(
 
 	builder.Spec = spec
 	builder.BaseExtractor = NewBaseExtractor(spec)
-	builder.BaseExtractor.RenderedConfig = renderedConfig
+	builder.RenderedConfig = renderedConfig
 
 	return &builder, nil
 }
@@ -102,21 +102,21 @@ func (r *ImmutableExtractor) GetReducers(phase string) []Rule {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Infrastructure)
+		return r.ExtractReducerRules(*r.Spec.Infrastructure)
 
 	case cluster.OperationPhaseKubernetes:
 		if r.Spec.Kubernetes == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Kubernetes)
+		return r.ExtractReducerRules(*r.Spec.Kubernetes)
 
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Distribution)
+		return r.ExtractReducerRules(*r.Spec.Distribution)
 
 	default:
 		return []Rule{}
@@ -130,21 +130,21 @@ func (r *ImmutableExtractor) GetUnsupportedRules(phase string) []Rule {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Infrastructure)
+		return r.ExtractUnsupportedRules(*r.Spec.Infrastructure)
 
 	case cluster.OperationPhaseKubernetes:
 		if r.Spec.Kubernetes == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Kubernetes)
+		return r.ExtractUnsupportedRules(*r.Spec.Kubernetes)
 
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Distribution)
+		return r.ExtractUnsupportedRules(*r.Spec.Distribution)
 
 	default:
 		return []Rule{}

--- a/pkg/rulesextractor/kfddistribution.go
+++ b/pkg/rulesextractor/kfddistribution.go
@@ -70,7 +70,7 @@ func (r *DistroExtractor) GetReducers(phase string) []Rule {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Distribution)
+		return r.ExtractReducerRules(*r.Spec.Distribution)
 
 	default:
 		return []Rule{}
@@ -84,7 +84,7 @@ func (r *DistroExtractor) GetUnsupportedRules(phase string) []Rule {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Distribution)
+		return r.ExtractUnsupportedRules(*r.Spec.Distribution)
 
 	default:
 		return []Rule{}

--- a/pkg/rulesextractor/onpremises.go
+++ b/pkg/rulesextractor/onpremises.go
@@ -82,14 +82,14 @@ func (r *OnPremExtractor) GetReducers(phase string) []Rule {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Kubernetes)
+		return r.ExtractReducerRules(*r.Spec.Kubernetes)
 
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractReducerRules(*r.Spec.Distribution)
+		return r.ExtractReducerRules(*r.Spec.Distribution)
 
 	default:
 		return []Rule{}
@@ -103,14 +103,14 @@ func (r *OnPremExtractor) GetUnsupportedRules(phase string) []Rule {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Kubernetes)
+		return r.ExtractUnsupportedRules(*r.Spec.Kubernetes)
 
 	case cluster.OperationPhaseDistribution:
 		if r.Spec.Distribution == nil {
 			return []Rule{}
 		}
 
-		return r.BaseExtractor.ExtractUnsupportedRules(*r.Spec.Distribution)
+		return r.ExtractUnsupportedRules(*r.Spec.Distribution)
 
 	default:
 		return []Rule{}

--- a/pkg/template/generator.go
+++ b/pkg/template/generator.go
@@ -73,12 +73,12 @@ func (g *Generator) ProcessTemplate() (*template.Template, error) {
 func (g *Generator) GetMissingKeys(tpl *template.Template) []string {
 	var missingKeys []string
 
-	if tpl == nil || tpl.Tree == nil || tpl.Tree.Root == nil {
+	if tpl == nil || tpl.Tree == nil || tpl.Root == nil {
 		return missingKeys
 	}
 
 	node := NewNode()
-	node.FromNodeList(tpl.Tree.Root.Nodes)
+	node.FromNodeList(tpl.Root.Nodes)
 
 	for _, f := range node.Fields {
 		val := g.getContextValueFromPath(f)

--- a/pkg/template/node.go
+++ b/pkg/template/node.go
@@ -108,16 +108,16 @@ func (t *TplNode) Set(n *Node) {
 type IfNode parse.IfNode
 
 func (i *IfNode) Set(n *Node) {
-	for _, cmd := range i.BranchNode.Pipe.Cmds {
+	for _, cmd := range i.Pipe.Cmds {
 		n.Set(n.FromNodeList(cmd.Args))
 	}
 
-	if i.BranchNode.List != nil {
-		n.Set(n.FromNodeList(i.BranchNode.List.Nodes))
+	if i.List != nil {
+		n.Set(n.FromNodeList(i.List.Nodes))
 	}
 
-	if i.BranchNode.ElseList != nil {
-		n.Set(n.FromNodeList(i.BranchNode.ElseList.Nodes))
+	if i.ElseList != nil {
+		n.Set(n.FromNodeList(i.ElseList.Nodes))
 	}
 }
 

--- a/test/utils/testutils.go
+++ b/test/utils/testutils.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:revive,stylecheck // dot import is required for ginkgo
-	. "github.com/onsi/gomega"    //nolint:revive,stylecheck // dot import is required for gomega
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck // dot import is required for ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck // dot import is required for gomega
 	"github.com/onsi/gomega/gexec"
 
 	"github.com/sighupio/furyctl/internal/cluster"


### PR DESCRIPTION
### Summary 💡

Update golangci-lint to 2.0.2


### Description 📝

Update golangci-lint to 2.0.2 + code alignments to new linters.
We can't enable the linting in CI until golanci-lint v2.4.0 due to golang v1.25.
The refactoring work isn't complete, but it's not easy to make all the fixes without being able to run the check command. Everything will be handled with version 2.4.0.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

Is not possibile to run lint checks with go 1.24

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

