### PR TITLE
chore: update golangci-lint to 2.4.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -71,23 +71,23 @@ steps:
       - name: mise-cache
         path: /mise-data
 
-  #- name: lint
-  #  image: quay.io/sighup/mise:v2025.4.4
-  #  pull: always
-  #  depends_on:
-  #    - prepare
-  #  commands:
-  #    - eval "$(mise activate bash --shims)"
-  #    - mise run lint
-  #  environment:
-  #    MISE_DATA_DIR: /mise-data
-  #    CGO_ENABLED: 0
-  #    GOCACHE: /drone/src/.go/cache
-  #    GOMODCACHE: /drone/src/.go/modcache
-  #    GOTMPDIR: /drone/src/.go/tmp
-  #  volumes:
-  #    - name: mise-cache
-  #      path: /mise-data
+  - name: lint
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    depends_on:
+      - prepare
+    commands:
+      - eval "$(mise activate bash --shims)"
+      - mise run lint
+    environment:
+      MISE_DATA_DIR: /mise-data
+      CGO_ENABLED: 0
+      GOCACHE: /drone/src/.go/cache
+      GOMODCACHE: /drone/src/.go/modcache
+      GOTMPDIR: /drone/src/.go/tmp
+    volumes:
+      - name: mise-cache
+        path: /mise-data
 
   - name: test-unit
     image: quay.io/sighup/mise:v2025.4.4
@@ -196,7 +196,7 @@ steps:
     image: quay.io/sighup/mise:v2025.4.4
     pull: always
     depends_on:
-      #- lint
+      - lint
       - test-unit
       - test-integration
       - test-flags
@@ -228,7 +228,7 @@ steps:
     image: quay.io/sighup/fury-release-notes-plugin:3.12_2.10.0
     pull: always
     depends_on:
-      #- lint
+      - lint
       - test-unit
       - test-integration
       - test-flags

--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -5,7 +5,7 @@
 version: "2"
 run:
   concurrency: 2
-  go: 1.24.13
+  go: 1.25.12
   modules-download-mode: readonly
 
 linters:
@@ -16,12 +16,14 @@ linters:
     - forbidigo
     - ireturn
     - maintidx
+    - nlreturn # too strict and mostly code is not more readable
     - noinlineerr
     - rowserrcheck
     - sqlclosecheck
     - varnamelen
     - wastedassign
     - wsl # deprecated, replaced by wsl_v5 since golangci-lint v2.2.0
+    - wsl_v5 # too strict and mostly code is not more readable
   settings:
     cyclop:
       max-complexity: 80
@@ -393,9 +395,6 @@ linters:
         - const C
         - T any
         - m map[string]int
-    wsl_v5:
-      allow-whole-block: true
-      default: all
   exclusions:
     generated: disable
     presets:

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -49,6 +49,7 @@ type ClusterSkipsCmdFlags struct {
 type ClusterCmdFlags struct {
 	ClusterSkipsCmdFlags
 	Timeouts
+
 	Debug                 bool
 	FuryctlPath           string
 	DistroLocation        string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,18 +40,14 @@ type rootConfig struct {
 
 type RootCommand struct {
 	*cobra.Command
+
 	config *rootConfig
 }
 
-var (
-	ErrInvalidPath    = errors.New("invalid path")
-	ErrUnexpandedPath = errors.New("cannot create log file with unexpanded dynamic values in path")
-)
+var ErrUnexpandedPath = errors.New("cannot create log file with unexpanded dynamic values in path")
 
 const (
-	timeout      = 100 * time.Millisecond
-	logRndCeil   = 100000
-	spinnerStyle = 11
+	logRndCeil = 100000
 )
 
 func NewRootCmd() *RootCommand {

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -22,6 +22,7 @@ import (
 // loggingResponseWriter wraps http.ResponseWriter to capture status code and bytes written.
 type loggingResponseWriter struct {
 	http.ResponseWriter
+
 	status int
 	bytes  int
 }

--- a/internal/analytics/event.go
+++ b/internal/analytics/event.go
@@ -86,6 +86,7 @@ type StopEvent struct {
 
 type CommandEvent struct {
 	properties
+
 	name string
 }
 

--- a/internal/analytics/tracker.go
+++ b/internal/analytics/tracker.go
@@ -21,6 +21,7 @@ const isNext = true
 
 type Tracker struct {
 	trackingInfo
+
 	client mixpanel.Mixpanel
 	events chan Event
 	enable bool

--- a/internal/apis/kfd/v1alpha2/common/create/preupgrade.go
+++ b/internal/apis/kfd/v1alpha2/common/create/preupgrade.go
@@ -38,6 +38,7 @@ var (
 
 type PreUpgrade struct {
 	*cluster.OperationPhase
+
 	dryRun               bool
 	kind                 string
 	upgrade              *upgrade.Upgrade

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/distribution.go
@@ -188,7 +188,7 @@ func (d *Distribution) SetUpgrade(upgradeEnabled bool) {
 }
 
 func (d *Distribution) Stop() error {
-	return cluster.StopAll(
+	if err := cluster.StopAll(
 		func() error {
 			logrus.Debug("Stopping terraform...")
 
@@ -216,7 +216,11 @@ func (d *Distribution) Stop() error {
 
 			return nil
 		},
-	)
+	); err != nil {
+		return fmt.Errorf("error stopping distribution: %w", err)
+	}
+
+	return nil
 }
 
 func (d *Distribution) preDistribution(

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/kubernetes.go
@@ -147,7 +147,7 @@ func (k *Kubernetes) SetUpgrade(upgradeEnabled bool) {
 }
 
 func (k *Kubernetes) Stop() error {
-	return cluster.StopAll(
+	if err := cluster.StopAll(
 		func() error {
 			logrus.Debug("Stopping terraform...")
 
@@ -166,7 +166,11 @@ func (k *Kubernetes) Stop() error {
 
 			return nil
 		},
-	)
+	); err != nil {
+		return fmt.Errorf("error stopping kubernetes: %w", err)
+	}
+
+	return nil
 }
 
 func (k *Kubernetes) preKubernetes(

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -66,6 +66,7 @@ type ClusterCreator struct {
 type Phases struct {
 	*create.PreFlight
 	*commcreate.Plugins
+
 	Infrastructure upgrade.OperatorPhaseAsync
 	Kubernetes     upgrade.OperatorPhaseAsync
 	Distribution   upgrade.ReducersOperatorPhaseAsync[reducers.Reducers]

--- a/internal/apis/kfd/v1alpha2/immutable/certificates_renewer.go
+++ b/internal/apis/kfd/v1alpha2/immutable/certificates_renewer.go
@@ -22,6 +22,7 @@ import (
 
 type CertificatesRenewer struct {
 	*cluster.OperationPhase
+
 	furyctlConf public.ImmutableKfdV1Alpha2
 	kfdManifest config.KFD
 	distroPath  string
@@ -38,7 +39,9 @@ func (c *CertificatesRenewer) SetProperties(props []cluster.CertificatesRenewerP
 }
 
 func (c *CertificatesRenewer) SetProperty(name string, value any) {
-	switch strings.ToLower(name) {
+	lcName := strings.ToLower(name)
+
+	switch lcName {
 	case cluster.CertificatesRenewerPropertyFuryctlConf:
 		if s, ok := value.(public.ImmutableKfdV1Alpha2); ok {
 			c.furyctlConf = s
@@ -63,6 +66,9 @@ func (c *CertificatesRenewer) SetProperty(name string, value any) {
 		if s, ok := value.(string); ok {
 			c.binPath = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
@@ -25,6 +25,7 @@ import (
 // Infrastructure wraps the common infrastructure phase.
 type Infrastructure struct {
 	*cluster.OperationPhase
+
 	paths         cluster.CreatorPaths
 	upgrade       *upgrade.Upgrade
 	upgradeNode   string

--- a/internal/apis/kfd/v1alpha2/immutable/creator.go
+++ b/internal/apis/kfd/v1alpha2/immutable/creator.go
@@ -76,7 +76,9 @@ func (c *ClusterCreator) SetProperties(props []cluster.CreatorProperty) {
 }
 
 func (c *ClusterCreator) SetProperty(name string, value any) {
-	switch strings.ToLower(name) {
+	lcName := strings.ToLower(name)
+
+	switch lcName {
 	case cluster.CreatorPropertyConfigPath:
 		if s, ok := value.(string); ok {
 			c.paths.ConfigPath = s
@@ -146,6 +148,9 @@ func (c *ClusterCreator) SetProperty(name string, value any) {
 		if s, ok := value.([]string); ok {
 			c.postApplyPhases = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 
@@ -648,6 +653,9 @@ func (c *ClusterCreator) extraPhases(
 					return fmt.Errorf("error while executing plugins phase: %w", err)
 				}
 			}
+
+		default:
+			logrus.Debugf("ignoring unknown post-apply phase %q", phase)
 		}
 	}
 

--- a/internal/apis/kfd/v1alpha2/immutable/deleter.go
+++ b/internal/apis/kfd/v1alpha2/immutable/deleter.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/sighupio/furyctl/internal/apis/config"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable/public"
 	"github.com/sighupio/furyctl/internal/cluster"
@@ -28,7 +30,9 @@ func (c *ClusterDeleter) SetProperties(props []cluster.DeleterProperty) {
 }
 
 func (c *ClusterDeleter) SetProperty(name string, value any) {
-	switch strings.ToLower(name) {
+	lcName := strings.ToLower(name)
+
+	switch lcName {
 	case cluster.DeleterPropertyConfigPath:
 		if s, ok := value.(string); ok {
 			c.paths.ConfigPath = s
@@ -58,6 +62,9 @@ func (c *ClusterDeleter) SetProperty(name string, value any) {
 		if s, ok := value.(config.KFD); ok {
 			c.kfdManifest = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/immutable/kubeconfig_getter.go
+++ b/internal/apis/kfd/v1alpha2/immutable/kubeconfig_getter.go
@@ -5,7 +5,6 @@
 package immutable
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -22,10 +21,9 @@ import (
 	"github.com/sighupio/furyctl/pkg/template"
 )
 
-var ErrKubeconfigGetNotImplemented = errors.New("kubeconfig get not implemented for Immutable kind")
-
 type KubeconfigGetter struct {
 	*cluster.OperationPhase
+
 	furyctlConf public.ImmutableKfdV1Alpha2
 	kfdManifest config.KFD
 	distroPath  string
@@ -43,7 +41,9 @@ func (k *KubeconfigGetter) SetProperties(props []cluster.KubeconfigProperty) {
 }
 
 func (k *KubeconfigGetter) SetProperty(name string, value any) {
-	switch strings.ToLower(name) {
+	lcName := strings.ToLower(name)
+
+	switch lcName {
 	case cluster.KubeconfigPropertyFuryctlConf:
 		if s, ok := value.(public.ImmutableKfdV1Alpha2); ok {
 			k.furyctlConf = s
@@ -73,6 +73,9 @@ func (k *KubeconfigGetter) SetProperty(name string, value any) {
 		if s, ok := value.(string); ok {
 			k.binPath = s
 		}
+
+	default:
+		logrus.Debugf("ignoring unknown property %q", lcName)
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/distribution.go
@@ -139,7 +139,7 @@ func (d *Distribution) Exec(rdcs reducers.Reducers, startFrom string, upgradeSta
 }
 
 func (d *Distribution) Stop() error {
-	return cluster.StopAll(
+	if err := cluster.StopAll(
 		func() error {
 			logrus.Debug("Stopping shell...")
 
@@ -158,7 +158,11 @@ func (d *Distribution) Stop() error {
 
 			return nil
 		},
-	)
+	); err != nil {
+		return fmt.Errorf("error stopping distribution: %w", err)
+	}
+
+	return nil
 }
 
 func (d *Distribution) SetUpgrade(upgradeEnabled bool) {

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
@@ -41,6 +41,7 @@ type Status struct {
 
 type PreFlight struct {
 	*cluster.OperationPhase
+
 	furyctlConf     public.KfddistributionKfdV1Alpha2
 	stateStore      state.Storer
 	distroPath      string

--- a/internal/apis/kfd/v1alpha2/onpremises/certificates_renewer.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/certificates_renewer.go
@@ -22,6 +22,7 @@ import (
 
 type CertificatesRenewer struct {
 	*cluster.OperationPhase
+
 	furyctlConf public.OnpremisesKfdV1Alpha2
 	kfdManifest config.KFD
 	distroPath  string

--- a/internal/apis/kfd/v1alpha2/onpremises/kubeconfig_getter.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/kubeconfig_getter.go
@@ -23,6 +23,7 @@ import (
 
 type KubeconfigGetter struct {
 	*cluster.OperationPhase
+
 	furyctlConf public.OnpremisesKfdV1Alpha2
 	kfdManifest config.KFD
 	distroPath  string

--- a/internal/cluster/stop.go
+++ b/internal/cluster/stop.go
@@ -4,7 +4,11 @@
 
 package cluster
 
-import "golang.org/x/sync/errgroup"
+import (
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+)
 
 // StopAll runs the given stop functions concurrently, waits for all of them to finish, and returns
 // the first non-nil error (or nil if they all succeed).
@@ -15,5 +19,9 @@ func StopAll(fns ...func() error) error {
 		eg.Go(fn)
 	}
 
-	return eg.Wait()
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("error waiting for stop functions: %w", err)
+	}
+
+	return nil
 }

--- a/internal/x/exec/cmd.go
+++ b/internal/x/exec/cmd.go
@@ -34,6 +34,7 @@ func NewErrCmdFailed(name string, args []string, err error, res *CmdLog) error {
 
 type Cmd struct {
 	*exec.Cmd
+
 	Log       *CmdLog
 	Sensitive bool
 }

--- a/internal/x/io/targz.go
+++ b/internal/x/io/targz.go
@@ -20,8 +20,13 @@ const (
 	copyChunk = 1 << 20 // 1 MiB per io.CopyN step when extracting regular files.
 )
 
-// ErrIllegalArchivePath is returned when a tar entry would extract outside the destination dir.
-var ErrIllegalArchivePath = errors.New("illegal path in archive (escapes destination)")
+var (
+	// ErrIllegalArchivePath is returned when a tar entry would extract outside the destination dir.
+	ErrIllegalArchivePath = errors.New("illegal path in archive (escapes destination)")
+
+	// ErrUnsupportedTarEntryType is returned when a tar entry has an unsupported type flag.
+	ErrUnsupportedTarEntryType = errors.New("unsupported tar entry type")
+)
 
 // TarGzEntry maps a file or directory on disk to the path prefix it should appear under inside the
 // archive.
@@ -186,6 +191,9 @@ func extractEntry(tr *tar.Reader, hdr *tar.Header, target string) error {
 		if err := os.Symlink(hdr.Linkname, target); err != nil {
 			return fmt.Errorf("error creating symlink %s: %w", target, err)
 		}
+
+	default:
+		return fmt.Errorf("%w: %b", ErrUnsupportedTarEntryType, hdr.Typeflag)
 	}
 
 	return nil

--- a/mise.toml
+++ b/mise.toml
@@ -128,10 +128,6 @@ description = "run linting with golangci-lint"
 env = { GOMEMLIMIT = "1GiB" }
 run = "golangci-lint -v run --timeout=10m --color=always --max-same-issues 25 --config=.rules/.golangci.yml ./..."
 
-[tasks.lint-go-common]
-description = "run common linting rules without config"
-run = "golangci-lint run --no-config -E godot -E wsl -E nlreturn -E grouper --color=always --max-same-issues 25 ./..."
-
 [tasks.test-unit]
 description = "run unit tests"
 run = "go test -v -tags=unit ./..."

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.3.1"
+golangci-lint = "2.4.0"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"
@@ -126,7 +126,7 @@ run = [
 [tasks.lint]
 description = "run linting with golangci-lint"
 env = { GOMEMLIMIT = "1GiB" }
-run = "golangci-lint -v run --timeout=5m --color=always --max-same-issues 25 --config=.rules/.golangci.yml ./..."
+run = "golangci-lint -v run --timeout=10m --color=always --max-same-issues 25 --config=.rules/.golangci.yml ./..."
 
 [tasks.lint-go-common]
 description = "run common linting rules without config"

--- a/pkg/rulesextractor/ekscluster.go
+++ b/pkg/rulesextractor/ekscluster.go
@@ -16,6 +16,7 @@ import (
 
 type EKSExtractor struct {
 	*BaseExtractor
+
 	Spec Spec
 }
 

--- a/pkg/rulesextractor/immutable.go
+++ b/pkg/rulesextractor/immutable.go
@@ -16,6 +16,7 @@ import (
 
 type ImmutableExtractor struct {
 	*BaseExtractor
+
 	Spec Spec
 }
 

--- a/pkg/rulesextractor/kfddistribution.go
+++ b/pkg/rulesextractor/kfddistribution.go
@@ -19,6 +19,7 @@ var ErrReadingRulesFile = errors.New("error while reading rules file")
 
 type DistroExtractor struct {
 	*BaseExtractor
+
 	Spec Spec
 }
 


### PR DESCRIPTION
### Summary 💡

Update golangci-lint to 2.4.0


### Description 📝

Update golangci-lint to 2.4.0 + code alignments to new linters.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

