### PR TITLE
feat(immutable): dump template support

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -5,6 +5,7 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 ## New features 🌟
 
 - [[#696](https://github.com/sighupio/furyctl/pull/696)] Immutable: show a dynamic table for the nodes provisioning phase instead of single line logs so the user does not need to mentally track the status of the nodes.
+- [[#710](https://github.com/sighupio/furyctl/pull/710)] Immutable: add support for `furyctl dump template` command.
 
 ## Bug fixes 🐞
 
@@ -14,3 +15,4 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 ## Breaking Changes 💔
 
 TBD
+

--- a/internal/distribution/iac.go
+++ b/internal/distribution/iac.go
@@ -184,6 +184,9 @@ func (m *IACBuilder) defaultsFile() (map[any]any, error) {
 	case "OnPremises":
 		defaultsFileName = "onpremises-kfd-v1alpha2.yaml"
 
+	case "Immutable":
+		defaultsFileName = "immutable-kfd-v1alpha2.yaml"
+
 	default:
 		return nil, ErrInvalidKind
 	}


### PR DESCRIPTION
### Summary 💡

Add support for Immutable in the dump template command

### Description 📝

Running `furyctl dump template` with a configuration file for an Immutable kind cluster resulted in the following error:

```
$ furyctl dump template
INFO Downloading distribution...
INFO Validating configuration file...
INFO Rendering distribution manifests...
ERRO error while generating distribution manifests: error getting defaults file: invalid kind
```

This PR adds makes the command work.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] furyctl dump template now works for immutable kind too

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

