### PR TITLE
chore: update golangci-lint to 2.6.2

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -368,7 +368,8 @@ linters:
         - name: unhandled-error
           arguments:
             - fmt.Printf
-            - myFunction
+            - fmt.Fprintf
+            - strings.Builder.WriteString
           severity: warning
           disabled: false
         - name: unnecessary-stmt

--- a/cmd/get/supported-versions.go
+++ b/cmd/get/supported-versions.go
@@ -120,13 +120,15 @@ func NewSupportedVersionsCmd() *cobra.Command {
 func FormatSupportedVersions(releases []distribution.KFDRelease, kinds []string) string {
 	distribution.SetRecommendedVersions(releases)
 
-	fmtSupportedVersions := "VERSION\tRELEASE DATE"
+	var sb strings.Builder
+
+	sb.WriteString("VERSION\tRELEASE DATE")
 
 	for _, k := range kinds {
-		fmtSupportedVersions += "\t" + k
+		sb.WriteString("\t" + k)
 	}
 
-	fmtSupportedVersions += "\n"
+	sb.WriteString("\n")
 
 	supported := func(s bool) string {
 		if s {
@@ -169,26 +171,22 @@ func FormatSupportedVersions(releases []distribution.KFDRelease, kinds []string)
 			showRecommendedMsg = true
 		}
 
-		fmtSupportedVersions += fmt.Sprintf(
-			"v%s\t%s",
-			versionStr,
-			dateStr,
-		)
+		sb.WriteString("v" + versionStr + "\t" + dateStr)
 
 		for _, k := range kinds {
-			fmtSupportedVersions += "\t" + supported(r.Support[k])
+			sb.WriteString("\t" + supported(r.Support[k]))
 		}
 
-		fmtSupportedVersions += "\n"
+		sb.WriteString("\n")
 	}
 
 	if showUnsupportedFuryctlMsg {
-		fmtSupportedVersions += "\n* this usually indicates you are not using the latest version of furyctl, try updating or checking the online documentation:\nhttps://docs.sighup.io/furyctl/compatibility-matrix\n"
+		sb.WriteString("\n* this usually indicates you are not using the latest version of furyctl, try updating or checking the online documentation:\nhttps://docs.sighup.io/furyctl/compatibility-matrix\n")
 	}
 
 	if showRecommendedMsg {
-		fmtSupportedVersions += "\n** indicates the recommended SD versions.\n"
+		sb.WriteString("\n** indicates the recommended SD versions.\n")
 	}
 
-	return fmtSupportedVersions
+	return sb.String()
 }

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -71,9 +71,8 @@ func Path(address, port, root string, nodesStatus map[string]string) error {
 	typedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Normalize MAC addresses to uppercase in /boot/ paths because iPXE sends lowercase MACs (bc-24-11-cc-dd-01)
 		// in the URL, but files are uppercase (BC-24-11-CC-DD-01).
-		if strings.HasPrefix(r.URL.Path, "/boot/") {
-			macPart := strings.TrimPrefix(r.URL.Path, "/boot/")
-			r.URL.Path = "/boot/" + strings.ToUpper(macPart)
+		if after, ok := strings.CutPrefix(r.URL.Path, "/boot/"); ok {
+			r.URL.Path = "/boot/" + strings.ToUpper(after)
 		}
 
 		// Use package-level loggingResponseWriter.

--- a/cmd/serve/status_table.go
+++ b/cmd/serve/status_table.go
@@ -7,6 +7,7 @@ package serve
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"slices"
 	"strconv"
@@ -141,9 +142,7 @@ func (t *nodeStatusTable) Snapshot() map[string]string {
 	defer t.mu.Unlock()
 
 	out := make(map[string]string, len(t.status))
-	for node, st := range t.status {
-		out[node] = st
-	}
+	maps.Copy(out, t.status)
 
 	return out
 }
@@ -222,7 +221,7 @@ func (t *nodeStatusTable) lines() []string {
 	lines := make([]string, 0, len(t.order)+1)
 	lines = append(lines, fmt.Sprintf("Nodes bootstrap status — %d/%d booted", t.bootedCount(), len(t.order)))
 
-	for _, row := range strings.Split(strings.TrimRight(sb.String(), "\n"), "\n") {
+	for row := range strings.SplitSeq(strings.TrimRight(sb.String(), "\n"), "\n") {
 		lines = append(lines, "  "+row)
 	}
 

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
@@ -129,6 +129,7 @@ func (i *Infrastructure) Exec(_ string, upgradeState *upgrade.State) error {
 	}
 
 	versionVars := map[any]any{}
+	//nolint:modernize // maps.Copy requires identical map types
 	for name, value := range buildVersionVars(i.kfdManifest.Kubernetes.Immutable.Version, i.KubectlPath, immutableAssets) {
 		versionVars[name] = value
 	}

--- a/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
@@ -157,6 +157,7 @@ func (k *Kubernetes) prepare() error {
 	}
 
 	versionVars := map[any]any{}
+	//nolint:modernize // maps.Copy requires identical map types
 	for name, value := range buildVersionVars(version, k.KubectlPath, immutableAssets) {
 		versionVars[name] = value
 	}

--- a/internal/clusterinfo/collector.go
+++ b/internal/clusterinfo/collector.go
@@ -655,10 +655,8 @@ func primaryRole(labels map[string]string) string {
 	var roles []string
 
 	for k := range labels {
-		if strings.HasPrefix(k, prefix) {
-			if role := strings.TrimPrefix(k, prefix); role != "" {
-				roles = append(roles, role)
-			}
+		if role, ok := strings.CutPrefix(k, prefix); ok && role != "" {
+			roles = append(roles, role)
 		}
 	}
 

--- a/internal/flags/validator.go
+++ b/internal/flags/validator.go
@@ -213,10 +213,8 @@ func (*Validator) validateSpecificFlag(flagName string, value any) error {
 	case "gitProtocol":
 		if str, ok := value.(string); ok {
 			validProtocols := []string{"https", "ssh"}
-			for _, valid := range validProtocols {
-				if str == valid {
-					return nil
-				}
+			if slices.Contains(validProtocols, str) {
+				return nil
 			}
 
 			return fmt.Errorf("%w: got '%s', must be one of: %s", ErrInvalidProtocol, str, strings.Join(validProtocols, ", "))

--- a/internal/x/io/liveregion.go
+++ b/internal/x/io/liveregion.go
@@ -115,19 +115,19 @@ func (lr *LiveRegion) truncate(line string) string {
 }
 
 func (lr *LiveRegion) repaint() {
-	out := ""
+	var sb strings.Builder
 
 	if lr.painted > 0 {
-		out += "\033[" + strconv.Itoa(lr.painted) + "A"
+		sb.WriteString("\033[" + strconv.Itoa(lr.painted) + "A")
 	}
 
 	for _, line := range lr.lines {
-		out += "\033[2K" + line + "\r\n"
+		sb.WriteString("\033[2K" + line + "\r\n")
 	}
 
 	lr.painted = len(lr.lines)
 
-	if _, err := io.WriteString(lr.w, out); err != nil {
+	if _, err := io.WriteString(lr.w, sb.String()); err != nil {
 		// The terminal is no longer writable; stop painting so we don't garble output.
 		lr.enabled = false
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.5.0"
+golangci-lint = "2.6.2"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"

--- a/pkg/diffs/checker.go
+++ b/pkg/diffs/checker.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	r3diff "github.com/r3labs/diff/v3"
@@ -75,15 +76,15 @@ func (*BaseChecker) FilterDiffFromPhase(changelog r3diff.Changelog, phasePath st
 }
 
 func (*BaseChecker) DiffToString(diffs r3diff.Changelog) string {
-	var str string
+	var buf strings.Builder
 
 	for _, diff := range diffs {
 		joinedPath := "." + strings.Join(diff.Path, ".")
 
-		str += fmt.Sprintf("%s: %v -> %v\n", joinedPath, diff.From, diff.To)
+		fmt.Fprintf(&buf, "%s: %v -> %v\n", joinedPath, diff.From, diff.To)
 	}
 
-	return str
+	return buf.String()
 }
 
 func (*BaseChecker) AssertImmutableViolations(diffs r3diff.Changelog, immutablePaths []string) []error {
@@ -231,11 +232,5 @@ func isImmutablePathChanged(change r3diff.Change, immutables []string) bool {
 	joinedPath := "." + strings.Join(change.Path, ".")
 	changePath := numbersToWildcardRegex.ReplaceAllString(joinedPath, ".*")
 
-	for _, immutable := range immutables {
-		if changePath == immutable {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(immutables, changePath)
 }

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -6,6 +6,7 @@ package merge
 
 import (
 	"fmt"
+	"maps"
 )
 
 type Merger struct {
@@ -48,9 +49,7 @@ func (m *Merger) Merge() (map[any]any, error) {
 
 func deepCopy(a, b map[any]any) map[any]any {
 	out := make(map[any]any, len(a))
-	for k, v := range a {
-		out[k] = v
-	}
+	maps.Copy(out, a)
 
 	for k, v := range b {
 		if v, ok := v.(map[any]any); ok {

--- a/pkg/merge/model.go
+++ b/pkg/merge/model.go
@@ -55,9 +55,7 @@ func (b *DefaultModel) Path() string {
 func (b *DefaultModel) Get() (map[any]any, error) {
 	ret := b.content
 
-	fields := strings.Split(b.path[1:], ".")
-
-	for _, f := range fields {
+	for f := range strings.SplitSeq(b.path[1:], ".") {
 		mapAtKey, ok := ret[f]
 		if !ok {
 			return nil, fmt.Errorf("%w %s on map", errCannotAccessKey, f)

--- a/pkg/reducers/reducer.go
+++ b/pkg/reducers/reducer.go
@@ -4,7 +4,10 @@
 
 package reducers
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Reducers []Reducer
 
@@ -97,15 +100,14 @@ func (rs Reducers) Combine(origin map[string]map[any]any, key string) map[string
 }
 
 func (rs Reducers) ToString() string {
-	res := ""
+	var buf strings.Builder
 
 	for _, r := range rs {
 		if r == nil {
 			continue
 		}
-
-		res += fmt.Sprintf("%s: %v -> %v\n", r.GetPath(), r.GetFrom(), r.GetTo())
+		fmt.Fprintf(&buf, "%s: %v -> %v\n", r.GetPath(), r.GetFrom(), r.GetTo())
 	}
 
-	return res
+	return buf.String()
 }

--- a/pkg/template/model.go
+++ b/pkg/template/model.go
@@ -7,6 +7,7 @@ package template
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -246,9 +247,7 @@ func (tm *Model) applyTemplates(
 func (tm *Model) generateContext() (map[string]map[any]any, error) {
 	context := make(map[string]map[any]any)
 
-	for k, v := range tm.Config.Data {
-		context[k] = v
-	}
+	maps.Copy(context, tm.Config.Data)
 
 	for k, v := range tm.Config.Include {
 		cPath := filepath.Join(filepath.Dir(tm.ConfigPath), v)

--- a/pkg/x/net/progress_test.go
+++ b/pkg/x/net/progress_test.go
@@ -50,10 +50,7 @@ func writeChunked(w http.ResponseWriter, payload []byte) {
 
 	const chunk = 1_000_000
 	for off := 0; off < len(payload); off += chunk {
-		end := off + chunk
-		if end > len(payload) {
-			end = len(payload)
-		}
+		end := min(off+chunk, len(payload))
 
 		_, _ = w.Write(payload[off:end])
 


### PR DESCRIPTION
### Summary 💡

Update golangci-lint to 2.6.2


### Description 📝

Update golangci-lint to 2.6.2 + code alignments to new linters.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

