### PR TITLE
chore: update golangci-lint to 2.2.2

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -16,10 +16,12 @@ linters:
     - forbidigo
     - ireturn
     - maintidx
+    - noinlineerr
     - rowserrcheck
     - sqlclosecheck
     - varnamelen
     - wastedassign
+    - wsl # deprecated, replaced by wsl_v5 since golangci-lint v2.2.0
   settings:
     cyclop:
       max-complexity: 80
@@ -388,12 +390,9 @@ linters:
         - const C
         - T any
         - m map[string]int
-    wsl:
-      allow-multiline-assign: true
-      force-case-trailing-whitespace: 1
-      allow-separated-leading-comment: false
-      allow-cuddle-declarations: false
-      force-err-cuddling: true
+    wsl_v5:
+      allow-whole-block: true
+      default: all
   exclusions:
     generated: disable
     presets:

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -34,8 +34,6 @@ import (
 	netx "github.com/sighupio/furyctl/pkg/x/net"
 )
 
-const WrappedErrMessage = "%w: %s"
-
 type Timeouts struct {
 	ProcessTimeout         int
 	PodRunningCheckTimeout int
@@ -49,6 +47,7 @@ type ClusterSkipsCmdFlags struct {
 }
 
 type ClusterCmdFlags struct {
+	ClusterSkipsCmdFlags
 	Timeouts
 	Debug                 bool
 	FuryctlPath           string
@@ -67,7 +66,6 @@ type ClusterCmdFlags struct {
 	UpgradeNode           string
 	DistroPatchesLocation string
 	PostApplyPhases       []string
-	ClusterSkipsCmdFlags
 }
 
 var (

--- a/cmd/serve/status_table.go
+++ b/cmd/serve/status_table.go
@@ -206,7 +206,7 @@ func (t *nodeStatusTable) lines() []string {
 
 	w := tabwriter.NewWriter(&sb, 0, 0, tabPadding, ' ', 0)
 
-	_, _ = fmt.Fprintf(w, "NODE\tSTATUS\tUPDATED\n")
+	_, _ = fmt.Fprint(w, "NODE\tSTATUS\tUPDATED\n")
 
 	for _, node := range t.order {
 		updated := "—"

--- a/internal/analytics/event.go
+++ b/internal/analytics/event.go
@@ -85,8 +85,8 @@ type StopEvent struct {
 }
 
 type CommandEvent struct {
-	name string
 	properties
+	name string
 }
 
 type properties map[string]any

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/distribution.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
-	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/phases"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/state"
@@ -40,7 +40,7 @@ const (
 var errClusterConnect = errors.New("error connecting to cluster")
 
 type Distribution struct {
-	*common.Distribution
+	*phases.Distribution
 
 	kfdManifest config.KFD
 
@@ -67,7 +67,7 @@ func NewDistribution(
 	)
 
 	return &Distribution{
-		Distribution: &common.Distribution{
+		Distribution: &phases.Distribution{
 			OperationPhase:                     phaseOp,
 			DryRun:                             dryRun,
 			DistroPath:                         paths.DistroPath,

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/infrastructure.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
-	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/phases"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/parser"
@@ -30,7 +30,7 @@ import (
 var ErrAbortedByUser = errors.New("aborted by user")
 
 type Infrastructure struct {
-	*common.Infrastructure
+	*phases.Infrastructure
 
 	kfdManifest config.KFD
 	tfRunner    *terraform.Runner
@@ -55,7 +55,7 @@ func NewInfrastructure(
 	executor := execx.NewStdExecutor()
 
 	return &Infrastructure{
-		Infrastructure: &common.Infrastructure{
+		Infrastructure: &phases.Infrastructure{
 			OperationPhase: phase,
 			FuryctlConf:    furyctlConf,
 			ConfigPath:     paths.ConfigPath,

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/kubernetes.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
-	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/phases"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/parser"
@@ -48,7 +48,7 @@ const (
 )
 
 type Kubernetes struct {
-	*common.Kubernetes
+	*phases.Kubernetes
 
 	tfRunner  *terraform.Runner
 	awsRunner *awscli.Runner
@@ -71,7 +71,7 @@ func NewKubernetes(
 	)
 
 	return &Kubernetes{
-		Kubernetes: &common.Kubernetes{
+		Kubernetes: &phases.Kubernetes{
 			OperationPhase:                     phase,
 			FuryctlConf:                        furyctlConf,
 			FuryctlConfPath:                    paths.ConfigPath,
@@ -339,7 +339,7 @@ func (k *Kubernetes) checkVPCConnection() error {
 			"text",
 		)
 		if err != nil {
-			return fmt.Errorf(common.SErrWrapWithStr, errCIDRBlockFromVpc, err)
+			return fmt.Errorf(phases.SErrWrapWithStr, errCIDRBlockFromVpc, err)
 		}
 	}
 
@@ -356,17 +356,17 @@ func (k *Kubernetes) checkVPCConnection() error {
 func (*Kubernetes) queryAWSDNSServer(cidr string) error {
 	_, ipNet, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return fmt.Errorf(common.SErrWrapWithStr, errParsingCIDR, err)
+		return fmt.Errorf(phases.SErrWrapWithStr, errParsingCIDR, err)
 	}
 
 	offIPNet, err := netx.AddOffsetToIPNet(ipNet, awsDNSServerIPOffset)
 	if err != nil {
-		return fmt.Errorf(common.SErrWrapWithStr, errAddingOffsetToIPNet, err)
+		return fmt.Errorf(phases.SErrWrapWithStr, errAddingOffsetToIPNet, err)
 	}
 
 	err = netx.DNSQuery(offIPNet.IP.String(), "google.com.")
 	if err != nil {
-		return fmt.Errorf(common.SErrWrapWithStr, errResolvingDNS, err)
+		return fmt.Errorf(phases.SErrWrapWithStr, errResolvingDNS, err)
 	}
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
-	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/phases"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/supported"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/vpn"
@@ -43,7 +43,7 @@ type Status struct {
 // Preflight is a phase tasked with ensuring cluster connectivity
 // and checking for violations in the updates made on the furyctl.yaml file.
 type PreFlight struct {
-	*common.PreFlight
+	*phases.PreFlight
 
 	stateStore   state.Storer
 	tfRunnerKube *terraform.Runner
@@ -93,7 +93,7 @@ func NewPreFlight(
 	}
 
 	return &PreFlight{
-		PreFlight: &common.PreFlight{
+		PreFlight: &phases.PreFlight{
 			OperationPhase: p,
 			FuryctlConf:    furyctlConf,
 			ConfigPath:     paths.ConfigPath,

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -65,10 +65,10 @@ type ClusterCreator struct {
 
 type Phases struct {
 	*create.PreFlight
+	*commcreate.Plugins
 	Infrastructure upgrade.OperatorPhaseAsync
 	Kubernetes     upgrade.OperatorPhaseAsync
 	Distribution   upgrade.ReducersOperatorPhaseAsync[reducers.Reducers]
-	*commcreate.Plugins
 }
 
 func (v *ClusterCreator) SetProperties(props []cluster.CreatorProperty) {

--- a/internal/apis/kfd/v1alpha2/ekscluster/delete/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/delete/distribution.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
-	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/phases"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/kubernetes"
@@ -32,7 +32,7 @@ type Ingress struct {
 }
 
 type Distribution struct {
-	*common.Distribution
+	*phases.Distribution
 
 	awsRunner   *awscli.Runner
 	shellRunner *shell.Runner
@@ -55,7 +55,7 @@ func NewDistribution(
 	)
 
 	return &Distribution{
-		Distribution: &common.Distribution{
+		Distribution: &phases.Distribution{
 			OperationPhase:                     phase,
 			DryRun:                             dryRun,
 			DistroPath:                         paths.DistroPath,

--- a/internal/apis/kfd/v1alpha2/ekscluster/delete/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/delete/infrastructure.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
-	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/phases"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/tool/terraform"
@@ -21,7 +21,7 @@ import (
 )
 
 type Infrastructure struct {
-	*common.Infrastructure
+	*phases.Infrastructure
 
 	tfRunner *terraform.Runner
 	dryRun   bool
@@ -40,7 +40,7 @@ func NewInfrastructure(
 	)
 
 	return &Infrastructure{
-		Infrastructure: &common.Infrastructure{
+		Infrastructure: &phases.Infrastructure{
 			OperationPhase: phase,
 			FuryctlConf:    furyctlConf,
 			ConfigPath:     paths.ConfigPath,

--- a/internal/apis/kfd/v1alpha2/ekscluster/delete/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/delete/kubernetes.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
-	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/phases"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/tool/awscli"
@@ -39,7 +39,7 @@ var (
 )
 
 type Kubernetes struct {
-	*common.Kubernetes
+	*phases.Kubernetes
 
 	tfRunner  *terraform.Runner
 	awsRunner *awscli.Runner
@@ -59,7 +59,7 @@ func NewKubernetes(
 	)
 
 	return &Kubernetes{
-		Kubernetes: &common.Kubernetes{
+		Kubernetes: &phases.Kubernetes{
 			OperationPhase:                     phase,
 			FuryctlConf:                        furyctlConf,
 			FuryctlConfPath:                    paths.ConfigPath,

--- a/internal/apis/kfd/v1alpha2/ekscluster/delete/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/delete/preflight.go
@@ -5,14 +5,13 @@
 package del
 
 import (
-	"errors"
 	"fmt"
 	"path"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
-	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/common"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/phases"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/vpn"
 	"github.com/sighupio/furyctl/internal/cluster"
@@ -24,10 +23,8 @@ import (
 	kubex "github.com/sighupio/furyctl/internal/x/kube"
 )
 
-var ErrClusterDoesNotExist = errors.New("cluster does not exist, nothing to delete")
-
 type PreFlight struct {
-	*common.PreFlight
+	*phases.PreFlight
 
 	tfRunnerKube *terraform.Runner
 	kubeRunner   *kubectl.Runner
@@ -66,7 +63,7 @@ func NewPreFlight(
 	}
 
 	return &PreFlight{
-		PreFlight: &common.PreFlight{
+		PreFlight: &phases.PreFlight{
 			OperationPhase: phase,
 			FuryctlConf:    furyctlConf,
 			ConfigPath:     paths.ConfigPath,

--- a/internal/apis/kfd/v1alpha2/ekscluster/phases/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/phases/distribution.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package common
+package phases
 
 import (
 	"encoding/json"

--- a/internal/apis/kfd/v1alpha2/ekscluster/phases/distribution_internal_test.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/phases/distribution_internal_test.go
@@ -4,7 +4,7 @@
 
 //go:build unit
 
-package common
+package phases
 
 import (
 	"os"

--- a/internal/apis/kfd/v1alpha2/ekscluster/phases/errors.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/phases/errors.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package common
+package phases
 
 import "errors"
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/phases/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/phases/infrastructure.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package common
+package phases
 
 import (
 	"fmt"

--- a/internal/apis/kfd/v1alpha2/ekscluster/phases/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/phases/kubernetes.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package common
+package phases
 
 import (
 	"encoding/json"

--- a/internal/apis/kfd/v1alpha2/ekscluster/phases/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/phases/preflight.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package common
+package phases
 
 import (
 	"errors"

--- a/internal/apis/kfd/v1alpha2/ekscluster/private/schema.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/private/schema.go
@@ -8,7 +8,7 @@
 // It is called "private" for historical reasons: besides the fields furyctl
 // reads from the user's furyctl.yaml, it also models the EKS-internal fields
 // that furyctl itself fills in by injecting infrastructure (Terraform/OpenTofu)
-// outputs before rendering templates — see common/distribution.go
+// outputs before rendering templates — see phases/distribution.go
 // (injectDataPreTf / InjectDataPostTf). Those values (IAM role ARNs, VPC id)
 // are never user input.
 //

--- a/internal/apis/kfd/v1alpha2/ekscluster/private/schema_test.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/private/schema_test.go
@@ -120,7 +120,7 @@ spec:
 func TestInjectMapUsesJSONTagKeys(t *testing.T) {
 	t.Parallel()
 
-	// Mirrors common.InjectType (kept local to avoid an import cycle).
+	// Mirrors phases.InjectType (kept local to avoid an import cycle).
 	type injectType struct {
 		Data private.SpecDistribution `json:"data"`
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.1.6"
+golangci-lint = "2.2.2"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"

--- a/pkg/dependencies/download.go
+++ b/pkg/dependencies/download.go
@@ -251,7 +251,6 @@ func (dd *Downloader) DownloadModules(kfd config.KFD, gitPrefix, kind string) er
 
 				if err := dd.client.Download(src, dst); err != nil {
 					errs = append(errs, fmt.Errorf("%w '%s': %v", dist.ErrDownloadingFolder, src, err))
-
 					if _, err := os.Stat(dst); err == nil {
 						if err := os.RemoveAll(dst); err != nil {
 							logrus.Warningf("Error while cleaning up folder after failing download: %v", err)

--- a/pkg/diffs/checker.go
+++ b/pkg/diffs/checker.go
@@ -224,7 +224,6 @@ func childPath(parent []string, key string) []string {
 	child := make([]string, 0, len(parent)+1)
 	child = append(child, parent...)
 	child = append(child, key)
-
 	return child
 }
 


### PR DESCRIPTION
### Summary 💡

Depends on #707
Update golangci-lint to 2.2.2


### Description 📝

Update golangci-lint to 2.2.2 + code alignments to new linters.
We can't enable the linting in CI until golanci-lint v2.4.0 due to golang v1.25.
The refactoring work isn't complete, but it's not easy to make all the fixes without being able to run the check command. Everything will be handled with version 2.4.0.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

