### PR TITLE
chore: update golangci-lint to 2.3.1

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -41,6 +41,9 @@ linters:
       comparison: true
     exhaustive:
       default-signifies-exhaustive: true
+      check:
+        - switch
+        - map
     funlen:
       lines: 400
       statements: 182

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -22,6 +22,7 @@ var (
 	ErrZshCompletion        = errors.New("error generating zsh completion")
 	ErrFishCompletion       = errors.New("error generating fish completion")
 	ErrPowershellCompletion = errors.New("error generating powershell completion")
+	ErrUnsupportedShell     = errors.New("unsupported shell")
 )
 
 func NewCompletionCmd(rootCmd *cobra.Command) *cobra.Command {
@@ -114,6 +115,9 @@ PowerShell:
 
 					return fmt.Errorf("error generating powershell completion: %w", err)
 				}
+
+			default:
+				return fmt.Errorf("%w: %s", ErrUnsupportedShell, args[0])
 			}
 
 			cmdEvent.AddSuccessMessage("completion generated for " + args[0])

--- a/cmd/create/pki.go
+++ b/cmd/create/pki.go
@@ -45,24 +45,6 @@ func NewPki(etcd, controlplane bool, pkiPath string) error {
 	data.CertConfig = certConfig
 
 	switch {
-	default:
-		logrus.Debug("creating PKI for etcd and Kubernetes control plane")
-
-		etcd := clusterpki.Etcd{ClusterPKI: data}
-		cp := clusterpki.ControlPlanePKI{ClusterPKI: data}
-
-		err = etcd.Create()
-		if err != nil {
-			msg = fmt.Errorf("got error while creating etcd PKI: %w", err)
-		}
-
-		err = cp.Create()
-		if err != nil {
-			msg = fmt.Errorf("got error while creating control plane PKI: %w", err)
-		}
-
-		return msg
-
 	case etcd:
 		logrus.Debug("creating PKI for etcd")
 
@@ -83,6 +65,24 @@ func NewPki(etcd, controlplane bool, pkiPath string) error {
 		err := cp.Create()
 		if err != nil {
 			msg = fmt.Errorf("creating PKI for etcd failed: %w", err)
+		}
+
+		return msg
+
+	default:
+		logrus.Debug("creating PKI for etcd and Kubernetes control plane")
+
+		etcd := clusterpki.Etcd{ClusterPKI: data}
+		cp := clusterpki.ControlPlanePKI{ClusterPKI: data}
+
+		err = etcd.Create()
+		if err != nil {
+			msg = fmt.Errorf("got error while creating etcd PKI: %w", err)
+		}
+
+		err = cp.Create()
+		if err != nil {
+			msg = fmt.Errorf("got error while creating control plane PKI: %w", err)
 		}
 
 		return msg

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -164,6 +164,9 @@ func (v *ClusterCreator) SetProperty(name string, value any) {
 		if s, ok := value.([]string); ok {
 			v.postApplyPhases = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 
@@ -278,6 +281,9 @@ func (v *ClusterCreator) Create(startFrom string, timeout, _ int) error {
 			})
 
 			stopWg.Wait()
+
+		default:
+			logrus.Debugf("no phase to stop: %q", v.phase)
 		}
 
 		return ErrTimeout
@@ -750,6 +756,9 @@ func (v *ClusterCreator) extraPhases(phases *Phases, upgradeState *upgrade.State
 					return fmt.Errorf("error while executing plugins phase: %w", err)
 				}
 			}
+
+		default:
+			logrus.Debugf("ignoring unknown post-apply phase %q", phase)
 		}
 	}
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/deleter.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/deleter.go
@@ -87,6 +87,9 @@ func (d *ClusterDeleter) SetProperty(name string, value any) {
 		if b, ok := value.(bool); ok {
 			d.dryRun = b
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/kubeconfig_getter.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/kubeconfig_getter.go
@@ -47,6 +47,9 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 		if s, ok := value.(string); ok {
 			k.workDir = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/kfddistribution/creator.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/creator.go
@@ -133,6 +133,9 @@ func (c *ClusterCreator) SetProperty(name string, value any) {
 		if s, ok := value.([]string); ok {
 			c.postApplyPhases = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", name)
 	}
 }
 
@@ -441,6 +444,9 @@ func (c *ClusterCreator) extraPhases(
 					return fmt.Errorf("error while executing plugins phase: %w", err)
 				}
 			}
+
+		default:
+			logrus.Debugf("ignoring unknown post-apply phase %q", phase)
 		}
 	}
 

--- a/internal/apis/kfd/v1alpha2/kfddistribution/deleter.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/deleter.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/sighupio/furyctl/internal/apis/config"
 	del "github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/kfddistribution/delete"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/kfddistribution/public"
@@ -71,6 +73,9 @@ func (d *ClusterDeleter) SetProperty(name string, value any) {
 		if b, ok := value.(bool); ok {
 			d.dryRun = b
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/kfddistribution/kubeconfig_getter.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/kubeconfig_getter.go
@@ -59,6 +59,9 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 		if s, ok := value.(config.KFD); ok {
 			k.kfdManifest = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/onpremises/certificates_renewer.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/certificates_renewer.go
@@ -65,6 +65,9 @@ func (k *CertificatesRenewer) SetProperty(name string, value any) {
 		if s, ok := value.(string); ok {
 			k.binPath = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/onpremises/creator.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/creator.go
@@ -147,6 +147,9 @@ func (c *ClusterCreator) SetProperty(name string, value any) {
 		if s, ok := value.([]string); ok {
 			c.postApplyPhases = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", name)
 	}
 }
 
@@ -560,6 +563,9 @@ func (c *ClusterCreator) extraPhases(
 					return fmt.Errorf("error while executing plugins phase: %w", err)
 				}
 			}
+
+		default:
+			logrus.Debugf("ignoring unknown post-apply phase %q", phase)
 		}
 	}
 

--- a/internal/apis/kfd/v1alpha2/onpremises/deleter.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/deleter.go
@@ -71,6 +71,9 @@ func (d *ClusterDeleter) SetProperty(name string, value any) {
 		if b, ok := value.(bool); ok {
 			d.dryRun = b
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", name)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/onpremises/kubeconfig_getter.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/kubeconfig_getter.go
@@ -72,6 +72,9 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 		if s, ok := value.(string); ok {
 			k.binPath = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/distribution/features.go
+++ b/internal/distribution/features.go
@@ -51,9 +51,10 @@ func HasFeature(kfd config.KFD, name Feature) bool {
 
 	case FeatureOpenTofuSupport:
 		return hasFeatureOpenTofuSupport(kfd)
-	}
 
-	return false
+	default:
+		return false
+	}
 }
 
 func hasFeatureClusterUpgrade(kfd config.KFD) bool {

--- a/internal/flags/validator.go
+++ b/internal/flags/validator.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Static error definitions for linting compliance.
@@ -196,6 +198,9 @@ func (v *Validator) validateFlagValue(flagName string, value any, flagInfo FlagI
 		// No validation needed - most types can be converted to string/duration.
 		// This is intentionally permissive for these types.
 		_ = value // No-op to satisfy WSL linter.
+
+	default:
+		logrus.Debugf("flag %q has unknown type %v; skipping basic type validation", flagName, flagInfo.Type)
 	}
 
 	// Specific flag validations.
@@ -216,6 +221,7 @@ func (*Validator) validateSpecificFlag(flagName string, value any) error {
 
 			return fmt.Errorf("%w: got '%s', must be one of: %s", ErrInvalidProtocol, str, strings.Join(validProtocols, ", "))
 		}
+		return nil
 
 	case "phase":
 		if str, ok := value.(string); ok && str != "" {
@@ -224,6 +230,7 @@ func (*Validator) validateSpecificFlag(flagName string, value any) error {
 			// For now, accept any non-empty string.
 			_ = str // Prevent unused variable warning.
 		}
+		return nil
 
 	case "force":
 		if slice, ok := value.([]any); ok {
@@ -238,6 +245,7 @@ func (*Validator) validateSpecificFlag(flagName string, value any) error {
 				}
 			}
 		}
+		return nil
 
 	case "timeout", "podRunningCheckTimeout":
 		if val, ok := value.(int); ok {
@@ -245,9 +253,12 @@ func (*Validator) validateSpecificFlag(flagName string, value any) error {
 				return fmt.Errorf("%w: %s must be greater than 0, got %v", ErrMustBePositiveInteger, flagName, val)
 			}
 		}
-	}
+		return nil
 
-	return nil
+	default:
+		logrus.Debugf("flag %q has no specific validation rule", flagName)
+		return nil
+	}
 }
 
 // validateFlagCombinations validates combinations of flags that might be incompatible.

--- a/internal/git/protocols.go
+++ b/internal/git/protocols.go
@@ -21,13 +21,14 @@ func NewProtocol(protocol string) (Protocol, error) {
 
 	case "https":
 		return ProtocolHTTPS, nil
-	}
 
-	return "", fmt.Errorf("%w: %s. Supported protocols are %s",
-		ErrUnsupportedGitProtocol,
-		protocol,
-		strings.Join(ProtocolsS(), ", "),
-	)
+	default:
+		return "", fmt.Errorf("%w: %s. Supported protocols are %s",
+			ErrUnsupportedGitProtocol,
+			protocol,
+			strings.Join(ProtocolsS(), ", "),
+		)
+	}
 }
 
 const (

--- a/internal/parser/terraform.go
+++ b/internal/parser/terraform.go
@@ -4,7 +4,11 @@
 
 package parser
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
 
 const MinDiffLineTokensNum = 3
 
@@ -65,6 +69,9 @@ func (p *TfPlanParser) Parse() *TfPlan {
 		case "+/-":
 			pl.Add = append(pl.Add, resourceName)
 			pl.Destroy = append(pl.Destroy, resourceName)
+
+		default:
+			logrus.Debugf("ignoring unknown diff prefix %q", diffLineTokens[0])
 		}
 	}
 

--- a/internal/x/exec/executor.go
+++ b/internal/x/exec/executor.go
@@ -21,6 +21,7 @@ func NewStdExecutor() *StdExecutor {
 }
 
 func (*StdExecutor) Command(name string, arg ...string) *exec.Cmd {
+	//nolint:noctx // it requires a massive refactor
 	return exec.Command(name, arg...)
 }
 
@@ -42,5 +43,6 @@ func (fe *FakeExecutor) Command(name string, arg ...string) *exec.Cmd {
 	cs := []string{"-test.run=" + fe.testHelperProcessFn, "--", filepath.Base(name)}
 	cs = append(cs, arg...)
 
+	//nolint:noctx // it requires a massive refactor
 	return exec.Command(os.Args[0], cs...)
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.2.2"
+golangci-lint = "2.3.1"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"

--- a/pkg/rulesextractor/onpremises.go
+++ b/pkg/rulesextractor/onpremises.go
@@ -16,6 +16,7 @@ import (
 
 type OnPremExtractor struct {
 	*BaseExtractor
+
 	Spec Spec
 }
 

--- a/pkg/template/node.go
+++ b/pkg/template/node.go
@@ -39,6 +39,7 @@ func (f *Node) FromNodeList(nodes []parse.Node) []string {
 
 func mapToAliasInterface(n parse.Node) any {
 	// MapParseNodeToAlias is a map of parse.Node to its alias.
+	//exhaustive:ignore
 	mapParseNodeToAlias := map[parse.NodeType]any{
 		parse.NodeList:     &ListNode{},
 		parse.NodeRange:    &RangeNode{},

--- a/test/expensive/ekscluster/furyctl_test.go
+++ b/test/expensive/ekscluster/furyctl_test.go
@@ -7,6 +7,7 @@
 package ekscluster_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,7 +49,7 @@ var (
 		CreateFuryctlYaml(state, furyctlYamlTemplate, nil)
 	}
 
-	CreateClusterTest = func(state *ContextState) {
+	CreateClusterTest = func(ctx context.Context, state *ContextState) {
 		dlRes := DownloadFuryDistribution(state.TestDir, state.FuryctlYaml)
 
 		tfPlanPath := path.Join(
@@ -69,6 +70,7 @@ var (
 		)
 
 		createClusterCmd := furyctlCreator.Create(
+			ctx,
 			cluster.OperationPhaseAll,
 			"",
 		)
@@ -82,7 +84,7 @@ var (
 		Eventually(session, assertTimeout, assertPollingInterval).Should(gexec.Exit(0))
 
 		kubectlPath := DownloadKubectl(dlRes.DistroManifest.Tools.Common.Kubectl.Version)
-		kubeCmd := exec.Command(kubectlPath, "--kubeconfig", state.Kubeconfig, "get", "nodes")
+		kubeCmd := exec.CommandContext(ctx, kubectlPath, "--kubeconfig", state.Kubeconfig, "get", "nodes")
 
 		kubeSession, err := gexec.Start(kubeCmd, GinkgoWriter, GinkgoWriter)
 
@@ -90,7 +92,7 @@ var (
 		Eventually(kubeSession, assertTimeout, assertPollingInterval).Should(gexec.Exit(0))
 	}
 
-	DeleteClusterTest = func(state *ContextState, ephemeral bool) {
+	DeleteClusterTest = func(ctx context.Context, state *ContextState, ephemeral bool) {
 		DeferCleanup(func() {
 			_ = os.RemoveAll(state.TestDir)
 		})
@@ -107,6 +109,7 @@ var (
 		)
 
 		deleteClusterCmd := furyctlDeleter.Delete(
+			ctx,
 			cluster.OperationPhaseAll,
 		)
 
@@ -129,12 +132,12 @@ var (
 			contextTitle := fmt.Sprintf("v%s create and delete a minimal public cluster", version)
 
 			Context(contextTitle, Label("slow"), func() {
-				It(fmt.Sprintf("should create and delete a minimal public %s cluster", version), func(s *ContextState) func() {
-					return func() {
+				It(fmt.Sprintf("should create and delete a minimal public %s cluster", version), func(s *ContextState) func(SpecContext) {
+					return func(ctx SpecContext) {
 						PrepareCreateDeleteClusterTest(state, version, "furyctl-public-minimal.yaml.tpl")
 
-						CreateClusterTest(s)
-						DeleteClusterTest(s, ephemeral)
+						CreateClusterTest(ctx, s)
+						DeleteClusterTest(ctx, s, ephemeral)
 					}
 				}(state))
 			})

--- a/test/expensive/kfddistribution/furyctl_test.go
+++ b/test/expensive/kfddistribution/furyctl_test.go
@@ -91,8 +91,8 @@ var (
 		}
 	}
 
-	CreateClusterTestFunc = func(state *distroContextState, phase string) func() {
-		return func() {
+	CreateClusterTestFunc = func(state *distroContextState, phase string) func(SpecContext) {
+		return func(ctx SpecContext) {
 			dlRes := DownloadFuryDistribution(state.TestDir, state.FuryctlYaml)
 
 			kubectlPath := DownloadKubectl(dlRes.DistroManifest.Tools.Common.Kubectl.Version)
@@ -107,6 +107,7 @@ var (
 			)
 
 			createClusterCmd := furyctlCreator.Create(
+				ctx,
 				phase,
 				"",
 			)
@@ -118,7 +119,7 @@ var (
 			Eventually(state.Kubeconfig, assertTimeout, assertPollingInterval).Should(BeAnExistingFile())
 			Eventually(session, assertTimeout, assertPollingInterval).Should(gexec.Exit(0))
 
-			kubeCmd := exec.Command(kubectlPath, "--kubeconfig", state.Kubeconfig, "get", "nodes")
+			kubeCmd := exec.CommandContext(ctx, kubectlPath, "--kubeconfig", state.Kubeconfig, "get", "nodes")
 
 			kubeSession, err := gexec.Start(kubeCmd, GinkgoWriter, GinkgoWriter)
 
@@ -135,8 +136,8 @@ var (
 		}
 	}
 
-	DeleteClusterTestFunc = func(state *distroContextState, phase string, ephemeral bool) func() {
-		return func() {
+	DeleteClusterTestFunc = func(state *distroContextState, phase string, ephemeral bool) func(SpecContext) {
+		return func(ctx SpecContext) {
 			if ephemeral {
 				_ = os.RemoveAll(path.Join(state.TestDir, ".furyctl"))
 			}
@@ -149,6 +150,7 @@ var (
 			)
 
 			deleteClusterCmd := furyctlDeleter.Delete(
+				ctx,
 				phase,
 			)
 

--- a/test/expensive/onpremises/furyctl_test.go
+++ b/test/expensive/onpremises/furyctl_test.go
@@ -365,8 +365,8 @@ var (
 		return nil
 	}
 
-	BeforeCreateDeleteTestFunc = func(state *onPremContextState, version string) func() {
-		return func() {
+	BeforeCreateDeleteTestFunc = func(state *onPremContextState, version string) func(SpecContext) {
+		return func(ctx SpecContext) {
 			testName := fmt.Sprintf("onpremises-v%s-create-and-delete", version)
 
 			ctxState := NewContextState(testName)
@@ -424,18 +424,18 @@ var (
 			err = ChmodSSHKey(secretsDir)
 			Expect(err).To(Not(HaveOccurred()))
 
-			openVPNSession := Must1(ConnectOpenVPN(certPath))
+			openVPNSession := Must1(ConnectOpenVPN(ctx, certPath))
 			Eventually(openVPNSession, assertTimeout, assertPollingInterval).Should(gexec.Exit(0))
 		}
 	}
 
-	AfterCreateDeleteTestFunc = func(state *onPremContextState) func() {
-		return func() {
+	AfterCreateDeleteTestFunc = func(state *onPremContextState) func(SpecContext) {
+		return func(ctx SpecContext) {
 			infraDir := path.Join(state.TestDir, "infra")
 
 			Must0(DestroyInfra(state.TerraformBinPath, infraDir))
 
-			pkillSession := Must1(KillOpenVPN())
+			pkillSession := Must1(KillOpenVPN(ctx))
 
 			Eventually(pkillSession, 5*time.Minute, 1*time.Second).Should(gexec.Exit(0))
 
@@ -447,8 +447,8 @@ var (
 		}
 	}
 
-	CreateClusterTestFunc = func(state *onPremContextState) func() {
-		return func() {
+	CreateClusterTestFunc = func(state *onPremContextState) func(SpecContext) {
+		return func(ctx SpecContext) {
 			dlRes := DownloadFuryDistribution(state.TestDir, state.FuryctlYaml)
 
 			kubectlPath := DownloadKubectl(dlRes.DistroManifest.Tools.Common.Kubectl.Version)
@@ -463,6 +463,7 @@ var (
 			)
 
 			createClusterCmd := furyctlCreator.Create(
+				ctx,
 				cluster.OperationPhaseAll,
 				"",
 			)
@@ -474,7 +475,7 @@ var (
 			Eventually(state.Kubeconfig, assertTimeout, assertPollingInterval).Should(BeAnExistingFile())
 			Eventually(session, assertTimeout, assertPollingInterval).Should(gexec.Exit(0))
 
-			kubeCmd := exec.Command(kubectlPath, "--kubeconfig", state.Kubeconfig, "get", "nodes")
+			kubeCmd := exec.CommandContext(ctx, kubectlPath, "--kubeconfig", state.Kubeconfig, "get", "nodes")
 
 			kubeSession, err := gexec.Start(kubeCmd, GinkgoWriter, GinkgoWriter)
 
@@ -483,8 +484,8 @@ var (
 		}
 	}
 
-	CreateClusterPhaseKubernetesTestFunc = func(state *onPremContextState) func() {
-		return func() {
+	CreateClusterPhaseKubernetesTestFunc = func(state *onPremContextState) func(SpecContext) {
+		return func(ctx SpecContext) {
 			GinkgoWriter.Write([]byte(fmt.Sprintf("Furyctl config path: %s", state.FuryctlYaml)))
 
 			furyctlCreator := NewFuryctlCreator(
@@ -495,6 +496,7 @@ var (
 			)
 
 			createClusterCmd := furyctlCreator.Create(
+				ctx,
 				cluster.OperationPhaseKubernetes,
 				"",
 			)
@@ -508,8 +510,8 @@ var (
 		}
 	}
 
-	CreateClusterPhaseDistributionTestFunc = func(state *onPremContextState) func() {
-		return func() {
+	CreateClusterPhaseDistributionTestFunc = func(state *onPremContextState) func(SpecContext) {
+		return func(ctx SpecContext) {
 			dlRes := DownloadFuryDistribution(state.TestDir, state.FuryctlYaml)
 
 			kubectlPath := DownloadKubectl(dlRes.DistroManifest.Tools.Common.Kubectl.Version)
@@ -524,6 +526,7 @@ var (
 			)
 
 			createClusterCmd := furyctlCreator.Create(
+				ctx,
 				cluster.OperationPhaseDistribution,
 				"",
 			)
@@ -532,7 +535,7 @@ var (
 
 			Consistently(session, 1*time.Minute).ShouldNot(gexec.Exit())
 
-			kubeCmd := exec.Command(kubectlPath, "--kubeconfig", state.Kubeconfig, "get", "nodes")
+			kubeCmd := exec.CommandContext(ctx, kubectlPath, "--kubeconfig", state.Kubeconfig, "get", "nodes")
 
 			kubeSession, err := gexec.Start(kubeCmd, GinkgoWriter, GinkgoWriter)
 
@@ -541,8 +544,8 @@ var (
 		}
 	}
 
-	DeleteClusterTestFunc = func(state *onPremContextState, phase string, ephemeral bool) func() {
-		return func() {
+	DeleteClusterTestFunc = func(state *onPremContextState, phase string, ephemeral bool) func(SpecContext) {
+		return func(ctx SpecContext) {
 			if ephemeral {
 				_ = os.RemoveAll(path.Join(state.TestDir, ".furyctl"))
 			}
@@ -555,6 +558,7 @@ var (
 			)
 
 			deleteClusterCmd := furyctlDeleter.Delete(
+				ctx,
 				phase,
 			)
 

--- a/test/utils/testutils.go
+++ b/test/utils/testutils.go
@@ -6,6 +6,7 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -134,9 +135,9 @@ func Copy(src, dst string) {
 	Must0(os.WriteFile(dst, input, iox.RWPermAccess))
 }
 
-func CompileFuryctl(outputPath string) func() {
-	return func() {
-		cmd := exec.Command("go", "build", "-o", outputPath, "../../../main.go")
+func CompileFuryctl(outputPath string) func(SpecContext) {
+	return func(ctx SpecContext) {
+		cmd := exec.CommandContext(ctx, "go", "build", "-o", outputPath, "../../../main.go")
 
 		session := Must1(gexec.Start(cmd, GinkgoWriter, GinkgoWriter))
 
@@ -217,7 +218,7 @@ func LoadFuryCtl(furyctlYamlPath string) Conf {
 	return Must1(yamlx.FromFileV3[Conf](furyctlYamlPath))
 }
 
-func ConnectOpenVPN(certPath string) (*gexec.Session, error) {
+func ConnectOpenVPN(ctx context.Context, certPath string) (*gexec.Session, error) {
 	var cmd *exec.Cmd
 
 	isRoot, err := osx.IsRoot()
@@ -226,9 +227,9 @@ func ConnectOpenVPN(certPath string) (*gexec.Session, error) {
 	}
 
 	if isRoot {
-		cmd = exec.Command("openvpn", "--config", certPath, "--daemon")
+		cmd = exec.CommandContext(ctx, "openvpn", "--config", certPath, "--daemon")
 	} else {
-		cmd = exec.Command("sudo", "openvpn", "--config", certPath, "--daemon")
+		cmd = exec.CommandContext(ctx, "sudo", "openvpn", "--config", certPath, "--daemon")
 	}
 
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
@@ -239,7 +240,7 @@ func ConnectOpenVPN(certPath string) (*gexec.Session, error) {
 	return session, nil
 }
 
-func KillOpenVPN() (*gexec.Session, error) {
+func KillOpenVPN(ctx context.Context) (*gexec.Session, error) {
 	var cmd *exec.Cmd
 
 	isRoot, err := osx.IsRoot()
@@ -248,9 +249,9 @@ func KillOpenVPN() (*gexec.Session, error) {
 	}
 
 	if isRoot {
-		cmd = exec.Command("pkill", "openvpn")
+		cmd = exec.CommandContext(ctx, "pkill", "openvpn")
 	} else {
-		cmd = exec.Command("sudo", "pkill", "openvpn")
+		cmd = exec.CommandContext(ctx, "sudo", "pkill", "openvpn")
 	}
 
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
@@ -270,7 +271,7 @@ func NewFuryctlCreator(furyctl, configPath, testDir string, dryRun bool) *Furyct
 	}
 }
 
-func (f *FuryctlCreator) Create(phase, startFrom string) *exec.Cmd {
+func (f *FuryctlCreator) Create(ctx context.Context, phase, startFrom string) *exec.Cmd {
 	args := []string{
 		"create",
 		"cluster",
@@ -303,7 +304,7 @@ func (f *FuryctlCreator) Create(phase, startFrom string) *exec.Cmd {
 		args = append(args, "--dry-run")
 	}
 
-	return exec.Command(f.furyctl, args...)
+	return exec.CommandContext(ctx, f.furyctl, args...)
 }
 
 func NewFuryctlDeleter(
@@ -320,7 +321,7 @@ func NewFuryctlDeleter(
 	}
 }
 
-func (f *FuryctlDeleter) Delete(phase string) *exec.Cmd {
+func (f *FuryctlDeleter) Delete(ctx context.Context, phase string) *exec.Cmd {
 	args := []string{
 		"delete",
 		"cluster",
@@ -343,5 +344,5 @@ func (f *FuryctlDeleter) Delete(phase string) *exec.Cmd {
 		args = append(args, "--dry-run")
 	}
 
-	return exec.Command(f.furyctl, args...)
+	return exec.CommandContext(ctx, f.furyctl, args...)
 }


### PR DESCRIPTION
### Summary 💡

Depends on #708
Update golangci-lint to 2.3.1


### Description 📝

Update golangci-lint to 2.3.1 + code alignments to new linters.
We can't enable the linting in CI until golanci-lint v2.4.0 due to golang v1.25.
The refactoring work isn't complete, but it's not easy to make all the fixes without being able to run the check command. Everything will be handled with version 2.4.0.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

