### PR TITLE
chore: update golangci-lint to 2.1.6

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -316,6 +316,8 @@ linters:
           severity: warning
           disabled: false
         - name: struct-tag
+          arguments:
+            - "validate,api-version,cluster-kind,eks-version,permissive-semver,permissive-constraint,aws-region"
           severity: warning
           disabled: false
         - name: superfluous-else

--- a/internal/analytics/tracker.go
+++ b/internal/analytics/tracker.go
@@ -19,6 +19,13 @@ import (
 
 const isNext = true
 
+type Tracker struct {
+	trackingInfo
+	client mixpanel.Mixpanel
+	events chan Event
+	enable bool
+}
+
 func NewTracker(token, version, arch, os, org, hostname string) *Tracker {
 	const timeout = time.Second * 5
 
@@ -67,13 +74,6 @@ func NewTracker(token, version, arch, os, org, hostname string) *Tracker {
 	return tracker
 }
 
-type Tracker struct {
-	trackingInfo
-	client mixpanel.Mixpanel
-	events chan Event
-	enable bool
-}
-
 type trackingInfo map[string]string
 
 // Track collects the event to be consumed by the event processor.
@@ -100,6 +100,13 @@ func (a *Tracker) Flush() {
 
 		logrus.Trace("Flushed events queue")
 	}
+}
+
+// Disable disables the tracker.
+func (a *Tracker) Disable() {
+	a.enable = false
+
+	a.close()
 }
 
 // processEvents is the event processor: it will listen for new events and send them to mixpanel.
@@ -148,13 +155,6 @@ func (a *Tracker) sendEvent(event Event) error {
 	}
 
 	return nil
-}
-
-// Disable disables the tracker.
-func (a *Tracker) Disable() {
-	a.enable = false
-
-	a.close()
 }
 
 // close closes the tracker's event chan.

--- a/internal/apis/kfd/v1alpha2/ekscluster/common/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/common/distribution.go
@@ -96,78 +96,6 @@ func (d *Distribution) PreparePreTerraform() (
 	return furyctlMerger, preTfMerger, &tfCfg, nil
 }
 
-func (d *Distribution) injectDataPreTf(fMerger *merge.Merger) (*merge.Merger, error) {
-	vpcID, err := d.extractVpcIDFromPrevPhases(fMerger)
-	if err != nil {
-		return nil, err
-	}
-
-	if vpcID == "" {
-		return fMerger, nil
-	}
-
-	injectData := InjectType{
-		Data: private.SpecDistribution{
-			Modules: private.SpecDistributionModules{
-				Ingress: private.SpecDistributionModulesIngress{
-					Dns: &private.SpecDistributionModulesIngressDNS{
-						Private: &private.SpecDistributionModulesIngressDNSPrivate{
-							VpcId: vpcID,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	injectDataModel := merge.NewDefaultModelFromStruct(injectData, ".data", true)
-
-	merger := merge.NewMerger(
-		*fMerger.GetBase(),
-		injectDataModel,
-	)
-
-	_, err = merger.Merge()
-	if err != nil {
-		return nil, fmt.Errorf("error merging furyctl config: %w", err)
-	}
-
-	return merger, nil
-}
-
-func (d *Distribution) extractVpcIDFromPrevPhases(fMerger *merge.Merger) (string, error) {
-	vpcID := ""
-
-	if infraOutJSON, err := os.ReadFile(path.Join(d.InfrastructureTerraformOutputsPath, "output.json")); err == nil {
-		var infraOut terraform.OutputJSON
-
-		if err := json.Unmarshal(infraOutJSON, &infraOut); err == nil {
-			if infraOut["vpc_id"] != nil {
-				vpcIDOut, ok := infraOut["vpc_id"].Value.(string)
-				if !ok {
-					return vpcID, ErrCastingVpcIDToStr
-				}
-
-				return vpcIDOut, nil
-			}
-		}
-	}
-
-	fModel := merge.NewDefaultModel((*fMerger.GetBase()).Content(), ".spec.kubernetes")
-
-	kubeFromFuryctlConf, err := fModel.Get()
-	if err != nil {
-		return vpcID, fmt.Errorf("error getting kubernetes from furyctl config: %w", err)
-	}
-
-	vpcFromFuryctlConf, ok := kubeFromFuryctlConf["vpcId"].(string)
-	if !ok && !d.DryRun {
-		return vpcID, ErrCastingVpcIDToStr
-	}
-
-	return vpcFromFuryctlConf, nil
-}
-
 func (d *Distribution) PreparePostTerraform(
 	furyctlMerger *merge.Merger,
 	preTfMerger *merge.Merger,
@@ -285,6 +213,78 @@ func (d *Distribution) InjectDataPostTf(fMerger *merge.Merger) (*merge.Merger, e
 	}
 
 	return merger, nil
+}
+
+func (d *Distribution) injectDataPreTf(fMerger *merge.Merger) (*merge.Merger, error) {
+	vpcID, err := d.extractVpcIDFromPrevPhases(fMerger)
+	if err != nil {
+		return nil, err
+	}
+
+	if vpcID == "" {
+		return fMerger, nil
+	}
+
+	injectData := InjectType{
+		Data: private.SpecDistribution{
+			Modules: private.SpecDistributionModules{
+				Ingress: private.SpecDistributionModulesIngress{
+					Dns: &private.SpecDistributionModulesIngressDNS{
+						Private: &private.SpecDistributionModulesIngressDNSPrivate{
+							VpcId: vpcID,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	injectDataModel := merge.NewDefaultModelFromStruct(injectData, ".data", true)
+
+	merger := merge.NewMerger(
+		*fMerger.GetBase(),
+		injectDataModel,
+	)
+
+	_, err = merger.Merge()
+	if err != nil {
+		return nil, fmt.Errorf("error merging furyctl config: %w", err)
+	}
+
+	return merger, nil
+}
+
+func (d *Distribution) extractVpcIDFromPrevPhases(fMerger *merge.Merger) (string, error) {
+	vpcID := ""
+
+	if infraOutJSON, err := os.ReadFile(path.Join(d.InfrastructureTerraformOutputsPath, "output.json")); err == nil {
+		var infraOut terraform.OutputJSON
+
+		if err := json.Unmarshal(infraOutJSON, &infraOut); err == nil {
+			if infraOut["vpc_id"] != nil {
+				vpcIDOut, ok := infraOut["vpc_id"].Value.(string)
+				if !ok {
+					return vpcID, ErrCastingVpcIDToStr
+				}
+
+				return vpcIDOut, nil
+			}
+		}
+	}
+
+	fModel := merge.NewDefaultModel((*fMerger.GetBase()).Content(), ".spec.kubernetes")
+
+	kubeFromFuryctlConf, err := fModel.Get()
+	if err != nil {
+		return vpcID, fmt.Errorf("error getting kubernetes from furyctl config: %w", err)
+	}
+
+	vpcFromFuryctlConf, ok := kubeFromFuryctlConf["vpcId"].(string)
+	if !ok && !d.DryRun {
+		return vpcID, ErrCastingVpcIDToStr
+	}
+
+	return vpcFromFuryctlConf, nil
 }
 
 func (d *Distribution) extractTfOutputs() (map[string]string, error) {

--- a/internal/apis/kfd/v1alpha2/ekscluster/common/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/common/preflight.go
@@ -50,19 +50,6 @@ type PreFlight struct {
 	InfrastructureTerraformOutputsPath string
 }
 
-func (p *PreFlight) getTerraformStateConfig() private.SpecToolsConfigurationTerraformStateS3 {
-	if p.FuryctlConf.Spec.ToolsConfiguration.Opentofu != nil {
-		return private.SpecToolsConfigurationTerraformStateS3{
-			BucketName:           p.FuryctlConf.Spec.ToolsConfiguration.Opentofu.State.S3.BucketName,
-			KeyPrefix:            p.FuryctlConf.Spec.ToolsConfiguration.Opentofu.State.S3.KeyPrefix,
-			Region:               p.FuryctlConf.Spec.ToolsConfiguration.Opentofu.State.S3.Region,
-			SkipRegionValidation: p.FuryctlConf.Spec.ToolsConfiguration.Opentofu.State.S3.SkipRegionValidation,
-		}
-	}
-
-	return p.FuryctlConf.Spec.ToolsConfiguration.Terraform.State.S3
-}
-
 func (p *PreFlight) Prepare() error {
 	if err := p.CreateRootFolder(); err != nil {
 		return fmt.Errorf("error creating preflight phase folder: %w", err)
@@ -106,6 +93,56 @@ func (p *PreFlight) EnsureTerraformStateAWSS3Bucket() error {
 	}
 
 	return getErr
+}
+
+func (p *PreFlight) IsVPNRequired() bool {
+	return p.FuryctlConf.Spec.Infrastructure != nil &&
+		p.FuryctlConf.Spec.Infrastructure.Vpn.IsConfigured() &&
+		p.FuryctlConf.Spec.Kubernetes.ApiServer.PrivateAccess &&
+		!p.FuryctlConf.Spec.Kubernetes.ApiServer.PublicAccess
+}
+
+func (p *PreFlight) HandleVPN() error {
+	logrus.Info("VPN required, checking if configuration file exists...")
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting current dir: %w", err)
+	}
+
+	ovpnFileName := p.FuryctlConf.Metadata.Name + ".ovpn"
+
+	ovpnPath, err := filepath.Abs(path.Join(wd, ovpnFileName))
+	if err != nil {
+		return fmt.Errorf("error getting ovpn absolute path: %w", err)
+	}
+
+	if _, err := os.Stat(ovpnPath); err != nil {
+		logrus.Info("No ovpn file found, generating it...")
+
+		if err := p.regenVPNCerts(); err != nil {
+			return fmt.Errorf("error regenerating vpn certs: %w", err)
+		}
+	}
+
+	if err := p.VPNConnector.Connect(); err != nil {
+		return fmt.Errorf("error connecting to vpn: %w", err)
+	}
+
+	return nil
+}
+
+func (p *PreFlight) getTerraformStateConfig() private.SpecToolsConfigurationTerraformStateS3 {
+	if p.FuryctlConf.Spec.ToolsConfiguration.Opentofu != nil {
+		return private.SpecToolsConfigurationTerraformStateS3{
+			BucketName:           p.FuryctlConf.Spec.ToolsConfiguration.Opentofu.State.S3.BucketName,
+			KeyPrefix:            p.FuryctlConf.Spec.ToolsConfiguration.Opentofu.State.S3.KeyPrefix,
+			Region:               p.FuryctlConf.Spec.ToolsConfiguration.Opentofu.State.S3.Region,
+			SkipRegionValidation: p.FuryctlConf.Spec.ToolsConfiguration.Opentofu.State.S3.SkipRegionValidation,
+		}
+	}
+
+	return p.FuryctlConf.Spec.ToolsConfiguration.Terraform.State.S3
 }
 
 func (p *PreFlight) assertTerraformStateAWSS3BucketMatches() error {
@@ -212,43 +249,6 @@ func (p *PreFlight) copyFromTemplate() error {
 	)
 	if err != nil {
 		return fmt.Errorf("error generating from template files: %w", err)
-	}
-
-	return nil
-}
-
-func (p *PreFlight) IsVPNRequired() bool {
-	return p.FuryctlConf.Spec.Infrastructure != nil &&
-		p.FuryctlConf.Spec.Infrastructure.Vpn.IsConfigured() &&
-		p.FuryctlConf.Spec.Kubernetes.ApiServer.PrivateAccess &&
-		!p.FuryctlConf.Spec.Kubernetes.ApiServer.PublicAccess
-}
-
-func (p *PreFlight) HandleVPN() error {
-	logrus.Info("VPN required, checking if configuration file exists...")
-
-	wd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("error getting current dir: %w", err)
-	}
-
-	ovpnFileName := p.FuryctlConf.Metadata.Name + ".ovpn"
-
-	ovpnPath, err := filepath.Abs(path.Join(wd, ovpnFileName))
-	if err != nil {
-		return fmt.Errorf("error getting ovpn absolute path: %w", err)
-	}
-
-	if _, err := os.Stat(ovpnPath); err != nil {
-		logrus.Info("No ovpn file found, generating it...")
-
-		if err := p.regenVPNCerts(); err != nil {
-			return fmt.Errorf("error regenerating vpn certs: %w", err)
-		}
-	}
-
-	if err := p.VPNConnector.Connect(); err != nil {
-		return fmt.Errorf("error connecting to vpn: %w", err)
 	}
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/distribution.go
@@ -183,6 +183,42 @@ func (d *Distribution) Exec(
 	return nil
 }
 
+func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
+	d.upgrade.Enabled = upgradeEnabled
+}
+
+func (d *Distribution) Stop() error {
+	return cluster.StopAll(
+		func() error {
+			logrus.Debug("Stopping terraform...")
+
+			if err := d.TFRunner.Stop(); err != nil {
+				return fmt.Errorf("error stopping terraform: %w", err)
+			}
+
+			return nil
+		},
+		func() error {
+			logrus.Debug("Stopping shell...")
+
+			if err := d.shellRunner.Stop(); err != nil {
+				return fmt.Errorf("error stopping shell: %w", err)
+			}
+
+			return nil
+		},
+		func() error {
+			logrus.Debug("Stopping kubectl...")
+
+			if err := d.kubeRunner.Stop(); err != nil {
+				return fmt.Errorf("error stopping kubectl: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
 func (d *Distribution) preDistribution(
 	startFrom string,
 	upgradeState *upgrade.State,
@@ -374,42 +410,6 @@ func (d *Distribution) runReducers(
 	}
 
 	return nil
-}
-
-func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
-	d.upgrade.Enabled = upgradeEnabled
-}
-
-func (d *Distribution) Stop() error {
-	return cluster.StopAll(
-		func() error {
-			logrus.Debug("Stopping terraform...")
-
-			if err := d.TFRunner.Stop(); err != nil {
-				return fmt.Errorf("error stopping terraform: %w", err)
-			}
-
-			return nil
-		},
-		func() error {
-			logrus.Debug("Stopping shell...")
-
-			if err := d.shellRunner.Stop(); err != nil {
-				return fmt.Errorf("error stopping shell: %w", err)
-			}
-
-			return nil
-		},
-		func() error {
-			logrus.Debug("Stopping kubectl...")
-
-			if err := d.kubeRunner.Stop(); err != nil {
-				return fmt.Errorf("error stopping kubectl: %w", err)
-			}
-
-			return nil
-		},
-	)
 }
 
 func (d *Distribution) createDummyOutput() error {

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/infrastructure.go
@@ -116,6 +116,20 @@ func (i *Infrastructure) Exec(startFrom string, upgradeState *upgrade.State) err
 	return nil
 }
 
+func (i *Infrastructure) SetUpgrade(upgradeEnabled bool) {
+	i.upgrade.Enabled = upgradeEnabled
+}
+
+func (i *Infrastructure) Stop() error {
+	logrus.Debug("Stopping terraform/tofu runner...")
+
+	if err := i.tfRunner.Stop(); err != nil {
+		return fmt.Errorf("error stopping terraform/tofu runner: %w", err)
+	}
+
+	return nil
+}
+
 func (i *Infrastructure) preInfrastructure(
 	startFrom string,
 	upgradeState *upgrade.State,
@@ -210,20 +224,6 @@ func (i *Infrastructure) postInfrastructure(
 
 	if i.upgrade.Enabled {
 		upgradeState.Phases.PostInfrastructure.Status = upgrade.PhaseStatusSuccess
-	}
-
-	return nil
-}
-
-func (i *Infrastructure) SetUpgrade(upgradeEnabled bool) {
-	i.upgrade.Enabled = upgradeEnabled
-}
-
-func (i *Infrastructure) Stop() error {
-	logrus.Debug("Stopping terraform/tofu runner...")
-
-	if err := i.tfRunner.Stop(); err != nil {
-		return fmt.Errorf("error stopping terraform/tofu runner: %w", err)
 	}
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/kubernetes.go
@@ -142,6 +142,33 @@ func (k *Kubernetes) Exec(startFrom string, upgradeState *upgrade.State) error {
 	return nil
 }
 
+func (k *Kubernetes) SetUpgrade(upgradeEnabled bool) {
+	k.upgrade.Enabled = upgradeEnabled
+}
+
+func (k *Kubernetes) Stop() error {
+	return cluster.StopAll(
+		func() error {
+			logrus.Debug("Stopping terraform...")
+
+			if err := k.tfRunner.Stop(); err != nil {
+				return fmt.Errorf("error stopping terraform: %w", err)
+			}
+
+			return nil
+		},
+		func() error {
+			logrus.Debug("Stopping awscli...")
+
+			if err := k.awsRunner.Stop(); err != nil {
+				return fmt.Errorf("error stopping awscli: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
 func (k *Kubernetes) preKubernetes(
 	startFrom string,
 	upgradeState *upgrade.State,
@@ -279,33 +306,6 @@ func (k *Kubernetes) postKubernetes(
 	}
 
 	return nil
-}
-
-func (k *Kubernetes) SetUpgrade(upgradeEnabled bool) {
-	k.upgrade.Enabled = upgradeEnabled
-}
-
-func (k *Kubernetes) Stop() error {
-	return cluster.StopAll(
-		func() error {
-			logrus.Debug("Stopping terraform...")
-
-			if err := k.tfRunner.Stop(); err != nil {
-				return fmt.Errorf("error stopping terraform: %w", err)
-			}
-
-			return nil
-		},
-		func() error {
-			logrus.Debug("Stopping awscli...")
-
-			if err := k.awsRunner.Stop(); err != nil {
-				return fmt.Errorf("error stopping awscli: %w", err)
-			}
-
-			return nil
-		},
-	)
 }
 
 func (k *Kubernetes) checkVPCConnection() error {

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -293,22 +293,6 @@ func (v *ClusterCreator) Create(startFrom string, timeout, _ int) error {
 	return nil
 }
 
-func (*ClusterCreator) initUpgradeState() *upgrade.State {
-	return &upgrade.State{
-		Phases: upgrade.Phases{
-			PreInfrastructure:  &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-			Infrastructure:     &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-			PostInfrastructure: &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-			PreKubernetes:      &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-			Kubernetes:         &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-			PostKubernetes:     &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-			PreDistribution:    &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-			Distribution:       &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-			PostDistribution:   &upgrade.Phase{Status: upgrade.PhaseStatusPending},
-		},
-	}
-}
-
 func (v *ClusterCreator) CreateAsync(
 	phases *Phases,
 	startFrom string,
@@ -435,6 +419,53 @@ func (v *ClusterCreator) CreateAsync(
 
 	default:
 		errCh <- fmt.Errorf("%w: %s", ErrUnsupportedPhase, v.phase)
+	}
+}
+
+func (v *ClusterCreator) RenderConfig() (map[string]any, error) {
+	specMap := map[string]any{}
+
+	phase := cluster.NewOperationPhase(
+		path.Join(v.paths.WorkDir, cluster.OperationPhaseDistribution),
+		v.kfdManifest.Tools,
+		v.paths.BinPath,
+	)
+
+	furyctlMerger, err := phase.CreateFuryctlMerger(
+		v.paths.DistroPath,
+		v.paths.ConfigPath,
+		"kfd-v1alpha2",
+		"ekscluster",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating furyctl merger: %w", err)
+	}
+
+	tfCfg, err := template.NewConfigWithoutData(furyctlMerger, []string{})
+	if err != nil {
+		return nil, fmt.Errorf("error while creating template config: %w", err)
+	}
+
+	for k, v := range tfCfg.Data {
+		specMap[k] = v
+	}
+
+	return specMap, nil
+}
+
+func (*ClusterCreator) initUpgradeState() *upgrade.State {
+	return &upgrade.State{
+		Phases: upgrade.Phases{
+			PreInfrastructure:  &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			Infrastructure:     &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			PostInfrastructure: &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			PreKubernetes:      &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			Kubernetes:         &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			PostKubernetes:     &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			PreDistribution:    &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			Distribution:       &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+			PostDistribution:   &upgrade.Phase{Status: upgrade.PhaseStatusPending},
+		},
 	}
 }
 
@@ -806,37 +837,6 @@ func (*ClusterCreator) getDistributionSubPhase(startFrom string) string {
 	default:
 		return ""
 	}
-}
-
-func (v *ClusterCreator) RenderConfig() (map[string]any, error) {
-	specMap := map[string]any{}
-
-	phase := cluster.NewOperationPhase(
-		path.Join(v.paths.WorkDir, cluster.OperationPhaseDistribution),
-		v.kfdManifest.Tools,
-		v.paths.BinPath,
-	)
-
-	furyctlMerger, err := phase.CreateFuryctlMerger(
-		v.paths.DistroPath,
-		v.paths.ConfigPath,
-		"kfd-v1alpha2",
-		"ekscluster",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating furyctl merger: %w", err)
-	}
-
-	tfCfg, err := template.NewConfigWithoutData(furyctlMerger, []string{})
-	if err != nil {
-		return nil, fmt.Errorf("error while creating template config: %w", err)
-	}
-
-	for k, v := range tfCfg.Data {
-		specMap[k] = v
-	}
-
-	return specMap, nil
 }
 
 //nolint:revive // ignore maximum number of return results

--- a/internal/apis/kfd/v1alpha2/ekscluster/vpn/connector.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/vpn/connector.go
@@ -143,21 +143,6 @@ func (v *Connector) GenerateCertificates() error {
 	return nil
 }
 
-func (v *Connector) writeOVPNFileToDisk(certName string, cert []byte) error {
-	err := os.WriteFile(
-		filepath.Join(
-			v.certDir,
-			certName+".ovpn"),
-		cert,
-		iox.FullRWPermAccess,
-	)
-	if err != nil {
-		return fmt.Errorf("error writing openvpn file to disk: %w", err)
-	}
-
-	return nil
-}
-
 func (v *Connector) IsConfigured() bool {
 	return v.config.IsConfigured()
 }
@@ -292,6 +277,21 @@ func (v *Connector) prompt() error {
 
 	if _, err := bufio.NewReader(os.Stdin).ReadBytes('\n'); err != nil {
 		return fmt.Errorf("%w: %v", ErrReadStdin, err)
+	}
+
+	return nil
+}
+
+func (v *Connector) writeOVPNFileToDisk(certName string, cert []byte) error {
+	err := os.WriteFile(
+		filepath.Join(
+			v.certDir,
+			certName+".ovpn"),
+		cert,
+		iox.FullRWPermAccess,
+	)
+	if err != nil {
+		return fmt.Errorf("error writing openvpn file to disk: %w", err)
 	}
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/immutable/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/distribution.go
@@ -45,6 +45,54 @@ type Distribution struct {
 	upgrade         *upgrade.Upgrade
 }
 
+func NewDistribution(
+	furyctlConf public.ImmutableKfdV1Alpha2,
+	kfdManifest config.KFD,
+	paths cluster.CreatorPaths,
+	dryRun bool,
+	upgr *upgrade.Upgrade,
+) *Distribution {
+	phase := cluster.NewOperationPhase(
+		path.Join(paths.WorkDir, cluster.OperationPhaseDistribution),
+		kfdManifest.Tools,
+		paths.BinPath,
+	)
+
+	return &Distribution{
+		OperationPhase:  phase,
+		furyctlConf:     furyctlConf,
+		kfdManifest:     kfdManifest,
+		paths:           paths,
+		dryRun:          dryRun,
+		furyctlConfPath: paths.ConfigPath,
+		stateStore: state.NewStore(
+			paths.DistroPath,
+			paths.ConfigPath,
+			paths.WorkDir,
+			kfdManifest.Tools.Common.Kubectl.Version,
+			paths.BinPath,
+		),
+		shellRunner: shell.NewRunner(
+			execx.NewStdExecutor(),
+			shell.Paths{
+				Shell:   "sh",
+				WorkDir: path.Join(phase.Path, "manifests"),
+			},
+		),
+		kubeRunner: kubectl.NewRunner(
+			execx.NewStdExecutor(),
+			kubectl.Paths{
+				Kubectl: phase.KubectlPath,
+				WorkDir: path.Join(phase.Path, "manifests"),
+			},
+			true,
+			true,
+			false,
+		),
+		upgrade: upgr,
+	}
+}
+
 func (d *Distribution) Self() *cluster.OperationPhase {
 	return d.OperationPhase
 }
@@ -78,6 +126,10 @@ func (d *Distribution) Exec(rdcs reducers.Reducers, startFrom string, upgradeSta
 	logrus.Info("SIGHUP Distribution configured successfully")
 
 	return nil
+}
+
+func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
+	d.upgrade.Enabled = upgradeEnabled
 }
 
 func (d *Distribution) prepare() (template.Config, error) {
@@ -300,56 +352,4 @@ func (d *Distribution) injectStoredConfig(cfg template.Config) (template.Config,
 	cfg.Data["storedCfg"] = storedCfg
 
 	return cfg, nil
-}
-
-func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
-	d.upgrade.Enabled = upgradeEnabled
-}
-
-func NewDistribution(
-	furyctlConf public.ImmutableKfdV1Alpha2,
-	kfdManifest config.KFD,
-	paths cluster.CreatorPaths,
-	dryRun bool,
-	upgr *upgrade.Upgrade,
-) *Distribution {
-	phase := cluster.NewOperationPhase(
-		path.Join(paths.WorkDir, cluster.OperationPhaseDistribution),
-		kfdManifest.Tools,
-		paths.BinPath,
-	)
-
-	return &Distribution{
-		OperationPhase:  phase,
-		furyctlConf:     furyctlConf,
-		kfdManifest:     kfdManifest,
-		paths:           paths,
-		dryRun:          dryRun,
-		furyctlConfPath: paths.ConfigPath,
-		stateStore: state.NewStore(
-			paths.DistroPath,
-			paths.ConfigPath,
-			paths.WorkDir,
-			kfdManifest.Tools.Common.Kubectl.Version,
-			paths.BinPath,
-		),
-		shellRunner: shell.NewRunner(
-			execx.NewStdExecutor(),
-			shell.Paths{
-				Shell:   "sh",
-				WorkDir: path.Join(phase.Path, "manifests"),
-			},
-		),
-		kubeRunner: kubectl.NewRunner(
-			execx.NewStdExecutor(),
-			kubectl.Paths{
-				Kubectl: phase.KubectlPath,
-				WorkDir: path.Join(phase.Path, "manifests"),
-			},
-			true,
-			true,
-			false,
-		),
-		upgrade: upgr,
-	}
 }

--- a/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
@@ -36,6 +36,39 @@ type Kubernetes struct {
 	podRunningTimeout int
 }
 
+func NewKubernetes(
+	furyctlConf public.ImmutableKfdV1Alpha2,
+	kfdManifest config.KFD,
+	paths cluster.CreatorPaths,
+	dryRun bool,
+	upgr *upgrade.Upgrade,
+	upgradeNode string,
+	force []string,
+	podRunningTimeout int,
+) *Kubernetes {
+	phase := cluster.NewOperationPhase(
+		path.Join(paths.WorkDir, cluster.OperationPhaseKubernetes),
+		kfdManifest.Tools,
+		paths.BinPath,
+	)
+
+	return &Kubernetes{
+		OperationPhase: phase,
+		furyctlConf:    furyctlConf,
+		kfdManifest:    kfdManifest,
+		paths:          paths,
+		dryRun:         dryRun,
+		ansibleRunner: ansible.NewRunner(
+			execx.NewStdExecutor(),
+			ansible.PathsForVersion(paths.BinPath, kfdManifest.Tools.Immutable.Ansible.Version, phase.Path),
+		),
+		upgrade:           upgr,
+		upgradeNode:       upgradeNode,
+		force:             force,
+		podRunningTimeout: podRunningTimeout,
+	}
+}
+
 func (k *Kubernetes) Self() *cluster.OperationPhase {
 	return k.OperationPhase
 }
@@ -76,6 +109,10 @@ func (k *Kubernetes) Exec(startFrom string, upgradeState *upgrade.State) error {
 	logrus.Info("SIGHUP Distribution Kubernetes cluster configured successfully")
 
 	return nil
+}
+
+func (k *Kubernetes) SetUpgrade(upgradeEnabled bool) {
+	k.upgrade.Enabled = upgradeEnabled
 }
 
 func (k *Kubernetes) prepare() error {
@@ -226,41 +263,4 @@ func (k *Kubernetes) postKubernetes(
 	}
 
 	return nil
-}
-
-func (k *Kubernetes) SetUpgrade(upgradeEnabled bool) {
-	k.upgrade.Enabled = upgradeEnabled
-}
-
-func NewKubernetes(
-	furyctlConf public.ImmutableKfdV1Alpha2,
-	kfdManifest config.KFD,
-	paths cluster.CreatorPaths,
-	dryRun bool,
-	upgr *upgrade.Upgrade,
-	upgradeNode string,
-	force []string,
-	podRunningTimeout int,
-) *Kubernetes {
-	phase := cluster.NewOperationPhase(
-		path.Join(paths.WorkDir, cluster.OperationPhaseKubernetes),
-		kfdManifest.Tools,
-		paths.BinPath,
-	)
-
-	return &Kubernetes{
-		OperationPhase: phase,
-		furyctlConf:    furyctlConf,
-		kfdManifest:    kfdManifest,
-		paths:          paths,
-		dryRun:         dryRun,
-		ansibleRunner: ansible.NewRunner(
-			execx.NewStdExecutor(),
-			ansible.PathsForVersion(paths.BinPath, kfdManifest.Tools.Immutable.Ansible.Version, phase.Path),
-		),
-		upgrade:           upgr,
-		upgradeNode:       upgradeNode,
-		force:             force,
-		podRunningTimeout: podRunningTimeout,
-	}
 }

--- a/internal/apis/kfd/v1alpha2/immutable/creator.go
+++ b/internal/apis/kfd/v1alpha2/immutable/creator.go
@@ -158,31 +158,6 @@ func (*ClusterCreator) GetPhasePath(phase string) (string, error) {
 	return schemaPath, nil
 }
 
-func createInfrastructurePhase(c *ClusterCreator, upgr *upgrade.Upgrade) *create.Infrastructure {
-	infraPath := filepath.Join(c.paths.WorkDir, "infrastructure")
-
-	phase := cluster.NewOperationPhase(
-		infraPath,
-		c.kfdManifest.Tools,
-		c.paths.BinPath,
-	)
-
-	infra := create.NewInfrastructure(
-		phase,
-		c.paths.ConfigPath,
-		c.paths.DistroPath,
-		upgr,
-		c.upgradeNode,
-		c.furyctlConf,
-		c.kfdManifest,
-		c.paths,
-		c.dryRun,
-		c.force,
-	)
-
-	return infra
-}
-
 func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int) error {
 	upgr := upgrade.New(c.paths, string(c.furyctlConf.Kind))
 
@@ -425,6 +400,70 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 	return nil
 }
 
+// RenderConfig loads the complete furyctl configuration merged with defaults from fury-distribution.
+// For infrastructure phase, we need the full spec including infrastructure config.
+func (c *ClusterCreator) RenderConfig() (map[string]any, error) {
+	// Create phase for infrastructure.
+	phase := cluster.NewOperationPhase(
+		path.Join(c.paths.WorkDir, cluster.OperationPhaseInfrastructure),
+		c.kfdManifest.Tools,
+		c.paths.BinPath,
+	)
+
+	// Use CreateFuryctlMerger to merge defaults + user config.
+	furyctlMerger, err := phase.CreateFuryctlMerger(
+		c.paths.DistroPath,
+		c.paths.ConfigPath,
+		"kfd-v1alpha2",
+		"immutable",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating furyctl merger: %w", err)
+	}
+
+	// Create template config without data.
+	tfCfg, err := template.NewConfigWithoutData(furyctlMerger, []string{})
+	if err != nil {
+		return nil, fmt.Errorf("error while creating template config: %w", err)
+	}
+
+	// TfCfg.Data already contains the properly structured merged config
+	// with "spec", "metadata", etc. from the user config merged with defaults.
+	// Convert to map[string]any (including nested maps).
+	result := make(map[string]any)
+
+	for k, v := range tfCfg.Data {
+		result[k] = convertValue(v)
+	}
+
+	return result, nil
+}
+
+func createInfrastructurePhase(c *ClusterCreator, upgr *upgrade.Upgrade) *create.Infrastructure {
+	infraPath := filepath.Join(c.paths.WorkDir, "infrastructure")
+
+	phase := cluster.NewOperationPhase(
+		infraPath,
+		c.kfdManifest.Tools,
+		c.paths.BinPath,
+	)
+
+	infra := create.NewInfrastructure(
+		phase,
+		c.paths.ConfigPath,
+		c.paths.DistroPath,
+		upgr,
+		c.upgradeNode,
+		c.furyctlConf,
+		c.kfdManifest,
+		c.paths,
+		c.dryRun,
+		c.force,
+	)
+
+	return infra
+}
+
 // convertValue recursively converts any value, handling maps and slices.
 func convertValue(v any) any {
 	switch val := v.(type) {
@@ -655,45 +694,6 @@ func (*ClusterCreator) getDistributionSubPhase(startFrom string) string {
 	default:
 		return ""
 	}
-}
-
-// RenderConfig loads the complete furyctl configuration merged with defaults from fury-distribution.
-// For infrastructure phase, we need the full spec including infrastructure config.
-func (c *ClusterCreator) RenderConfig() (map[string]any, error) {
-	// Create phase for infrastructure.
-	phase := cluster.NewOperationPhase(
-		path.Join(c.paths.WorkDir, cluster.OperationPhaseInfrastructure),
-		c.kfdManifest.Tools,
-		c.paths.BinPath,
-	)
-
-	// Use CreateFuryctlMerger to merge defaults + user config.
-	furyctlMerger, err := phase.CreateFuryctlMerger(
-		c.paths.DistroPath,
-		c.paths.ConfigPath,
-		"kfd-v1alpha2",
-		"immutable",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating furyctl merger: %w", err)
-	}
-
-	// Create template config without data.
-	tfCfg, err := template.NewConfigWithoutData(furyctlMerger, []string{})
-	if err != nil {
-		return nil, fmt.Errorf("error while creating template config: %w", err)
-	}
-
-	// TfCfg.Data already contains the properly structured merged config
-	// with "spec", "metadata", etc. from the user config merged with defaults.
-	// Convert to map[string]any (including nested maps).
-	result := make(map[string]any)
-
-	for k, v := range tfCfg.Data {
-		result[k] = convertValue(v)
-	}
-
-	return result, nil
 }
 
 func (c *ClusterCreator) confirmInfrastructureChanges(

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/distribution.go
@@ -138,6 +138,33 @@ func (d *Distribution) Exec(rdcs reducers.Reducers, startFrom string, upgradeSta
 	return nil
 }
 
+func (d *Distribution) Stop() error {
+	return cluster.StopAll(
+		func() error {
+			logrus.Debug("Stopping shell...")
+
+			if err := d.shellRunner.Stop(); err != nil {
+				return fmt.Errorf("error stopping shell: %w", err)
+			}
+
+			return nil
+		},
+		func() error {
+			logrus.Debug("Stopping kubectl...")
+
+			if err := d.kubeRunner.Stop(); err != nil {
+				return fmt.Errorf("error stopping kubectl: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
+	d.upgrade.Enabled = upgradeEnabled
+}
+
 func (d *Distribution) prepare() (template.Config, error) {
 	if err := d.CreateRootFolder(); err != nil {
 		return template.Config{}, fmt.Errorf("error creating distribution phase folder: %w", err)
@@ -328,33 +355,6 @@ func (d *Distribution) postDistribution(
 	}
 
 	return nil
-}
-
-func (d *Distribution) Stop() error {
-	return cluster.StopAll(
-		func() error {
-			logrus.Debug("Stopping shell...")
-
-			if err := d.shellRunner.Stop(); err != nil {
-				return fmt.Errorf("error stopping shell: %w", err)
-			}
-
-			return nil
-		},
-		func() error {
-			logrus.Debug("Stopping kubectl...")
-
-			if err := d.kubeRunner.Stop(); err != nil {
-				return fmt.Errorf("error stopping kubectl: %w", err)
-			}
-
-			return nil
-		},
-	)
-}
-
-func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
-	d.upgrade.Enabled = upgradeEnabled
 }
 
 func (d *Distribution) runReducers(

--- a/internal/apis/kfd/v1alpha2/kfddistribution/creator.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/creator.go
@@ -311,6 +311,37 @@ func (c *ClusterCreator) Create(startFrom string, _, _ int) error {
 	return nil
 }
 
+func (c *ClusterCreator) RenderConfig() (map[string]any, error) {
+	specMap := map[string]any{}
+
+	phase := cluster.NewOperationPhase(
+		path.Join(c.paths.WorkDir, cluster.OperationPhaseDistribution),
+		c.kfdManifest.Tools,
+		c.paths.BinPath,
+	)
+
+	furyctlMerger, err := phase.CreateFuryctlMerger(
+		c.paths.DistroPath,
+		c.paths.ConfigPath,
+		"kfd-v1alpha2",
+		"kfddistribution",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating furyctl merger: %w", err)
+	}
+
+	tfCfg, err := template.NewConfigWithoutData(furyctlMerger, []string{})
+	if err != nil {
+		return nil, fmt.Errorf("error while creating template config: %w", err)
+	}
+
+	for k, v := range tfCfg.Data {
+		specMap[k] = v
+	}
+
+	return specMap, nil
+}
+
 func (c *ClusterCreator) allPhases(
 	startFrom string,
 	rdcs reducers.Reducers,
@@ -436,35 +467,4 @@ func (*ClusterCreator) getDistributionSubPhase(startFrom string) string {
 	default:
 		return ""
 	}
-}
-
-func (c *ClusterCreator) RenderConfig() (map[string]any, error) {
-	specMap := map[string]any{}
-
-	phase := cluster.NewOperationPhase(
-		path.Join(c.paths.WorkDir, cluster.OperationPhaseDistribution),
-		c.kfdManifest.Tools,
-		c.paths.BinPath,
-	)
-
-	furyctlMerger, err := phase.CreateFuryctlMerger(
-		c.paths.DistroPath,
-		c.paths.ConfigPath,
-		"kfd-v1alpha2",
-		"kfddistribution",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating furyctl merger: %w", err)
-	}
-
-	tfCfg, err := template.NewConfigWithoutData(furyctlMerger, []string{})
-	if err != nil {
-		return nil, fmt.Errorf("error while creating template config: %w", err)
-	}
-
-	for k, v := range tfCfg.Data {
-		specMap[k] = v
-	}
-
-	return specMap, nil
 }

--- a/internal/apis/kfd/v1alpha2/onpremises/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/distribution.go
@@ -45,6 +45,54 @@ type Distribution struct {
 	upgrade         *upgrade.Upgrade
 }
 
+func NewDistribution(
+	furyctlConf public.OnpremisesKfdV1Alpha2,
+	kfdManifest config.KFD,
+	paths cluster.CreatorPaths,
+	dryRun bool,
+	upgr *upgrade.Upgrade,
+) *Distribution {
+	phase := cluster.NewOperationPhase(
+		path.Join(paths.WorkDir, cluster.OperationPhaseDistribution),
+		kfdManifest.Tools,
+		paths.BinPath,
+	)
+
+	return &Distribution{
+		OperationPhase:  phase,
+		furyctlConf:     furyctlConf,
+		kfdManifest:     kfdManifest,
+		paths:           paths,
+		dryRun:          dryRun,
+		furyctlConfPath: paths.ConfigPath,
+		stateStore: state.NewStore(
+			paths.DistroPath,
+			paths.ConfigPath,
+			paths.WorkDir,
+			kfdManifest.Tools.Common.Kubectl.Version,
+			paths.BinPath,
+		),
+		shellRunner: shell.NewRunner(
+			execx.NewStdExecutor(),
+			shell.Paths{
+				Shell:   "sh",
+				WorkDir: path.Join(phase.Path, "manifests"),
+			},
+		),
+		kubeRunner: kubectl.NewRunner(
+			execx.NewStdExecutor(),
+			kubectl.Paths{
+				Kubectl: phase.KubectlPath,
+				WorkDir: path.Join(phase.Path, "manifests"),
+			},
+			true,
+			true,
+			false,
+		),
+		upgrade: upgr,
+	}
+}
+
 func (d *Distribution) Self() *cluster.OperationPhase {
 	return d.OperationPhase
 }
@@ -78,6 +126,10 @@ func (d *Distribution) Exec(rdcs reducers.Reducers, startFrom string, upgradeSta
 	logrus.Info("SIGHUP Distribution installed successfully")
 
 	return nil
+}
+
+func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
+	d.upgrade.Enabled = upgradeEnabled
 }
 
 func (d *Distribution) prepare() (template.Config, error) {
@@ -300,56 +352,4 @@ func (d *Distribution) injectStoredConfig(cfg template.Config) (template.Config,
 	cfg.Data["storedCfg"] = storedCfg
 
 	return cfg, nil
-}
-
-func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
-	d.upgrade.Enabled = upgradeEnabled
-}
-
-func NewDistribution(
-	furyctlConf public.OnpremisesKfdV1Alpha2,
-	kfdManifest config.KFD,
-	paths cluster.CreatorPaths,
-	dryRun bool,
-	upgr *upgrade.Upgrade,
-) *Distribution {
-	phase := cluster.NewOperationPhase(
-		path.Join(paths.WorkDir, cluster.OperationPhaseDistribution),
-		kfdManifest.Tools,
-		paths.BinPath,
-	)
-
-	return &Distribution{
-		OperationPhase:  phase,
-		furyctlConf:     furyctlConf,
-		kfdManifest:     kfdManifest,
-		paths:           paths,
-		dryRun:          dryRun,
-		furyctlConfPath: paths.ConfigPath,
-		stateStore: state.NewStore(
-			paths.DistroPath,
-			paths.ConfigPath,
-			paths.WorkDir,
-			kfdManifest.Tools.Common.Kubectl.Version,
-			paths.BinPath,
-		),
-		shellRunner: shell.NewRunner(
-			execx.NewStdExecutor(),
-			shell.Paths{
-				Shell:   "sh",
-				WorkDir: path.Join(phase.Path, "manifests"),
-			},
-		),
-		kubeRunner: kubectl.NewRunner(
-			execx.NewStdExecutor(),
-			kubectl.Paths{
-				Kubectl: phase.KubectlPath,
-				WorkDir: path.Join(phase.Path, "manifests"),
-			},
-			true,
-			true,
-			false,
-		),
-		upgrade: upgr,
-	}
 }

--- a/internal/apis/kfd/v1alpha2/onpremises/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/kubernetes.go
@@ -40,6 +40,39 @@ type Kubernetes struct {
 	podRunningTimeout int
 }
 
+func NewKubernetes(
+	furyctlConf public.OnpremisesKfdV1Alpha2,
+	kfdManifest config.KFD,
+	paths cluster.CreatorPaths,
+	dryRun bool,
+	upgr *upgrade.Upgrade,
+	upgradeNode string,
+	force []string,
+	podRunningTimeout int,
+) *Kubernetes {
+	phase := cluster.NewOperationPhase(
+		path.Join(paths.WorkDir, cluster.OperationPhaseKubernetes),
+		kfdManifest.Tools,
+		paths.BinPath,
+	)
+
+	return &Kubernetes{
+		OperationPhase: phase,
+		furyctlConf:    furyctlConf,
+		kfdManifest:    kfdManifest,
+		paths:          paths,
+		dryRun:         dryRun,
+		ansibleRunner: ansible.NewRunner(
+			execx.NewStdExecutor(),
+			ansible.PathsForVersion(paths.BinPath, kfdManifest.Tools.OnPremises.Ansible.Version, phase.Path),
+		),
+		upgrade:           upgr,
+		upgradeNode:       upgradeNode,
+		force:             force,
+		podRunningTimeout: podRunningTimeout,
+	}
+}
+
 func (k *Kubernetes) Self() *cluster.OperationPhase {
 	return k.OperationPhase
 }
@@ -84,6 +117,10 @@ func (k *Kubernetes) Exec(rdcs reducers.Reducers, startFrom string, upgradeState
 	logrus.Info("Kubernetes cluster created successfully")
 
 	return nil
+}
+
+func (k *Kubernetes) SetUpgrade(upgradeEnabled bool) {
+	k.upgrade.Enabled = upgradeEnabled
 }
 
 // runMigrations runs, for each reducer lifecycle present, the matching migration
@@ -268,41 +305,4 @@ func (k *Kubernetes) postKubernetes(
 	}
 
 	return nil
-}
-
-func (k *Kubernetes) SetUpgrade(upgradeEnabled bool) {
-	k.upgrade.Enabled = upgradeEnabled
-}
-
-func NewKubernetes(
-	furyctlConf public.OnpremisesKfdV1Alpha2,
-	kfdManifest config.KFD,
-	paths cluster.CreatorPaths,
-	dryRun bool,
-	upgr *upgrade.Upgrade,
-	upgradeNode string,
-	force []string,
-	podRunningTimeout int,
-) *Kubernetes {
-	phase := cluster.NewOperationPhase(
-		path.Join(paths.WorkDir, cluster.OperationPhaseKubernetes),
-		kfdManifest.Tools,
-		paths.BinPath,
-	)
-
-	return &Kubernetes{
-		OperationPhase: phase,
-		furyctlConf:    furyctlConf,
-		kfdManifest:    kfdManifest,
-		paths:          paths,
-		dryRun:         dryRun,
-		ansibleRunner: ansible.NewRunner(
-			execx.NewStdExecutor(),
-			ansible.PathsForVersion(paths.BinPath, kfdManifest.Tools.OnPremises.Ansible.Version, phase.Path),
-		),
-		upgrade:           upgr,
-		upgradeNode:       upgradeNode,
-		force:             force,
-		podRunningTimeout: podRunningTimeout,
-	}
 }

--- a/internal/apis/kfd/v1alpha2/onpremises/creator.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/creator.go
@@ -389,6 +389,37 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 	return nil
 }
 
+func (c *ClusterCreator) RenderConfig() (map[string]any, error) {
+	specMap := map[string]any{}
+
+	phase := cluster.NewOperationPhase(
+		path.Join(c.paths.WorkDir, cluster.OperationPhaseDistribution),
+		c.kfdManifest.Tools,
+		c.paths.BinPath,
+	)
+
+	furyctlMerger, err := phase.CreateFuryctlMerger(
+		c.paths.DistroPath,
+		c.paths.ConfigPath,
+		"kfd-v1alpha2",
+		"onpremises",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating furyctl merger: %w", err)
+	}
+
+	tfCfg, err := template.NewConfigWithoutData(furyctlMerger, []string{})
+	if err != nil {
+		return nil, fmt.Errorf("error while creating template config: %w", err)
+	}
+
+	for k, v := range tfCfg.Data {
+		specMap[k] = v
+	}
+
+	return specMap, nil
+}
+
 func (c *ClusterCreator) allPhases(
 	startFrom string,
 	kubernetesPhase upgrade.ReducersOperatorPhase[reducers.Reducers],
@@ -570,35 +601,4 @@ func (*ClusterCreator) getDistributionSubPhase(startFrom string) string {
 	default:
 		return ""
 	}
-}
-
-func (c *ClusterCreator) RenderConfig() (map[string]any, error) {
-	specMap := map[string]any{}
-
-	phase := cluster.NewOperationPhase(
-		path.Join(c.paths.WorkDir, cluster.OperationPhaseDistribution),
-		c.kfdManifest.Tools,
-		c.paths.BinPath,
-	)
-
-	furyctlMerger, err := phase.CreateFuryctlMerger(
-		c.paths.DistroPath,
-		c.paths.ConfigPath,
-		"kfd-v1alpha2",
-		"onpremises",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating furyctl merger: %w", err)
-	}
-
-	tfCfg, err := template.NewConfigWithoutData(furyctlMerger, []string{})
-	if err != nil {
-		return nil, fmt.Errorf("error while creating template config: %w", err)
-	}
-
-	for k, v := range tfCfg.Data {
-		specMap[k] = v
-	}
-
-	return specMap, nil
 }

--- a/internal/apis/kfd/v1alpha2/onpremises/delete/distribution.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/delete/distribution.go
@@ -36,6 +36,51 @@ type Distribution struct {
 	stateStore  state.Storer
 }
 
+func NewDistribution(
+	furyctlConf public.OnpremisesKfdV1Alpha2,
+	kfdManifest config.KFD,
+	paths cluster.DeleterPaths,
+	dryRun bool,
+) *Distribution {
+	phase := cluster.NewOperationPhase(
+		path.Join(paths.WorkDir, cluster.OperationPhaseDistribution),
+		kfdManifest.Tools,
+		paths.BinPath,
+	)
+
+	return &Distribution{
+		OperationPhase: phase,
+		furyctlConf:    furyctlConf,
+		kfdManifest:    kfdManifest,
+		paths:          paths,
+		dryRun:         dryRun,
+		shellRunner: shell.NewRunner(
+			execx.NewStdExecutor(),
+			shell.Paths{
+				Shell:   "sh",
+				WorkDir: path.Join(phase.Path, "manifests"),
+			},
+		),
+		kubeRunner: kubectl.NewRunner(
+			execx.NewStdExecutor(),
+			kubectl.Paths{
+				Kubectl: phase.KubectlPath,
+				WorkDir: path.Join(phase.Path, "manifests"),
+			},
+			true,
+			true,
+			false,
+		),
+		stateStore: state.NewStore(
+			paths.DistroPath,
+			paths.ConfigPath,
+			paths.WorkDir,
+			kfdManifest.Tools.Common.Kubectl.Version,
+			paths.BinPath,
+		),
+	}
+}
+
 func (d *Distribution) Exec() error {
 	logrus.Info("Deleting SIGHUP Distribution...")
 
@@ -142,49 +187,4 @@ func (d *Distribution) injectStoredConfig(cfg template.Config) (template.Config,
 	cfg.Data["storedCfg"] = storedCfg
 
 	return cfg, nil
-}
-
-func NewDistribution(
-	furyctlConf public.OnpremisesKfdV1Alpha2,
-	kfdManifest config.KFD,
-	paths cluster.DeleterPaths,
-	dryRun bool,
-) *Distribution {
-	phase := cluster.NewOperationPhase(
-		path.Join(paths.WorkDir, cluster.OperationPhaseDistribution),
-		kfdManifest.Tools,
-		paths.BinPath,
-	)
-
-	return &Distribution{
-		OperationPhase: phase,
-		furyctlConf:    furyctlConf,
-		kfdManifest:    kfdManifest,
-		paths:          paths,
-		dryRun:         dryRun,
-		shellRunner: shell.NewRunner(
-			execx.NewStdExecutor(),
-			shell.Paths{
-				Shell:   "sh",
-				WorkDir: path.Join(phase.Path, "manifests"),
-			},
-		),
-		kubeRunner: kubectl.NewRunner(
-			execx.NewStdExecutor(),
-			kubectl.Paths{
-				Kubectl: phase.KubectlPath,
-				WorkDir: path.Join(phase.Path, "manifests"),
-			},
-			true,
-			true,
-			false,
-		),
-		stateStore: state.NewStore(
-			paths.DistroPath,
-			paths.ConfigPath,
-			paths.WorkDir,
-			kfdManifest.Tools.Common.Kubectl.Version,
-			paths.BinPath,
-		),
-	}
 }

--- a/internal/apis/kfd/v1alpha2/onpremises/delete/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/delete/kubernetes.go
@@ -29,6 +29,31 @@ type Kubernetes struct {
 	ansibleRunner *ansible.Runner
 }
 
+func NewKubernetes(
+	furyctlConf public.OnpremisesKfdV1Alpha2,
+	kfdManifest config.KFD,
+	paths cluster.DeleterPaths,
+	dryRun bool,
+) *Kubernetes {
+	phase := cluster.NewOperationPhase(
+		path.Join(paths.WorkDir, cluster.OperationPhaseKubernetes),
+		kfdManifest.Tools,
+		paths.BinPath,
+	)
+
+	return &Kubernetes{
+		OperationPhase: phase,
+		furyctlConf:    furyctlConf,
+		kfdManifest:    kfdManifest,
+		paths:          paths,
+		dryRun:         dryRun,
+		ansibleRunner: ansible.NewRunner(
+			execx.NewStdExecutor(),
+			ansible.PathsForVersion(paths.BinPath, kfdManifest.Tools.OnPremises.Ansible.Version, phase.Path),
+		),
+	}
+}
+
 func (k *Kubernetes) Exec() error {
 	logrus.Info("Deleting SIGHUP Distribution cluster...")
 
@@ -92,29 +117,4 @@ func (k *Kubernetes) Exec() error {
 	logrus.Info("Kubernetes cluster deleted successfully")
 
 	return nil
-}
-
-func NewKubernetes(
-	furyctlConf public.OnpremisesKfdV1Alpha2,
-	kfdManifest config.KFD,
-	paths cluster.DeleterPaths,
-	dryRun bool,
-) *Kubernetes {
-	phase := cluster.NewOperationPhase(
-		path.Join(paths.WorkDir, cluster.OperationPhaseKubernetes),
-		kfdManifest.Tools,
-		paths.BinPath,
-	)
-
-	return &Kubernetes{
-		OperationPhase: phase,
-		furyctlConf:    furyctlConf,
-		kfdManifest:    kfdManifest,
-		paths:          paths,
-		dryRun:         dryRun,
-		ansibleRunner: ansible.NewRunner(
-			execx.NewStdExecutor(),
-			ansible.PathsForVersion(paths.BinPath, kfdManifest.Tools.OnPremises.Ansible.Version, phase.Path),
-		),
-	}
 }

--- a/internal/apis/kfd/v1alpha2/onpremises/tool.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/tool.go
@@ -20,6 +20,14 @@ type ExtraToolsValidator struct {
 	binPath  string
 }
 
+func NewExtraToolsValidator(executor execx.Executor, kfd config.KFD, binPath string) *ExtraToolsValidator {
+	return &ExtraToolsValidator{
+		executor: executor,
+		kfd:      kfd,
+		binPath:  binPath,
+	}
+}
+
 func (x *ExtraToolsValidator) Validate(_ string) ([]string, []error) {
 	var (
 		oks  []string
@@ -48,12 +56,4 @@ func (x *ExtraToolsValidator) validateAnsible() error {
 	}
 
 	return nil
-}
-
-func NewExtraToolsValidator(executor execx.Executor, kfd config.KFD, binPath string) *ExtraToolsValidator {
-	return &ExtraToolsValidator{
-		executor: executor,
-		kfd:      kfd,
-		binPath:  binPath,
-	}
 }

--- a/internal/dependencies/envvars/validator.go
+++ b/internal/dependencies/envvars/validator.go
@@ -16,11 +16,11 @@ var (
 	ErrMissingRequiredEnvVar = errors.New("missing required environment variable")
 )
 
+type Validator struct{}
+
 func NewValidator() *Validator {
 	return &Validator{}
 }
-
-type Validator struct{}
 
 func (ev *Validator) Validate(kind string) ([]string, []error) {
 	if kind == "EKSCluster" {

--- a/internal/dependencies/tools/ansible.go
+++ b/internal/dependencies/tools/ansible.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/ansible"
 )
 
+type Ansible struct {
+	checker *checker
+	version string
+}
+
 func NewAnsible(runner *ansible.Runner, version string) *Ansible {
 	return &Ansible{
 		version: version,
@@ -26,11 +31,6 @@ func NewAnsible(runner *ansible.Runner, version string) *Ansible {
 			},
 		},
 	}
-}
-
-type Ansible struct {
-	checker *checker
-	version string
 }
 
 func (a *Ansible) CheckBinVersion() error {

--- a/internal/dependencies/tools/awscli.go
+++ b/internal/dependencies/tools/awscli.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/awscli"
 )
 
+type Awscli struct {
+	checker *checker
+	version string
+}
+
 func NewAwscli(runner *awscli.Runner, version string) *Awscli {
 	return &Awscli{
 		version: version,
@@ -26,11 +31,6 @@ func NewAwscli(runner *awscli.Runner, version string) *Awscli {
 			},
 		},
 	}
-}
-
-type Awscli struct {
-	checker *checker
-	version string
 }
 
 func (a *Awscli) CheckBinVersion() error {

--- a/internal/dependencies/tools/furyagent.go
+++ b/internal/dependencies/tools/furyagent.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/furyagent"
 )
 
+type Furyagent struct {
+	checker *checker
+	version string
+}
+
 func NewFuryagent(runner *furyagent.Runner, version string) *Furyagent {
 	return &Furyagent{
 		version: version,
@@ -26,11 +31,6 @@ func NewFuryagent(runner *furyagent.Runner, version string) *Furyagent {
 			},
 		},
 	}
-}
-
-type Furyagent struct {
-	checker *checker
-	version string
 }
 
 func (f *Furyagent) CheckBinVersion() error {

--- a/internal/dependencies/tools/git.go
+++ b/internal/dependencies/tools/git.go
@@ -13,6 +13,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/git"
 )
 
+type Git struct {
+	checker *checker
+	version string
+}
+
 func NewGit(runner *git.Runner, version string) *Git {
 	return &Git{
 		version: version,
@@ -27,11 +32,6 @@ func NewGit(runner *git.Runner, version string) *Git {
 			},
 		},
 	}
-}
-
-type Git struct {
-	checker *checker
-	version string
 }
 
 func (a *Git) CheckBinVersion() error {

--- a/internal/dependencies/tools/helm.go
+++ b/internal/dependencies/tools/helm.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/helm"
 )
 
+type Helm struct {
+	checker *checker
+	version string
+}
+
 func NewHelm(runner *helm.Runner, version string) *Helm {
 	return &Helm{
 		version: version,
@@ -26,11 +31,6 @@ func NewHelm(runner *helm.Runner, version string) *Helm {
 			},
 		},
 	}
-}
-
-type Helm struct {
-	checker *checker
-	version string
 }
 
 func (h *Helm) CheckBinVersion() error {

--- a/internal/dependencies/tools/helmfile.go
+++ b/internal/dependencies/tools/helmfile.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/helmfile"
 )
 
+type Helmfile struct {
+	checker *checker
+	version string
+}
+
 func NewHelmfile(runner *helmfile.Runner, version string) *Helmfile {
 	return &Helmfile{
 		version: version,
@@ -26,11 +31,6 @@ func NewHelmfile(runner *helmfile.Runner, version string) *Helmfile {
 			},
 		},
 	}
-}
-
-type Helmfile struct {
-	checker *checker
-	version string
 }
 
 func (h *Helmfile) CheckBinVersion() error {

--- a/internal/dependencies/tools/kapp.go
+++ b/internal/dependencies/tools/kapp.go
@@ -13,6 +13,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/kapp"
 )
 
+type Kapp struct {
+	checker *checker
+	version string
+}
+
 func NewKapp(runner *kapp.Runner, version string) *Kapp {
 	return &Kapp{
 		version: version,
@@ -27,11 +32,6 @@ func NewKapp(runner *kapp.Runner, version string) *Kapp {
 			},
 		},
 	}
-}
-
-type Kapp struct {
-	checker *checker
-	version string
 }
 
 func (k *Kapp) CheckBinVersion() error {

--- a/internal/dependencies/tools/kubectl.go
+++ b/internal/dependencies/tools/kubectl.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/kubectl"
 )
 
+type Kubectl struct {
+	checker *checker
+	version string
+}
+
 func NewKubectl(runner *kubectl.Runner, version string) *Kubectl {
 	return &Kubectl{
 		version: version,
@@ -29,11 +34,6 @@ func NewKubectl(runner *kubectl.Runner, version string) *Kubectl {
 			},
 		},
 	}
-}
-
-type Kubectl struct {
-	checker *checker
-	version string
 }
 
 func (k *Kubectl) CheckBinVersion() error {

--- a/internal/dependencies/tools/kustomize.go
+++ b/internal/dependencies/tools/kustomize.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/kustomize"
 )
 
+type Kustomize struct {
+	checker *checker
+	version string
+}
+
 func NewKustomize(runner *kustomize.Runner, version string) *Kustomize {
 	return &Kustomize{
 		version: version,
@@ -26,11 +31,6 @@ func NewKustomize(runner *kustomize.Runner, version string) *Kustomize {
 			},
 		},
 	}
-}
-
-type Kustomize struct {
-	checker *checker
-	version string
 }
 
 func (k *Kustomize) CheckBinVersion() error {

--- a/internal/dependencies/tools/opentofu.go
+++ b/internal/dependencies/tools/opentofu.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/terraform"
 )
 
+type OpenTofu struct {
+	checker *checker
+	version string
+}
+
 func NewOpenTofu(runner *terraform.Runner, version string) *OpenTofu {
 	return &OpenTofu{
 		version: version,
@@ -26,11 +31,6 @@ func NewOpenTofu(runner *terraform.Runner, version string) *OpenTofu {
 			},
 		},
 	}
-}
-
-type OpenTofu struct {
-	checker *checker
-	version string
 }
 
 func (t *OpenTofu) CheckBinVersion() error {

--- a/internal/dependencies/tools/openvpn.go
+++ b/internal/dependencies/tools/openvpn.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/openvpn"
 )
 
+type Openvpn struct {
+	checker *checker
+	version string
+}
+
 func NewOpenvpn(runner *openvpn.Runner, version string) *Openvpn {
 	return &Openvpn{
 		version: version,
@@ -26,11 +31,6 @@ func NewOpenvpn(runner *openvpn.Runner, version string) *Openvpn {
 			},
 		},
 	}
-}
-
-type Openvpn struct {
-	checker *checker
-	version string
 }
 
 func (o *Openvpn) CheckBinVersion() error {

--- a/internal/dependencies/tools/sed.go
+++ b/internal/dependencies/tools/sed.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/sed"
 )
 
+type Sed struct {
+	checker *checker
+	version string
+}
+
 func NewSed(runner *sed.Runner, version string) *Sed {
 	return &Sed{
 		version: version,
@@ -26,11 +31,6 @@ func NewSed(runner *sed.Runner, version string) *Sed {
 			},
 		},
 	}
-}
-
-type Sed struct {
-	checker *checker
-	version string
 }
 
 func (s *Sed) CheckBinVersion() error {

--- a/internal/dependencies/tools/shell.go
+++ b/internal/dependencies/tools/shell.go
@@ -8,11 +8,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/shell"
 )
 
+type Shell struct{}
+
 func NewShell(_ *shell.Runner, _ string) *Shell {
 	return &Shell{}
 }
-
-type Shell struct{}
 
 func (*Shell) CheckBinVersion() error {
 	return nil

--- a/internal/dependencies/tools/terraform.go
+++ b/internal/dependencies/tools/terraform.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/terraform"
 )
 
+type Terraform struct {
+	checker *checker
+	version string
+}
+
 func NewTerraform(runner *terraform.Runner, version string) *Terraform {
 	return &Terraform{
 		version: version,
@@ -26,11 +31,6 @@ func NewTerraform(runner *terraform.Runner, version string) *Terraform {
 			},
 		},
 	}
-}
-
-type Terraform struct {
-	checker *checker
-	version string
 }
 
 func (t *Terraform) CheckBinVersion() error {

--- a/internal/dependencies/tools/tool.go
+++ b/internal/dependencies/tools/tool.go
@@ -46,16 +46,6 @@ type Tool interface {
 	CheckBinVersion() error
 }
 
-func NewFactory(executor execx.Executor, paths FactoryPaths) *Factory {
-	return &Factory{
-		executor: executor,
-		paths:    paths,
-		runnerFactory: tool.NewRunnerFactory(executor, tool.RunnerFactoryPaths{
-			Bin: paths.Bin,
-		}),
-	}
-}
-
 type FactoryPaths struct {
 	Bin string
 }
@@ -64,6 +54,16 @@ type Factory struct {
 	executor      execx.Executor
 	paths         FactoryPaths
 	runnerFactory *tool.RunnerFactory
+}
+
+func NewFactory(executor execx.Executor, paths FactoryPaths) *Factory {
+	return &Factory{
+		executor: executor,
+		paths:    paths,
+		runnerFactory: tool.NewRunnerFactory(executor, tool.RunnerFactoryPaths{
+			Bin: paths.Bin,
+		}),
+	}
 }
 
 func (f *Factory) Create(name tool.Name, version string) Tool {

--- a/internal/dependencies/tools/validator.go
+++ b/internal/dependencies/tools/validator.go
@@ -22,6 +22,13 @@ var (
 	ErrToolNotFound     = errors.New("tool not found in the toolFactory, possible fury-distribution version mismatch")
 )
 
+type Validator struct {
+	executor    execx.Executor
+	toolFactory *Factory
+	binPath     string
+	furyctlPath string
+}
+
 func NewValidator(executor execx.Executor, binPath, furyctlPath string) *Validator {
 	return &Validator{
 		executor: executor,
@@ -31,13 +38,6 @@ func NewValidator(executor execx.Executor, binPath, furyctlPath string) *Validat
 		binPath:     binPath,
 		furyctlPath: furyctlPath,
 	}
-}
-
-type Validator struct {
-	executor    execx.Executor
-	toolFactory *Factory
-	binPath     string
-	furyctlPath string
 }
 
 func (tv *Validator) ValidateBaseReqs() ([]string, []error) {

--- a/internal/dependencies/tools/yq.go
+++ b/internal/dependencies/tools/yq.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sighupio/furyctl/internal/tool/yq"
 )
 
+type Yq struct {
+	checker *checker
+	version string
+}
+
 func NewYq(runner *yq.Runner, version string) *Yq {
 	return &Yq{
 		version: version,
@@ -26,11 +31,6 @@ func NewYq(runner *yq.Runner, version string) *Yq {
 			},
 		},
 	}
-}
-
-type Yq struct {
-	checker *checker
-	version string
 }
 
 func (y *Yq) CheckBinVersion() error {

--- a/internal/flags/loader.go
+++ b/internal/flags/loader.go
@@ -73,6 +73,28 @@ func (l *Loader) LoadFromFile(configPath string) (*LoadResult, error) {
 	return result, nil
 }
 
+// LoadFromDirectory tries to find and load flags from a furyctl.yaml file in the given directory..
+func (l *Loader) LoadFromDirectory(dir string) (*LoadResult, error) {
+	// Common configuration file names to try.
+	configNames := []string{"furyctl.yaml", "furyctl.yml"}
+
+	for _, name := range configNames {
+		configPath := filepath.Join(dir, name)
+		if _, err := os.Stat(configPath); err == nil {
+			return l.LoadFromFile(configPath)
+		}
+	}
+
+	// No configuration file found.
+	result := &LoadResult{
+		ConfigPath: "",
+		Flags:      nil,
+		Errors:     []error{fmt.Errorf("%w: %s", ErrNoFuryctlConfigFileFound, dir)},
+	}
+
+	return result, nil
+}
+
 // processDynamicValues processes dynamic values like {env://VAR} and {file://path} in the flags configuration.
 func (l *Loader) processDynamicValues(flags *FlagsConfig) (*FlagsConfig, error) {
 	processed := &FlagsConfig{}
@@ -181,26 +203,4 @@ func (l *Loader) processCommandFlags(flagsMap map[string]any) (map[string]any, e
 	}
 
 	return processed, nil
-}
-
-// LoadFromDirectory tries to find and load flags from a furyctl.yaml file in the given directory..
-func (l *Loader) LoadFromDirectory(dir string) (*LoadResult, error) {
-	// Common configuration file names to try.
-	configNames := []string{"furyctl.yaml", "furyctl.yml"}
-
-	for _, name := range configNames {
-		configPath := filepath.Join(dir, name)
-		if _, err := os.Stat(configPath); err == nil {
-			return l.LoadFromFile(configPath)
-		}
-	}
-
-	// No configuration file found.
-	result := &LoadResult{
-		ConfigPath: "",
-		Flags:      nil,
-		Errors:     []error{fmt.Errorf("%w: %s", ErrNoFuryctlConfigFileFound, dir)},
-	}
-
-	return result, nil
 }

--- a/internal/flags/merger.go
+++ b/internal/flags/merger.go
@@ -110,63 +110,6 @@ func (m *Merger) MergeIntoViper(flags *FlagsConfig, command string) error {
 	return nil
 }
 
-// mergeCommandFlags merges flags for a specific command into viper.
-func (m *Merger) mergeCommandFlags(flagsMap map[string]any, command string) error {
-	var supportedFlagsMap map[string]FlagInfo
-
-	switch command {
-	case CommandGlobal:
-		supportedFlagsMap = m.supportedFlags.Global
-
-	case CommandApply:
-		supportedFlagsMap = m.supportedFlags.Apply
-
-	case CommandDelete:
-		supportedFlagsMap = m.supportedFlags.Delete
-
-	case CommandCreate:
-		supportedFlagsMap = m.supportedFlags.Create
-
-	case CommandGet:
-		supportedFlagsMap = m.supportedFlags.Get
-
-	case CommandDiff:
-		supportedFlagsMap = m.supportedFlags.Diff
-
-	case CommandTools:
-		supportedFlagsMap = m.supportedFlags.Tools
-
-	default:
-		return fmt.Errorf("%w: %s", ErrUnsupportedCommand, command)
-	}
-
-	for flagName, value := range flagsMap {
-		// Check if the flag is supported.
-		flagInfo, supported := supportedFlagsMap[flagName]
-		if !supported {
-			// Log warning but don't fail - might be a new flag.
-			continue
-		}
-
-		// Convert and validate the value.
-		convertedValue, err := m.ConvertValue(value, flagInfo.Type)
-		if err != nil {
-			return fmt.Errorf("error converting flag %s: %w", flagName, err)
-		}
-
-		// Convert camelCase flag name to kebab-case for viper.
-		viperKey := CamelToKebab(flagName)
-
-		// Set the value in viper only if it's not already set.
-		// This preserves the priority: env vars and command line flags take precedence.
-		if !viper.IsSet(viperKey) {
-			viper.Set(viperKey, convertedValue)
-		}
-	}
-
-	return nil
-}
-
 // ConvertValue converts a value to the expected type for the flag.
 func (*Merger) ConvertValue(value any, expectedType FlagType) (any, error) {
 	switch expectedType {
@@ -283,4 +226,61 @@ func (m *Merger) GetSupportedFlagsForCommand(command string) map[string]FlagInfo
 	default:
 		return nil
 	}
+}
+
+// mergeCommandFlags merges flags for a specific command into viper.
+func (m *Merger) mergeCommandFlags(flagsMap map[string]any, command string) error {
+	var supportedFlagsMap map[string]FlagInfo
+
+	switch command {
+	case CommandGlobal:
+		supportedFlagsMap = m.supportedFlags.Global
+
+	case CommandApply:
+		supportedFlagsMap = m.supportedFlags.Apply
+
+	case CommandDelete:
+		supportedFlagsMap = m.supportedFlags.Delete
+
+	case CommandCreate:
+		supportedFlagsMap = m.supportedFlags.Create
+
+	case CommandGet:
+		supportedFlagsMap = m.supportedFlags.Get
+
+	case CommandDiff:
+		supportedFlagsMap = m.supportedFlags.Diff
+
+	case CommandTools:
+		supportedFlagsMap = m.supportedFlags.Tools
+
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedCommand, command)
+	}
+
+	for flagName, value := range flagsMap {
+		// Check if the flag is supported.
+		flagInfo, supported := supportedFlagsMap[flagName]
+		if !supported {
+			// Log warning but don't fail - might be a new flag.
+			continue
+		}
+
+		// Convert and validate the value.
+		convertedValue, err := m.ConvertValue(value, flagInfo.Type)
+		if err != nil {
+			return fmt.Errorf("error converting flag %s: %w", flagName, err)
+		}
+
+		// Convert camelCase flag name to kebab-case for viper.
+		viperKey := CamelToKebab(flagName)
+
+		// Set the value in viper only if it's not already set.
+		// This preserves the priority: env vars and command line flags take precedence.
+		if !viper.IsSet(viperKey) {
+			viper.Set(viperKey, convertedValue)
+		}
+	}
+
+	return nil
 }

--- a/internal/flags/validator.go
+++ b/internal/flags/validator.go
@@ -79,6 +79,11 @@ func (v *Validator) Validate(flags *FlagsConfig) []ValidationError {
 	return validationErrors
 }
 
+// ValidateIndividualFlag ValidateFlagValue is a public wrapper for testing the flag value validation.
+func (v *Validator) ValidateIndividualFlag(flagName string, value any, flagInfo FlagInfo) error {
+	return v.validateFlagValue(flagName, value, flagInfo)
+}
+
 // validateCommandFlags validates flags for a specific command.
 func (v *Validator) validateCommandFlags(flagsMap map[string]any, command string) []ValidationError {
 	var validationErrors []ValidationError
@@ -350,9 +355,4 @@ func getValidationSeverity(flagName string, err error) ValidationSeverity {
 
 	// Default to warning for less critical validation issues.
 	return ValidationSeverityWarning
-}
-
-// ValidateFlagValue is a public wrapper for testing the flag value validation.
-func (v *Validator) ValidateIndividualFlag(flagName string, value any, flagInfo FlagInfo) error {
-	return v.validateFlagValue(flagName, value, flagInfo)
 }

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -55,6 +55,17 @@ type GitHubClient struct {
 	config ClientConfig
 }
 
+// NewGitHubClient creates a new GitHub client with the given configuration.
+func NewGitHubClient() *GitHubClient {
+	return &GitHubClient{
+		client: http.DefaultClient,
+		config: ClientConfig{
+			ReleaseAPI: "https://api.github.com/repos/sighupio/fury-distribution/releases",
+			Timeout:    gitHubClientTimeout,
+		},
+	}
+}
+
 var ErrGHRateLimit = errors.New("rate limited from GitHub public API, retry in 1 hour")
 
 // GetReleases fetches all releases from GitHub.
@@ -122,15 +133,4 @@ func (gc GitHubClient) fetchReleasesPage(page, perPage int) ([]Release, int, err
 	}
 
 	return releases, page + 1, nil
-}
-
-// NewGitHubClient creates a new GitHub client with the given configuration.
-func NewGitHubClient() *GitHubClient {
-	return &GitHubClient{
-		client: http.DefaultClient,
-		config: ClientConfig{
-			ReleaseAPI: "https://api.github.com/repos/sighupio/fury-distribution/releases",
-			Timeout:    gitHubClientTimeout,
-		},
-	}
 }

--- a/internal/git/protocols.go
+++ b/internal/git/protocols.go
@@ -12,6 +12,8 @@ import (
 
 var ErrUnsupportedGitProtocol = errors.New("unsupported git protocol")
 
+type Protocol string
+
 func NewProtocol(protocol string) (Protocol, error) {
 	switch protocol {
 	case "ssh":
@@ -27,8 +29,6 @@ func NewProtocol(protocol string) (Protocol, error) {
 		strings.Join(ProtocolsS(), ", "),
 	)
 }
-
-type Protocol string
 
 const (
 	ProtocolSSH   = Protocol("ssh")

--- a/internal/tool/ansible/runner.go
+++ b/internal/tool/ansible/runner.go
@@ -63,49 +63,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Ansible
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	return r.build(r.paths.Ansible, args)
-}
-
-func (r *Runner) newPlaybookCmd(args []string) (*execx.Cmd, string) {
-	return r.build(r.paths.AnsiblePlaybook, args)
-}
-
-// build runs the given ansible entrypoint directly (host) or as `<python> <entrypoint> ...` with the
-// collections env (mise-managed).
-func (r *Runner) build(entrypoint string, args []string) (*execx.Cmd, string) {
-	name := entrypoint
-	fullArgs := args
-
-	var env []string
-
-	if r.paths.Python != "" {
-		name = r.paths.Python
-
-		fullArgs = append([]string{entrypoint}, args...)
-
-		if r.paths.CollectionsPath != "" {
-			env = []string{"ANSIBLE_COLLECTIONS_PATH=" + r.paths.CollectionsPath}
-		}
-	}
-
-	cmd := execx.NewCmd(name, execx.CmdOptions{
-		Args:     fullArgs,
-		Env:      env,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Playbook(params ...string) ([]byte, error) {
 	args := []string{}
 	out := []byte{}
@@ -168,4 +125,47 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	return r.build(r.paths.Ansible, args)
+}
+
+func (r *Runner) newPlaybookCmd(args []string) (*execx.Cmd, string) {
+	return r.build(r.paths.AnsiblePlaybook, args)
+}
+
+// build runs the given ansible entrypoint directly (host) or as `<python> <entrypoint> ...` with the
+// collections env (mise-managed).
+func (r *Runner) build(entrypoint string, args []string) (*execx.Cmd, string) {
+	name := entrypoint
+	fullArgs := args
+
+	var env []string
+
+	if r.paths.Python != "" {
+		name = r.paths.Python
+
+		fullArgs = append([]string{entrypoint}, args...)
+
+		if r.paths.CollectionsPath != "" {
+			env = []string{"ANSIBLE_COLLECTIONS_PATH=" + r.paths.CollectionsPath}
+		}
+	}
+
+	cmd := execx.NewCmd(name, execx.CmdOptions{
+		Args:     fullArgs,
+		Env:      env,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/awscli/runner.go
+++ b/internal/tool/awscli/runner.go
@@ -35,24 +35,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Awscli
 }
 
-func (r *Runner) newCmd(args []string, sensitive bool) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Awscli, execx.CmdOptions{
-		Args:      args,
-		Executor:  r.executor,
-		WorkDir:   r.paths.WorkDir,
-		Sensitive: sensitive,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Ec2(sensitive bool, sub string, params ...string) (string, error) {
 	args := []string{"ec2", sub}
 
@@ -153,4 +135,22 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string, sensitive bool) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Awscli, execx.CmdOptions{
+		Args:      args,
+		Executor:  r.executor,
+		WorkDir:   r.paths.WorkDir,
+		Sensitive: sensitive,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/furyagent/runner.go
+++ b/internal/tool/furyagent/runner.go
@@ -36,23 +36,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Furyagent
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Furyagent, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) ConfigOpenvpnClient(name string, params ...string) (*bytes.Buffer, error) {
 	args := []string{
 		"configure",
@@ -114,4 +97,21 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Furyagent, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/git/runner.go
+++ b/internal/tool/git/runner.go
@@ -35,23 +35,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Git
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Git, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Version() (string, error) {
 	cmd, id := r.newCmd([]string{"version"})
 	defer r.deleteCmd(id)
@@ -72,4 +55,21 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Git, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/helm/runner.go
+++ b/internal/tool/helm/runner.go
@@ -44,23 +44,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Helm
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Helm, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Version() (string, error) {
 	cmd, id := r.newCmd([]string{"version", "--short"})
 	defer r.deleteCmd(id)
@@ -81,4 +64,21 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Helm, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/helmfile/runner.go
+++ b/internal/tool/helmfile/runner.go
@@ -53,26 +53,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Helmfile
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Helmfile, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-		// Disable helmfile's "newer version available" check: it hits the network on every
-		// invocation (including `version`), which slows things down and breaks air-gapped runs.
-		Env: []string{"HELMFILE_UPGRADE_NOTICE_DISABLED=1"},
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Init(helmBinary string) error {
 	// Helm plugin install hooks (e.g. helm-diff's install-binary.sh) call `helm` by bare name, so put the
 	// helm binary's dir on PATH — furyctl otherwise drives tools by absolute path and there may be no
@@ -102,17 +82,6 @@ func (r *Runner) Init(helmBinary string) error {
 	}
 
 	return nil
-}
-
-// hasDownloader reports whether curl or wget is available to download helm plugin binaries.
-func hasDownloader() bool {
-	for _, tool := range []string{"curl", "wget"} {
-		if _, err := exec.LookPath(tool); err == nil {
-			return true
-		}
-	}
-
-	return false
 }
 
 func (r *Runner) Apply() error {
@@ -148,4 +117,35 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Helmfile, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+		// Disable helmfile's "newer version available" check: it hits the network on every
+		// invocation (including `version`), which slows things down and breaks air-gapped runs.
+		Env: []string{"HELMFILE_UPGRADE_NOTICE_DISABLED=1"},
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
+}
+
+// hasDownloader reports whether curl or wget is available to download helm plugin binaries.
+func hasDownloader() bool {
+	for _, tool := range []string{"curl", "wget"} {
+		if _, err := exec.LookPath(tool); err == nil {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/tool/kapp/runner.go
+++ b/internal/tool/kapp/runner.go
@@ -37,24 +37,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Kapp
 }
 
-func (r *Runner) newCmd(args []string, sensitive bool) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Kapp, execx.CmdOptions{
-		Args:      args,
-		Executor:  r.executor,
-		WorkDir:   r.paths.WorkDir,
-		Sensitive: sensitive,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Deploy(manifestPath string, params ...string) error {
 	args := []string{"deploy"}
 
@@ -104,4 +86,22 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string, sensitive bool) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Kapp, execx.CmdOptions{
+		Args:      args,
+		Executor:  r.executor,
+		WorkDir:   r.paths.WorkDir,
+		Sensitive: sensitive,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/kubectl/runner.go
+++ b/internal/tool/kubectl/runner.go
@@ -41,24 +41,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Kubectl
 }
 
-func (r *Runner) newCmd(args []string, sensitive bool) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Kubectl, execx.CmdOptions{
-		Args:      args,
-		Executor:  r.executor,
-		WorkDir:   r.paths.WorkDir,
-		Sensitive: sensitive,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Apply(manifestPath string, params ...string) error {
 	args := []string{"apply"}
 
@@ -153,4 +135,22 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string, sensitive bool) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Kubectl, execx.CmdOptions{
+		Args:      args,
+		Executor:  r.executor,
+		WorkDir:   r.paths.WorkDir,
+		Sensitive: sensitive,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/kustomize/runner.go
+++ b/internal/tool/kustomize/runner.go
@@ -35,23 +35,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Kustomize
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Kustomize, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Version() (string, error) {
 	args := []string{"version"}
 
@@ -74,4 +57,21 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Kustomize, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/mise/mise.go
+++ b/internal/tool/mise/mise.go
@@ -140,38 +140,6 @@ func NewRunner(executor execx.Executor, paths Paths) *Runner {
 	return &Runner{executor: executor, paths: paths}
 }
 
-// hermeticEnv isolates our mise from the user's: dedicated data/cache/config, auto-confirm and a
-// trusted config path (no prompt).
-func (r *Runner) hermeticEnv() []string {
-	return []string{
-		"MISE_DATA_DIR=" + r.paths.DataDir,
-		"MISE_CACHE_DIR=" + r.paths.CacheDir,
-		"MISE_GLOBAL_CONFIG_FILE=" + r.paths.ConfigFile,
-		"MISE_TRUSTED_CONFIG_PATHS=" + filepath.Dir(r.paths.ConfigFile),
-		"MISE_YES=1",
-	}
-}
-
-// newCmd builds a mise invocation: always `--cd <isolated workdir>` so config discovery can't pick
-// up ambient mise.toml files, with the hermetic env.
-func (r *Runner) newCmd(args ...string) *execx.Cmd {
-	return r.newCmdOut(nil, args...)
-}
-
-// newCmdOut is like newCmd but also tees mise's stdout/stderr to progress (in addition to the
-// captured buffers), so the caller can stream install output live.
-func (r *Runner) newCmdOut(progress io.Writer, args ...string) *execx.Cmd {
-	fullArgs := append([]string{"--cd", r.paths.WorkDir}, args...)
-
-	return execx.NewCmd(r.paths.Mise, execx.CmdOptions{
-		Args:     fullArgs,
-		Env:      r.hermeticEnv(),
-		Executor: r.executor,
-		Out:      progress,
-		Err:      progress,
-	})
-}
-
 // Install installs all tools declared in the (hermetic) global config into DataDir, teeing mise's
 // progress output to progress (may be nil). No-op if they are already installed.
 func (r *Runner) Install(progress io.Writer) error {
@@ -221,4 +189,36 @@ func (r *Runner) Version() (string, error) {
 	}
 
 	return strings.TrimSpace(out), nil
+}
+
+// hermeticEnv isolates our mise from the user's: dedicated data/cache/config, auto-confirm and a
+// trusted config path (no prompt).
+func (r *Runner) hermeticEnv() []string {
+	return []string{
+		"MISE_DATA_DIR=" + r.paths.DataDir,
+		"MISE_CACHE_DIR=" + r.paths.CacheDir,
+		"MISE_GLOBAL_CONFIG_FILE=" + r.paths.ConfigFile,
+		"MISE_TRUSTED_CONFIG_PATHS=" + filepath.Dir(r.paths.ConfigFile),
+		"MISE_YES=1",
+	}
+}
+
+// newCmd builds a mise invocation: always `--cd <isolated workdir>` so config discovery can't pick
+// up ambient mise.toml files, with the hermetic env.
+func (r *Runner) newCmd(args ...string) *execx.Cmd {
+	return r.newCmdOut(nil, args...)
+}
+
+// newCmdOut is like newCmd but also tees mise's stdout/stderr to progress (in addition to the
+// captured buffers), so the caller can stream install output live.
+func (r *Runner) newCmdOut(progress io.Writer, args ...string) *execx.Cmd {
+	fullArgs := append([]string{"--cd", r.paths.WorkDir}, args...)
+
+	return execx.NewCmd(r.paths.Mise, execx.CmdOptions{
+		Args:     fullArgs,
+		Env:      r.hermeticEnv(),
+		Executor: r.executor,
+		Out:      progress,
+		Err:      progress,
+	})
 }

--- a/internal/tool/openvpn/runner.go
+++ b/internal/tool/openvpn/runner.go
@@ -36,27 +36,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Openvpn
 }
 
-func (r *Runner) newCmdWithPath(path string, args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(path, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	return r.newCmdWithPath(r.paths.Openvpn, args)
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Connect(name string) error {
 	path := "sudo"
 	args := []string{"openvpn", "--config", name + ".ovpn", "--daemon"}
@@ -103,4 +82,25 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmdWithPath(path string, args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(path, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	return r.newCmdWithPath(r.paths.Openvpn, args)
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/runner.go
+++ b/internal/tool/runner.go
@@ -54,16 +54,16 @@ type RunnerFactoryPaths struct {
 	Bin string
 }
 
+type RunnerFactory struct {
+	executor execx.Executor
+	paths    RunnerFactoryPaths
+}
+
 func NewRunnerFactory(executor execx.Executor, paths RunnerFactoryPaths) *RunnerFactory {
 	return &RunnerFactory{
 		executor: executor,
 		paths:    paths,
 	}
-}
-
-type RunnerFactory struct {
-	executor execx.Executor
-	paths    RunnerFactoryPaths
 }
 
 func (rf *RunnerFactory) Create(name Name, version, workDir string) Runner {

--- a/internal/tool/sed/runner.go
+++ b/internal/tool/sed/runner.go
@@ -35,23 +35,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Sed
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Sed, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Version() (string, error) {
 	cmd, id := r.newCmd([]string{""})
 	defer r.deleteCmd(id)
@@ -84,4 +67,21 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Sed, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/shell/runner.go
+++ b/internal/tool/shell/runner.go
@@ -35,23 +35,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Shell
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Shell, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (*Runner) Version() (string, error) {
 	return "", nil
 }
@@ -76,4 +59,21 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Shell, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/terraform/runner.go
+++ b/internal/tool/terraform/runner.go
@@ -45,23 +45,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Terraform
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Terraform, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Init() error {
 	args := []string{"init", "-upgrade"}
 
@@ -204,4 +187,21 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Terraform, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/tool/yq/runner.go
+++ b/internal/tool/yq/runner.go
@@ -35,23 +35,6 @@ func (r *Runner) CmdPath() string {
 	return r.paths.Yq
 }
 
-func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
-	cmd := execx.NewCmd(r.paths.Yq, execx.CmdOptions{
-		Args:     args,
-		Executor: r.executor,
-		WorkDir:  r.paths.WorkDir,
-	})
-
-	id := uuid.NewString()
-	r.cmds[id] = cmd
-
-	return cmd, id
-}
-
-func (r *Runner) deleteCmd(id string) {
-	delete(r.cmds, id)
-}
-
 func (r *Runner) Version() (string, error) {
 	cmd, id := r.newCmd([]string{"--version"})
 	defer r.deleteCmd(id)
@@ -72,4 +55,21 @@ func (r *Runner) Stop() error {
 	}
 
 	return nil
+}
+
+func (r *Runner) newCmd(args []string) (*execx.Cmd, string) {
+	cmd := execx.NewCmd(r.paths.Yq, execx.CmdOptions{
+		Args:     args,
+		Executor: r.executor,
+		WorkDir:  r.paths.WorkDir,
+	})
+
+	id := uuid.NewString()
+	r.cmds[id] = cmd
+
+	return cmd, id
+}
+
+func (r *Runner) deleteCmd(id string) {
+	delete(r.cmds, id)
 }

--- a/internal/upgrade/storedecorator.go
+++ b/internal/upgrade/storedecorator.go
@@ -145,6 +145,13 @@ type OperatorPhaseAsync interface {
 	Stop() error
 }
 
+type OperatorPhaseDecorator struct {
+	storer Storer
+	phase  OperatorPhase
+	dryRun bool
+	upgr   *Upgrade
+}
+
 func NewOperatorPhaseDecorator(
 	storer Storer,
 	phase OperatorPhase,
@@ -157,13 +164,6 @@ func NewOperatorPhaseDecorator(
 		dryRun: dryRun,
 		upgr:   upgr,
 	}
-}
-
-type OperatorPhaseDecorator struct {
-	storer Storer
-	phase  OperatorPhase
-	dryRun bool
-	upgr   *Upgrade
 }
 
 func (d *OperatorPhaseDecorator) Exec(startFrom string, upgradeState *State) error {

--- a/internal/x/exec/cmd.go
+++ b/internal/x/exec/cmd.go
@@ -32,6 +32,12 @@ func NewErrCmdFailed(name string, args []string, err error, res *CmdLog) error {
 	return fmt.Errorf("%s %s: %w - %v\n%s", name, strings.Join(args, " "), ErrCmdFailed, err, res)
 }
 
+type Cmd struct {
+	*exec.Cmd
+	Log       *CmdLog
+	Sensitive bool
+}
+
 func NewCmd(name string, opts CmdOptions) *Cmd {
 	outLog := bytes.NewBufferString("")
 	errLog := bytes.NewBufferString("")
@@ -99,12 +105,6 @@ func NewCmd(name string, opts CmdOptions) *Cmd {
 		},
 		Sensitive: opts.Sensitive,
 	}
-}
-
-type Cmd struct {
-	*exec.Cmd
-	Log       *CmdLog
-	Sensitive bool
 }
 
 func (c *Cmd) Run() error {

--- a/internal/x/exec/executor.go
+++ b/internal/x/exec/executor.go
@@ -14,14 +14,18 @@ type Executor interface {
 	Command(name string, arg ...string) *exec.Cmd
 }
 
+type StdExecutor struct{}
+
 func NewStdExecutor() *StdExecutor {
 	return &StdExecutor{}
 }
 
-type StdExecutor struct{}
-
 func (*StdExecutor) Command(name string, arg ...string) *exec.Cmd {
 	return exec.Command(name, arg...)
+}
+
+type FakeExecutor struct {
+	testHelperProcessFn string
 }
 
 func NewFakeExecutor(testHelperProcessFn string) *FakeExecutor {
@@ -32,10 +36,6 @@ func NewFakeExecutor(testHelperProcessFn string) *FakeExecutor {
 	return &FakeExecutor{
 		testHelperProcessFn: testHelperProcessFn,
 	}
-}
-
-type FakeExecutor struct {
-	testHelperProcessFn string
 }
 
 func (fe *FakeExecutor) Command(name string, arg ...string) *exec.Cmd {

--- a/internal/x/io/liveregion.go
+++ b/internal/x/io/liveregion.go
@@ -90,6 +90,21 @@ func (lr *LiveRegion) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// Clear wipes the painted region, leaving the cursor where the region began.
+func (lr *LiveRegion) Clear() {
+	if !lr.enabled || lr.painted == 0 {
+		return
+	}
+
+	if _, err := io.WriteString(lr.w, "\033["+strconv.Itoa(lr.painted)+"A\033[J"); err != nil {
+		lr.enabled = false
+	}
+
+	lr.painted = 0
+	lr.lines = nil
+	lr.partial = ""
+}
+
 // truncate clips a line to the terminal width so it never wraps and breaks the line accounting.
 func (lr *LiveRegion) truncate(line string) string {
 	if lr.width <= 0 || len(line) <= lr.width {
@@ -116,19 +131,4 @@ func (lr *LiveRegion) repaint() {
 		// The terminal is no longer writable; stop painting so we don't garble output.
 		lr.enabled = false
 	}
-}
-
-// Clear wipes the painted region, leaving the cursor where the region began.
-func (lr *LiveRegion) Clear() {
-	if !lr.enabled || lr.painted == 0 {
-		return
-	}
-
-	if _, err := io.WriteString(lr.w, "\033["+strconv.Itoa(lr.painted)+"A\033[J"); err != nil {
-		lr.enabled = false
-	}
-
-	lr.painted = 0
-	lr.lines = nil
-	lr.partial = ""
 }

--- a/internal/x/io/nullwriter.go
+++ b/internal/x/io/nullwriter.go
@@ -4,11 +4,11 @@
 
 package iox
 
+type NullWriter struct{}
+
 func NewNullWriter() *NullWriter {
 	return &NullWriter{}
 }
-
-type NullWriter struct{}
 
 func (*NullWriter) Write(_ []byte) (int, error) {
 	return 0, nil

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.0.2"
+golangci-lint = "2.1.6"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"

--- a/pkg/dependencies/download.go
+++ b/pkg/dependencies/download.go
@@ -38,6 +38,13 @@ var (
 	ErrModuleNotFound     = errors.New("module not found")
 )
 
+type Downloader struct {
+	client      netx.Client
+	basePath    string
+	binPath     string
+	gitProtocol git.Protocol
+}
+
 func NewCachingDownloader(client netx.Client, outDir, basePath, binPath string, gitProtocol git.Protocol) *Downloader {
 	return NewDownloader(netx.WithLocalCache(
 		client,
@@ -55,13 +62,6 @@ func NewDownloader(client netx.Client, basePath, binPath string, gitProtocol git
 		binPath:     binPath,
 		gitProtocol: gitProtocol,
 	}
-}
-
-type Downloader struct {
-	client      netx.Client
-	basePath    string
-	binPath     string
-	gitProtocol git.Protocol
 }
 
 func (dd *Downloader) DownloadAll(kfd config.KFD, kind string) ([]error, []string) {

--- a/pkg/dependencies/validate.go
+++ b/pkg/dependencies/validate.go
@@ -19,16 +19,16 @@ var (
 	errValidatingEnv   = errors.New("errors validating env vars")
 )
 
+type Validator struct {
+	toolsValidator   *tools.Validator
+	envVarsValidator *envvars.Validator
+}
+
 func NewValidator(executor execx.Executor, binPath, furyctlPath string) *Validator {
 	return &Validator{
 		toolsValidator:   tools.NewValidator(executor, binPath, furyctlPath),
 		envVarsValidator: envvars.NewValidator(),
 	}
-}
-
-type Validator struct {
-	toolsValidator   *tools.Validator
-	envVarsValidator *envvars.Validator
 }
 
 func (v *Validator) ValidateBaseReqs() error {

--- a/pkg/distribution/download.go
+++ b/pkg/distribution/download.go
@@ -43,10 +43,11 @@ var (
 	ErrUnsupportedVersion         = errors.New("unsupported SD version")
 )
 
-type DownloadResult struct {
-	RepoPath       string
-	MinimalConf    config.Furyctl
-	DistroManifest config.KFD
+type Downloader struct {
+	client                  netx.Client
+	validate                *validator.Validate
+	gitProtocol             git.Protocol
+	customDistroPatchesPath string
 }
 
 func NewCachingDownloader(
@@ -71,11 +72,10 @@ func NewDownloader(client netx.Client, gitProtocol git.Protocol, customDistroPat
 	}
 }
 
-type Downloader struct {
-	client                  netx.Client
-	validate                *validator.Validate
-	gitProtocol             git.Protocol
-	customDistroPatchesPath string
+type DownloadResult struct {
+	RepoPath       string
+	MinimalConf    config.Furyctl
+	DistroManifest config.KFD
 }
 
 func (d *Downloader) Download(

--- a/pkg/rulesextractor/extractor.go
+++ b/pkg/rulesextractor/extractor.go
@@ -206,6 +206,157 @@ func (b *BaseExtractor) FilterSafeImmutableRules(rules []Rule, ds diff.Changelog
 	return filteredRules
 }
 
+func (b *BaseExtractor) GetReducers(_ string) []Rule {
+	var reducers []Rule
+
+	if b.Spec.Infrastructure != nil {
+		for _, rule := range *b.Spec.Infrastructure {
+			if rule.Reducers != nil {
+				reducers = append(reducers, rule)
+			}
+		}
+	}
+
+	if b.Spec.Kubernetes != nil {
+		for _, rule := range *b.Spec.Kubernetes {
+			if rule.Reducers != nil {
+				reducers = append(reducers, rule)
+			}
+		}
+	}
+
+	if b.Spec.Distribution != nil {
+		for _, rule := range *b.Spec.Distribution {
+			if rule.Reducers != nil {
+				reducers = append(reducers, rule)
+			}
+		}
+	}
+
+	return reducers
+}
+
+// GetUnsupportedRules returns all the rules that declare unsupported transitions,
+// regardless of whether they also define reducers. This is what drives the
+// "unsupported transition" validation, which must not depend on reducers being set.
+func (b *BaseExtractor) GetUnsupportedRules(_ string) []Rule {
+	var unsupported []Rule
+
+	if b.Spec.Infrastructure != nil {
+		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Infrastructure)...)
+	}
+
+	if b.Spec.Kubernetes != nil {
+		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Kubernetes)...)
+	}
+
+	if b.Spec.Distribution != nil {
+		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Distribution)...)
+	}
+
+	return unsupported
+}
+
+func (*BaseExtractor) ReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule {
+	filteredRules := make([]Rule, 0)
+
+	for _, rule := range rules {
+		for _, d := range ds {
+			joinedPath := "." + strings.Join(d.Path, ".")
+			changePath := numbersToWildcardRegex.ReplaceAllString(joinedPath, ".*")
+
+			if MatchesPattern(changePath, rule.Path) {
+				if rule.Reducers == nil {
+					continue
+				}
+
+				for i := range *rule.Reducers {
+					(*rule.Reducers)[i].To = d.To
+					(*rule.Reducers)[i].From = d.From
+				}
+
+				filteredRules = append(filteredRules, rule)
+			}
+		}
+	}
+
+	return filteredRules
+}
+
+func (b *BaseExtractor) UnsupportedReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule {
+	filteredRules := make([]Rule, 0)
+
+	for _, rule := range b.ReducerRulesByDiffs(rules, ds) {
+		if rule.Unsupported == nil {
+			continue
+		}
+
+		if len(*rule.Unsupported) == 0 {
+			continue
+		}
+
+		filteredRules = append(filteredRules, rule)
+	}
+
+	return filteredRules
+}
+
+func (b *BaseExtractor) UnsafeReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule {
+	filteredRules := make([]Rule, 0)
+
+	for _, rule := range b.ReducerRulesByDiffs(rules, ds) {
+		if rule.Safe != nil && len(*rule.Safe) > 0 {
+			if b.areReducersSafe(rule.Reducers, rule.Safe, ds) {
+				continue
+			}
+		}
+
+		filteredRules = append(filteredRules, rule)
+	}
+
+	return filteredRules
+}
+
+func (*BaseExtractor) ExtractImmutablesFromRules(rls []Rule) []string {
+	immutables := make([]string, 0)
+
+	for _, rule := range rls {
+		if rule.Immutable {
+			immutables = append(immutables, rule.Path)
+		}
+	}
+
+	return immutables
+}
+
+func (*BaseExtractor) ExtractReducerRules(rls []Rule) []Rule {
+	reducers := make([]Rule, 0)
+
+	for _, rule := range rls {
+		if rule.Reducers != nil {
+			reducers = append(reducers, rule)
+		}
+	}
+
+	return reducers
+}
+
+// ExtractUnsupportedRules returns the rules that declare at least one unsupported
+// transition, regardless of whether they also define reducers. Unsupported
+// transitions are enforced independently from reducers (see
+// diffs.AssertReducerUnsupportedViolations).
+func (*BaseExtractor) ExtractUnsupportedRules(rls []Rule) []Rule {
+	unsupported := make([]Rule, 0)
+
+	for _, rule := range rls {
+		if rule.Unsupported != nil && len(*rule.Unsupported) > 0 {
+			unsupported = append(unsupported, rule)
+		}
+	}
+
+	return unsupported
+}
+
 func (b *BaseExtractor) isImmutableRuleSafe(rule Rule, ds diff.Changelog) bool {
 	if rule.Safe == nil || len(*rule.Safe) == 0 {
 		return false
@@ -348,117 +499,6 @@ func (*BaseExtractor) checkConditionTo(nodeTo *string, diffTo any) bool {
 	return (*nodeTo == "none" && diffTo == nil) || (diffTo != nil && diffTo == *nodeTo)
 }
 
-func (b *BaseExtractor) GetReducers(_ string) []Rule {
-	var reducers []Rule
-
-	if b.Spec.Infrastructure != nil {
-		for _, rule := range *b.Spec.Infrastructure {
-			if rule.Reducers != nil {
-				reducers = append(reducers, rule)
-			}
-		}
-	}
-
-	if b.Spec.Kubernetes != nil {
-		for _, rule := range *b.Spec.Kubernetes {
-			if rule.Reducers != nil {
-				reducers = append(reducers, rule)
-			}
-		}
-	}
-
-	if b.Spec.Distribution != nil {
-		for _, rule := range *b.Spec.Distribution {
-			if rule.Reducers != nil {
-				reducers = append(reducers, rule)
-			}
-		}
-	}
-
-	return reducers
-}
-
-// GetUnsupportedRules returns all the rules that declare unsupported transitions,
-// regardless of whether they also define reducers. This is what drives the
-// "unsupported transition" validation, which must not depend on reducers being set.
-func (b *BaseExtractor) GetUnsupportedRules(_ string) []Rule {
-	var unsupported []Rule
-
-	if b.Spec.Infrastructure != nil {
-		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Infrastructure)...)
-	}
-
-	if b.Spec.Kubernetes != nil {
-		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Kubernetes)...)
-	}
-
-	if b.Spec.Distribution != nil {
-		unsupported = append(unsupported, b.ExtractUnsupportedRules(*b.Spec.Distribution)...)
-	}
-
-	return unsupported
-}
-
-func (*BaseExtractor) ReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule {
-	filteredRules := make([]Rule, 0)
-
-	for _, rule := range rules {
-		for _, d := range ds {
-			joinedPath := "." + strings.Join(d.Path, ".")
-			changePath := numbersToWildcardRegex.ReplaceAllString(joinedPath, ".*")
-
-			if MatchesPattern(changePath, rule.Path) {
-				if rule.Reducers == nil {
-					continue
-				}
-
-				for i := range *rule.Reducers {
-					(*rule.Reducers)[i].To = d.To
-					(*rule.Reducers)[i].From = d.From
-				}
-
-				filteredRules = append(filteredRules, rule)
-			}
-		}
-	}
-
-	return filteredRules
-}
-
-func (b *BaseExtractor) UnsupportedReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule {
-	filteredRules := make([]Rule, 0)
-
-	for _, rule := range b.ReducerRulesByDiffs(rules, ds) {
-		if rule.Unsupported == nil {
-			continue
-		}
-
-		if len(*rule.Unsupported) == 0 {
-			continue
-		}
-
-		filteredRules = append(filteredRules, rule)
-	}
-
-	return filteredRules
-}
-
-func (b *BaseExtractor) UnsafeReducerRulesByDiffs(rules []Rule, ds diff.Changelog) []Rule {
-	filteredRules := make([]Rule, 0)
-
-	for _, rule := range b.ReducerRulesByDiffs(rules, ds) {
-		if rule.Safe != nil && len(*rule.Safe) > 0 {
-			if b.areReducersSafe(rule.Reducers, rule.Safe, ds) {
-				continue
-			}
-		}
-
-		filteredRules = append(filteredRules, rule)
-	}
-
-	return filteredRules
-}
-
 func (b *BaseExtractor) areReducersSafe(reducers *[]Reducer, safe *[]Safe, ds diff.Changelog) bool {
 	if safe == nil {
 		return false
@@ -490,44 +530,4 @@ func (b *BaseExtractor) isReducerSafe(reducer Reducer, safe []Safe, ds diff.Chan
 	}
 
 	return false
-}
-
-func (*BaseExtractor) ExtractImmutablesFromRules(rls []Rule) []string {
-	immutables := make([]string, 0)
-
-	for _, rule := range rls {
-		if rule.Immutable {
-			immutables = append(immutables, rule.Path)
-		}
-	}
-
-	return immutables
-}
-
-func (*BaseExtractor) ExtractReducerRules(rls []Rule) []Rule {
-	reducers := make([]Rule, 0)
-
-	for _, rule := range rls {
-		if rule.Reducers != nil {
-			reducers = append(reducers, rule)
-		}
-	}
-
-	return reducers
-}
-
-// ExtractUnsupportedRules returns the rules that declare at least one unsupported
-// transition, regardless of whether they also define reducers. Unsupported
-// transitions are enforced independently from reducers (see
-// diffs.AssertReducerUnsupportedViolations).
-func (*BaseExtractor) ExtractUnsupportedRules(rls []Rule) []Rule {
-	unsupported := make([]Rule, 0)
-
-	for _, rule := range rls {
-		if rule.Unsupported != nil && len(*rule.Unsupported) > 0 {
-			unsupported = append(unsupported, rule)
-		}
-	}
-
-	return unsupported
 }

--- a/pkg/template/model.go
+++ b/pkg/template/model.go
@@ -106,17 +106,6 @@ func NewTemplateModel(
 	}, nil
 }
 
-func (tm *Model) isExcluded(source string) bool {
-	for _, exc := range tm.Config.Templates.Excludes {
-		regex := regexp.MustCompile(exc)
-		if regex.MatchString(source) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (tm *Model) Generate() error {
 	if tm.StopIfTargetNotEmpty {
 		err := iox.CheckDirIsEmpty(tm.TargetPath)
@@ -153,6 +142,17 @@ func (tm *Model) Generate() error {
 	}
 
 	return nil
+}
+
+func (tm *Model) isExcluded(source string) bool {
+	for _, exc := range tm.Config.Templates.Excludes {
+		regex := regexp.MustCompile(exc)
+		if regex.MatchString(source) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (tm *Model) applyTemplates(

--- a/pkg/x/net/client_test.go
+++ b/pkg/x/net/client_test.go
@@ -27,11 +27,11 @@ var (
 	errCannotCreateFakeDistroDstFolder = errors.New("cannot create fake distro dst folder")
 )
 
+type FakeClient struct{}
+
 func NewFakeClient() *FakeClient {
 	return &FakeClient{}
 }
-
-type FakeClient struct{}
 
 func (f *FakeClient) Clear() error {
 	return nil

--- a/pkg/x/net/hashicorp.go
+++ b/pkg/x/net/hashicorp.go
@@ -23,14 +23,14 @@ const headProbeTimeout = 10 * time.Second
 
 var ErrDownloadOptionsExhausted = errors.New("downloading options exhausted")
 
+type GoGetterClient struct {
+	protocols []string
+}
+
 func NewGoGetterClient() *GoGetterClient {
 	return &GoGetterClient{
 		protocols: []string{"", "git::", "file::", "http::", "s3::", "gcs::", "mercurial::"},
 	}
-}
-
-type GoGetterClient struct {
-	protocols []string
 }
 
 func (*GoGetterClient) Clear() error {

--- a/pkg/x/net/progress.go
+++ b/pkg/x/net/progress.go
@@ -52,14 +52,6 @@ var newProgressTracker = func() *downloadProgressTracker {
 	}
 }
 
-func (t *downloadProgressTracker) interval() time.Duration {
-	if t.tty {
-		return progressTTYInterval
-	}
-
-	return progressLogInterval
-}
-
 // TrackProgress wraps the download stream in a reader that reports progress as it is read.
 func (t *downloadProgressTracker) TrackProgress(
 	src string,
@@ -80,6 +72,14 @@ func (t *downloadProgressTracker) TrackProgress(
 	}
 }
 
+func (t *downloadProgressTracker) interval() time.Duration {
+	if t.tty {
+		return progressTTYInterval
+	}
+
+	return progressLogInterval
+}
+
 // progressReader counts bytes read from the download stream and renders progress, throttled by the
 // tracker's interval.
 type progressReader struct {
@@ -90,16 +90,6 @@ type progressReader struct {
 	total      int64
 	lastRender time.Time
 	started    bool
-}
-
-// tracked reports whether the download is large enough to report. With a known size we decide upfront;
-// with an unknown size we start once enough bytes have streamed to prove it's large.
-func (r *progressReader) tracked() bool {
-	if r.total >= progressMinTrackedSize {
-		return true
-	}
-
-	return r.total <= 0 && r.read >= progressMinTrackedSize
 }
 
 func (r *progressReader) Read(p []byte) (int, error) {
@@ -127,6 +117,16 @@ func (r *progressReader) Close() error {
 
 	//nolint:wrapcheck // Pass the stream error through unchanged; go-getter handles it.
 	return r.stream.Close()
+}
+
+// tracked reports whether the download is large enough to report. With a known size we decide upfront;
+// with an unknown size we start once enough bytes have streamed to prove it's large.
+func (r *progressReader) tracked() bool {
+	if r.total >= progressMinTrackedSize {
+		return true
+	}
+
+	return r.total <= 0 && r.read >= progressMinTrackedSize
 }
 
 func (r *progressReader) render() {


### PR DESCRIPTION
### Summary 💡

Depends on #706 
Update golangci-lint to 2.1.6


### Description 📝

Update golangci-lint to 2.1.6 + code alignments to new linters.
All changes are strictly code reordering (no logic changes):
- Moved struct before constructors
- Moved struct constructors directly under the struct declaration
- Moved private functions below public functions

We can't enable the linting in CI until golanci-lint v2.4.0 due to golang v1.25.
The refactoring work isn't complete, but it's not easy to make all the fixes without being able to run the check command. Everything will be handled with version 2.4.0.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

Is not possibile to run lint checks with go 1.24

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

