### PR TITLE
chore: update golangci-lint to 2.5.0

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -92,6 +92,10 @@ linters:
         - k8s.io/sample-apiserver
         - k8s.io/sample-cli-plugin
         - k8s.io/sample-controller
+    godoclint:
+      default: basic
+      enable:
+        - no-unused-link
     gosec:
       excludes:
         - G204
@@ -291,6 +295,13 @@ linters:
         - name: package-comments
           severity: warning
           disabled: false
+          # Disabled because we intentionally use mismatched names in two cases:
+          #   - `delete` directories use `package del` (delete is a Go builtin).
+          #   - `internal/x/*` and `pkg/x/*` packages use the `x` suffix convention
+          #     (e.g. `execx`, `iox`, `netx`) to avoid shadowing stdlib package names.
+        - name: package-directory-mismatch
+          severity: warning
+          disabled: true
         - name: range
           severity: warning
           disabled: false

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -49,7 +49,7 @@ func (lrw *loggingResponseWriter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
-// Start an HTTP server serving a path in the file system on a custom address and port, logging each request.
+// Path starts an HTTP server serving a path in the file system on a custom address and port, logging each request.
 // The server stops when the user presses ENTER or once every node reports "booted".
 func Path(address, port, root string, nodesStatus map[string]string) error {
 	// ENTER and all-nodes-booted both cancel this context to stop the server; cancel() is

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
@@ -40,7 +40,7 @@ type Status struct {
 	Success bool
 }
 
-// Preflight is a phase tasked with ensuring cluster connectivity
+// PreFlight is a phase tasked with ensuring cluster connectivity
 // and checking for violations in the updates made on the furyctl.yaml file.
 type PreFlight struct {
 	*phases.PreFlight

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
@@ -859,7 +859,7 @@ func (*Infrastructure) downloadSysextPackages(
 	return nil
 }
 
-// Bootstrap Flatcar nodes by:
+// BootstrapNodes bootstraps Flatcar nodes by:
 // - Downloading the Flatcar image and prepare the assets for the installer defined in immutable.yaml.
 // - Starting a server to serve the assets to the installer.
 func (i *Infrastructure) BootstrapNodes() error {

--- a/internal/distribution/compatibility.go
+++ b/internal/distribution/compatibility.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// Package distribution provides compatibility checks for distribution versions.
 package distribution
 
 import (
@@ -120,7 +122,8 @@ type CompatibilityCheck struct {
 	distributionVersion string
 }
 
-// Check the minimal KDF version supported by furyctl.
+// IsReleaseUnsupportedByFuryctl reports whether the given release is below
+// the minimal KFD version supported by furyctl.
 func IsReleaseUnsupportedByFuryctl(ghRelease git.Release) bool {
 	distributionVersion := ghRelease.TagName
 

--- a/internal/distribution/supported_versions.go
+++ b/internal/distribution/supported_versions.go
@@ -32,7 +32,8 @@ type KFDRelease struct {
 	Recommended bool
 }
 
-// Check if current KFD version is a release or a prerelease.
+// IsNotRelease reports whether the given KFD version is a prerelease
+// (or otherwise not parsable as a stable release).
 func IsNotRelease(ghRelease git.Release) bool {
 	v, err := VersionFromString(ghRelease.TagName)
 	if err != nil || v.Prerelease() != "" {

--- a/internal/flags/merger.go
+++ b/internal/flags/merger.go
@@ -113,7 +113,8 @@ func (m *Merger) MergeIntoViper(flags *FlagsConfig, command string) error {
 // ConvertValue converts a value to the expected type for the flag.
 func (*Merger) ConvertValue(value any, expectedType FlagType) (any, error) {
 	switch expectedType {
-	case FlagTypeString:
+	case FlagTypeString, FlagTypeDuration:
+		// Duration is treated as string here; viper handles the actual conversion later.
 		return fmt.Sprintf("%v", value), nil
 
 	case FlagTypeBool:
@@ -180,10 +181,6 @@ func (*Merger) ConvertValue(value any, expectedType FlagType) (any, error) {
 		default:
 			return []string{}, ErrTypeConversion
 		}
-
-	case FlagTypeDuration:
-		// For now, treat duration as string and let viper handle the conversion.
-		return fmt.Sprintf("%v", value), nil
 
 	default:
 		return nil, ErrUnsupportedFlagType

--- a/internal/flags/types.go
+++ b/internal/flags/types.go
@@ -56,8 +56,9 @@ const (
 	FlagTypeStringSlice FlagType = "stringSlice"
 	FlagTypeDuration    FlagType = "duration"
 
-	// Default timeout values.
-	DefaultTimeoutSeconds         = 3600
+	// DefaultTimeoutSeconds is the default timeout for cluster operations, in seconds.
+	DefaultTimeoutSeconds = 3600
+	// DefaultPodRunningCheckTimeout is the default timeout for the pod-running check, in seconds.
 	DefaultPodRunningCheckTimeout = 300
 
 	// ValidationSeverityFatal indicates a critical error that should stop execution.

--- a/internal/flags/validator.go
+++ b/internal/flags/validator.go
@@ -81,7 +81,7 @@ func (v *Validator) Validate(flags *FlagsConfig) []ValidationError {
 	return validationErrors
 }
 
-// ValidateIndividualFlag ValidateFlagValue is a public wrapper for testing the flag value validation.
+// ValidateIndividualFlag is a public wrapper around validateFlagValue, exposed for testing.
 func (v *Validator) ValidateIndividualFlag(flagName string, value any, flagInfo FlagInfo) error {
 	return v.validateFlagValue(flagName, value, flagInfo)
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.4.0"
+golangci-lint = "2.5.0"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"

--- a/pkg/template/funcmap.go
+++ b/pkg/template/funcmap.go
@@ -83,11 +83,11 @@ func digFromDictAny(dict map[any]any, d any, ks []string) (any, error) {
 	return digFromDictAny(next, d, ns)
 }
 
-// This is a copy of the Sprig dig function that recurse a dict with any keys
+// DigAny is a copy of the Sprig dig function that recurses a dict with any keys
 // instead of map keys.
-// `digAny` will recurse all the specified keys of the given dict and return the
+// It walks all the specified keys of the given dict and returns the
 // last key value if found.
-// If any of the keys does not exist, digAny will return the default value
+// If any of the keys do not exist, DigAny returns the default value
 // passed as the last argument.
 // Usage in templates:
 //


### PR DESCRIPTION
### Summary 💡

Update golangci-lint to 2.5.0


### Description 📝

Update golangci-lint to 2.5.0 + code alignments to new linters.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

