### PR TITLE
chore: update golangci-lint to 2.8.0

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -96,6 +96,7 @@ linters:
       default: basic
       enable:
         - no-unused-link
+        - require-stdlib-doclink
     gosec:
       excludes:
         - G204

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -382,7 +382,7 @@ func getApplyCmdFlags() (ClusterCmdFlags, error) {
 
 	gitProtocol := viper.GetString("git-protocol")
 
-	typedGitProtocol, err := git.NewProtocol(gitProtocol)
+	typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 	if err != nil {
 		return ClusterCmdFlags{}, fmt.Errorf("%w: %w", ErrParsingFlag, err)
 	}

--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -88,7 +88,7 @@ func NewConfigCmd() *cobra.Command {
 
 			gitProtocol := viper.GetString("git-protocol")
 
-			typedGitProtocol, err := git.NewProtocol(gitProtocol)
+			typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 			if err != nil {
 				return fmt.Errorf("%w: %w", ErrParsingFlag, err)
 			}

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -450,7 +450,7 @@ func getDeleteClusterCmdFlags() (ClusterCmdFlags, error) {
 
 	gitProtocol := viper.GetString("git-protocol")
 
-	typedGitProtocol, err := git.NewProtocol(gitProtocol)
+	typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 	if err != nil {
 		return ClusterCmdFlags{}, fmt.Errorf("%w: %w", ErrParsingFlag, err)
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -331,7 +331,7 @@ func getDiffCommandFlags() (DiffCommandFlags, error) {
 
 	gitProtocol := viper.GetString("git-protocol")
 
-	typedGitProtocol, err := git.NewProtocol(gitProtocol)
+	typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 	if err != nil {
 		return DiffCommandFlags{}, fmt.Errorf("%w: %w", ErrParsingFlag, err)
 	}

--- a/cmd/download/airgappedbundle.go
+++ b/cmd/download/airgappedbundle.go
@@ -122,7 +122,7 @@ func NewAirGappedBundleCmd() *cobra.Command {
 				return fmt.Errorf("error while getting absolute path for bundle output: %w", err)
 			}
 
-			typedGitProtocol, err := git.NewProtocol(gitProtocol)
+			typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)

--- a/cmd/download/dependencies.go
+++ b/cmd/download/dependencies.go
@@ -61,7 +61,7 @@ func NewDependenciesCmd() *cobra.Command {
 			distroPatchesLocation := viper.GetString("distro-patches")
 			binPath := viper.GetString("bin-path")
 
-			typedGitProtocol, err := git.NewProtocol(gitProtocol)
+			typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)

--- a/cmd/dump/template.go
+++ b/cmd/dump/template.go
@@ -228,7 +228,7 @@ The command will dump into a 'distribution' folder in the working directory all 
 func getDumpTemplateCmdFlags() (TemplateCmdFlags, error) {
 	gitProtocol := viper.GetString("git-protocol")
 
-	typedGitProtocol, err := git.NewProtocol(gitProtocol)
+	typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 	if err != nil {
 		return TemplateCmdFlags{}, fmt.Errorf("%w: %w", ErrParsingFlag, err)
 	}

--- a/cmd/get/kubeconfig.go
+++ b/cmd/get/kubeconfig.go
@@ -99,7 +99,7 @@ func NewKubeconfigCmd() *cobra.Command {
 				}
 			}
 
-			typedGitProtocol, err := git.NewProtocol(gitProtocol)
+			typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)

--- a/cmd/get/upgrade-paths.go
+++ b/cmd/get/upgrade-paths.go
@@ -106,7 +106,7 @@ func NewUpgradePathsCmd() *cobra.Command {
 				}
 			}
 
-			typedGitProtocol, err := git.NewProtocol(gitProtocol)
+			typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)

--- a/cmd/renew/certificates.go
+++ b/cmd/renew/certificates.go
@@ -96,7 +96,7 @@ func NewCertificatesCmd() *cobra.Command {
 				}
 			}
 
-			typedGitProtocol, err := git.NewProtocol(gitProtocol)
+			typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 			if err != nil {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)

--- a/cmd/serve/path.go
+++ b/cmd/serve/path.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// loggingResponseWriter wraps http.ResponseWriter to capture status code and bytes written.
+// loggingResponseWriter wraps [http.ResponseWriter] to capture status code and bytes written.
 type loggingResponseWriter struct {
 	http.ResponseWriter
 

--- a/cmd/validate/config.go
+++ b/cmd/validate/config.go
@@ -61,7 +61,7 @@ func NewConfigCmd() *cobra.Command {
 			outDir := viper.GetString("outdir")
 			distroPatchesLocation := viper.GetString("distro-patches")
 
-			typedGitProtocol, err := git.NewProtocol(gitProtocol)
+			typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 			if err != nil {
 				return fmt.Errorf("%w: %w", ErrParsingFlag, err)
 			}

--- a/cmd/validate/dependencies.go
+++ b/cmd/validate/dependencies.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -74,7 +75,7 @@ func NewDependenciesCmd() *cobra.Command {
 			}
 
 			gitProtocol := viper.GetString("git-protocol")
-			typedGitProtocol, err := git.NewProtocol(gitProtocol)
+			typedGitProtocol, err := git.ParseProtocol(gitProtocol)
 			if err != nil {
 				return fmt.Errorf("%w: %w", ErrParsingFlag, err)
 			}
@@ -128,7 +129,6 @@ func NewDependenciesCmd() *cobra.Command {
 
 			toolsValidator := tools.NewValidator(executor, binPath, furyctlPath)
 			envVarsValidator := envvars.NewValidator()
-			errs := make([]error, 0)
 
 			logrus.Info("Validating tools...")
 
@@ -143,8 +143,7 @@ func NewDependenciesCmd() *cobra.Command {
 
 			logrus.Info("Validating tools configuration...")
 
-			errs = append(errs, terrs...)
-			errs = append(errs, eerrs...)
+			errs := slices.Concat(terrs, eerrs)
 
 			for _, tok := range toks {
 				logrus.Infof("%s: binary found in vendor folder", tok)

--- a/internal/airgap/airgap.go
+++ b/internal/airgap/airgap.go
@@ -83,7 +83,7 @@ func MaybePrepare() error {
 	return nil
 }
 
-//nolint:revive // force is an explicit user choice (--force-extract), not an internal mode toggle.
+//revive:disable:flag-parameter // force is an explicit user choice (--force-extract), not an internal mode toggle.
 func prepare(bundle, outDir string, force bool) (string, error) {
 	bundle, err := filepath.Abs(bundle)
 	if err != nil {

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"slices"
 
 	r3diff "github.com/r3labs/diff/v3"
 	"github.com/sirupsen/logrus"
@@ -304,8 +305,6 @@ func (p *PreFlight) CreateDiffChecker(
 }
 
 func (p *PreFlight) CheckImmutablesDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
-	var errs []error
-
 	r, err := rules.NewEKSClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
@@ -344,9 +343,11 @@ func (p *PreFlight) CheckImmutablesDiffs(d r3diff.Changelog, diffChecker diffs.C
 		distroImmutablePaths = append(distroImmutablePaths, rule.Path)
 	}
 
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, infraImmutablePaths)...)
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, kubeImmutablePaths)...)
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, distroImmutablePaths)...)
+	errs := slices.Concat(
+		diffChecker.AssertImmutableViolations(d, infraImmutablePaths),
+		diffChecker.AssertImmutableViolations(d, kubeImmutablePaths),
+		diffChecker.AssertImmutableViolations(d, distroImmutablePaths),
+	)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %w", errImmutable, errors.Join(errs...))
@@ -358,8 +359,6 @@ func (p *PreFlight) CheckImmutablesDiffs(d r3diff.Changelog, diffChecker diffs.C
 // CheckReducersDiffs checks if the changes to the reducers are supported by the distribution.
 // This is needed as not all from/to combinations are supported.
 func (p *PreFlight) CheckReducersDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
-	var errs []error
-
 	r, err := rules.NewEKSClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
@@ -371,18 +370,19 @@ func (p *PreFlight) CheckReducersDiffs(d r3diff.Changelog, diffChecker diffs.Che
 		return nil
 	}
 
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
+	errs := slices.Concat(diffChecker.AssertReducerUnsupportedViolations(
 		d,
 		r.GetUnsupportedRules("infrastructure"),
-	)...)
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
-		d,
-		r.GetUnsupportedRules("kubernetes"),
-	)...)
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
-		d,
-		r.GetUnsupportedRules("distribution"),
-	)...)
+	),
+		diffChecker.AssertReducerUnsupportedViolations(
+			d,
+			r.GetUnsupportedRules("kubernetes"),
+		),
+		diffChecker.AssertReducerUnsupportedViolations(
+			d,
+			r.GetUnsupportedRules("distribution"),
+		),
+	)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %w", errUnsupported, errors.Join(errs...))

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
@@ -129,7 +129,6 @@ func (i *Infrastructure) Exec(_ string, upgradeState *upgrade.State) error {
 	}
 
 	versionVars := map[any]any{}
-	//nolint:modernize // maps.Copy requires identical map types
 	for name, value := range buildVersionVars(i.kfdManifest.Kubernetes.Immutable.Version, i.KubectlPath, immutableAssets) {
 		versionVars[name] = value
 	}

--- a/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
@@ -157,7 +157,6 @@ func (k *Kubernetes) prepare() error {
 	}
 
 	versionVars := map[any]any{}
-	//nolint:modernize // maps.Copy requires identical map types
 	for name, value := range buildVersionVars(version, k.KubectlPath, immutableAssets) {
 		versionVars[name] = value
 	}

--- a/internal/apis/kfd/v1alpha2/immutable/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/preflight.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"slices"
 
 	r3diff "github.com/r3labs/diff/v3"
 	"github.com/sirupsen/logrus"
@@ -244,8 +245,6 @@ func (p *PreFlight) CreateDiffChecker(renderedConfig map[string]any) (diffs.Chec
 }
 
 func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
-	var errs []error
-
 	r, err := rules.NewImmutableClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
@@ -284,9 +283,11 @@ func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checke
 		distroImmutablePaths = append(distroImmutablePaths, rule.Path)
 	}
 
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, infraImmutablePaths)...)
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, kubeImmutablePaths)...)
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, distroImmutablePaths)...)
+	errs := slices.Concat(
+		diffChecker.AssertImmutableViolations(d, infraImmutablePaths),
+		diffChecker.AssertImmutableViolations(d, kubeImmutablePaths),
+		diffChecker.AssertImmutableViolations(d, distroImmutablePaths),
+	)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %w", errImmutable, errors.Join(errs...))
@@ -296,8 +297,6 @@ func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checke
 }
 
 func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
-	var errs []error
-
 	r, err := rules.NewImmutableClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
@@ -309,19 +308,20 @@ func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Chec
 		return nil
 	}
 
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
-		d,
-		r.GetUnsupportedRules(cluster.OperationPhaseInfrastructure),
-	)...)
-
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
-		d,
-		r.GetUnsupportedRules(cluster.OperationPhaseKubernetes),
-	)...)
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
-		d,
-		r.GetUnsupportedRules(cluster.OperationPhaseDistribution),
-	)...)
+	errs := slices.Concat(
+		diffChecker.AssertReducerUnsupportedViolations(
+			d,
+			r.GetUnsupportedRules(cluster.OperationPhaseInfrastructure),
+		),
+		diffChecker.AssertReducerUnsupportedViolations(
+			d,
+			r.GetUnsupportedRules(cluster.OperationPhaseKubernetes),
+		),
+		diffChecker.AssertReducerUnsupportedViolations(
+			d,
+			r.GetUnsupportedRules(cluster.OperationPhaseDistribution),
+		),
+	)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %w", errUnsupported, errors.Join(errs...))

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
@@ -225,8 +225,6 @@ func (p *PreFlight) CreateDiffChecker(storedCfgStr []byte, renderedConfig map[st
 }
 
 func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
-	var errs []error
-
 	r, err := rules.NewDistroClusterRulesExtractor(p.distroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
@@ -251,7 +249,7 @@ func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checke
 		immutablePaths = append(immutablePaths, rule.Path)
 	}
 
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, immutablePaths)...)
+	errs := diffChecker.AssertImmutableViolations(d, immutablePaths)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %w", errImmutable, errors.Join(errs...))
@@ -261,8 +259,6 @@ func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checke
 }
 
 func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
-	var errs []error
-
 	r, err := rules.NewDistroClusterRulesExtractor(p.distroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
@@ -274,10 +270,10 @@ func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Chec
 		return nil
 	}
 
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
+	errs := diffChecker.AssertReducerUnsupportedViolations(
 		d,
 		r.GetUnsupportedRules("distribution"),
-	)...)
+	)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %w", errUnsupported, errors.Join(errs...))

--- a/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"slices"
 
 	r3diff "github.com/r3labs/diff/v3"
 	"github.com/sirupsen/logrus"
@@ -244,8 +245,6 @@ func (p *PreFlight) CreateDiffChecker(renderedConfig map[string]any) (diffs.Chec
 }
 
 func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
-	var errs []error
-
 	r, err := rules.NewOnPremClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
@@ -277,8 +276,10 @@ func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checke
 		distroImmutablePaths = append(distroImmutablePaths, rule.Path)
 	}
 
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, kubeImmutablePaths)...)
-	errs = append(errs, diffChecker.AssertImmutableViolations(d, distroImmutablePaths)...)
+	errs := slices.Concat(
+		diffChecker.AssertImmutableViolations(d, kubeImmutablePaths),
+		diffChecker.AssertImmutableViolations(d, distroImmutablePaths),
+	)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %w", errImmutable, errors.Join(errs...))
@@ -288,8 +289,6 @@ func (p *PreFlight) CheckStateDiffs(d r3diff.Changelog, diffChecker diffs.Checke
 }
 
 func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Checker) error {
-	var errs []error
-
 	r, err := rules.NewOnPremClusterRulesExtractor(p.paths.DistroPath, diffChecker.GetCurrentConfig())
 	if err != nil {
 		if !errors.Is(err, rules.ErrReadingRulesFile) {
@@ -301,14 +300,16 @@ func (p *PreFlight) CheckReducerDiffs(d r3diff.Changelog, diffChecker diffs.Chec
 		return nil
 	}
 
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
-		d,
-		r.GetUnsupportedRules("kubernetes"),
-	)...)
-	errs = append(errs, diffChecker.AssertReducerUnsupportedViolations(
-		d,
-		r.GetUnsupportedRules("distribution"),
-	)...)
+	errs := slices.Concat(
+		diffChecker.AssertReducerUnsupportedViolations(
+			d,
+			r.GetUnsupportedRules("kubernetes"),
+		),
+		diffChecker.AssertReducerUnsupportedViolations(
+			d,
+			r.GetUnsupportedRules("distribution"),
+		),
+	)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%w: %w", errUnsupported, errors.Join(errs...))

--- a/internal/git/flag.go
+++ b/internal/git/flag.go
@@ -20,7 +20,7 @@ func (p *ProtocolFlag) String() string {
 }
 
 func (p *ProtocolFlag) Set(value string) error {
-	protocol, err := NewProtocol(value)
+	protocol, err := ParseProtocol(value)
 	if err != nil {
 		return fmt.Errorf("%w: \"%s\". Supported protocols are %s",
 			ErrUnsupportedGitProtocol,

--- a/internal/git/protocols.go
+++ b/internal/git/protocols.go
@@ -14,26 +14,9 @@ var ErrUnsupportedGitProtocol = errors.New("unsupported git protocol")
 
 type Protocol string
 
-func NewProtocol(protocol string) (Protocol, error) {
-	switch protocol {
-	case "ssh":
-		return ProtocolSSH, nil
-
-	case "https":
-		return ProtocolHTTPS, nil
-
-	default:
-		return "", fmt.Errorf("%w: %s. Supported protocols are %s",
-			ErrUnsupportedGitProtocol,
-			protocol,
-			strings.Join(ProtocolsS(), ", "),
-		)
-	}
-}
-
 const (
-	ProtocolSSH   = Protocol("ssh")
-	ProtocolHTTPS = Protocol("https")
+	ProtocolSSH   Protocol = "ssh"
+	ProtocolHTTPS Protocol = "https"
 )
 
 // Protocols returns a slice of Protocols that are supported.
@@ -46,10 +29,25 @@ func Protocols() []Protocol {
 
 // ProtocolsS returns a slice of Strings representation of the Protocols that are supported.
 func ProtocolsS() []string {
-	protocols := []string{}
-	for _, p := range Protocols() {
-		protocols = append(protocols, string(p))
+	ps := Protocols()
+	result := make([]string, len(ps))
+	for i, p := range ps {
+		result[i] = string(p)
 	}
 
-	return protocols
+	return result
+}
+
+func ParseProtocol(protocol string) (Protocol, error) {
+	for _, p := range Protocols() {
+		if string(p) == protocol {
+			return p, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s. Supported protocols are %s",
+		ErrUnsupportedGitProtocol,
+		protocol,
+		strings.Join(ProtocolsS(), ", "),
+	)
 }

--- a/internal/tool/awscli/runner.go
+++ b/internal/tool/awscli/runner.go
@@ -6,6 +6,7 @@ package awscli
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 
@@ -54,8 +55,7 @@ func (r *Runner) Ec2(sensitive bool, sub string, params ...string) (string, erro
 }
 
 func (r *Runner) S3(sensitive bool, params ...string) (string, error) {
-	args := []string{"s3"}
-	args = append(args, params...)
+	args := slices.Concat([]string{"s3"}, params)
 
 	cmd, id := r.newCmd(args, sensitive)
 	defer r.deleteCmd(id)
@@ -69,8 +69,7 @@ func (r *Runner) S3(sensitive bool, params ...string) (string, error) {
 }
 
 func (r *Runner) S3Api(sensitive bool, params ...string) (string, error) {
-	args := []string{"s3api"}
-	args = append(args, params...)
+	args := slices.Concat([]string{"s3api"}, params)
 
 	cmd, id := r.newCmd(args, sensitive)
 	defer r.deleteCmd(id)
@@ -84,8 +83,7 @@ func (r *Runner) S3Api(sensitive bool, params ...string) (string, error) {
 }
 
 func (r *Runner) Eks(sensitive bool, params ...string) (string, error) {
-	args := []string{"eks"}
-	args = append(args, params...)
+	args := slices.Concat([]string{"eks"}, params)
 
 	cmd, id := r.newCmd(args, sensitive)
 	defer r.deleteCmd(id)
@@ -99,8 +97,7 @@ func (r *Runner) Eks(sensitive bool, params ...string) (string, error) {
 }
 
 func (r *Runner) Configure(sensitive bool, params ...string) (string, error) {
-	args := []string{"configure"}
-	args = append(args, params...)
+	args := slices.Concat([]string{"configure"}, params)
 
 	cmd, id := r.newCmd(args, sensitive)
 	defer r.deleteCmd(id)

--- a/internal/x/exec/executor.go
+++ b/internal/x/exec/executor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 )
 
 type Executor interface {
@@ -40,8 +41,10 @@ func NewFakeExecutor(testHelperProcessFn string) *FakeExecutor {
 }
 
 func (fe *FakeExecutor) Command(name string, arg ...string) *exec.Cmd {
-	cs := []string{"-test.run=" + fe.testHelperProcessFn, "--", filepath.Base(name)}
-	cs = append(cs, arg...)
+	cs := slices.Concat(
+		[]string{"-test.run=" + fe.testHelperProcessFn, "--", filepath.Base(name)},
+		arg,
+	)
 
 	//nolint:noctx // it requires a massive refactor
 	return exec.Command(os.Args[0], cs...)

--- a/internal/x/logrus/config.go
+++ b/internal/x/logrus/config.go
@@ -51,7 +51,8 @@ func newFormatterHook(writer io.Writer, formatter logrus.Formatter, logLevels []
 	}
 }
 
-func InitLog(logFile *os.File, debug, disableColors bool) { //nolint:revive // debug is a boolean flag
+//revive:disable:flag-parameter // debug is a boolean flag
+func InitLog(logFile *os.File, debug, disableColors bool) {
 	logrus.SetOutput(io.Discard)
 
 	stdLevels := []logrus.Level{

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.7.2"
+golangci-lint = "2.8.0"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"

--- a/pkg/diffs/checker.go
+++ b/pkg/diffs/checker.go
@@ -190,7 +190,7 @@ func ExpandMapChanges(changelog r3diff.Changelog) r3diff.Changelog {
 func expandChange(c r3diff.Change) []r3diff.Change {
 	// Object added wholesale: To is a map, From is nil.
 	if m, ok := c.To.(map[string]any); ok && len(m) > 0 {
-		var res []r3diff.Change
+		res := make([]r3diff.Change, 0, len(m))
 		for k, v := range m {
 			res = append(res, expandChange(r3diff.Change{
 				Type: c.Type,
@@ -205,7 +205,7 @@ func expandChange(c r3diff.Change) []r3diff.Change {
 
 	// Object removed wholesale: From is a map, To is nil.
 	if m, ok := c.From.(map[string]any); ok && len(m) > 0 {
-		var res []r3diff.Change
+		res := make([]r3diff.Change, 0, len(m))
 		for k, v := range m {
 			res = append(res, expandChange(r3diff.Change{
 				Type: c.Type,
@@ -222,10 +222,7 @@ func expandChange(c r3diff.Change) []r3diff.Change {
 }
 
 func childPath(parent []string, key string) []string {
-	child := make([]string, 0, len(parent)+1)
-	child = append(child, parent...)
-	child = append(child, key)
-	return child
+	return append(slices.Clone(parent), key)
 }
 
 func isImmutablePathChanged(change r3diff.Change, immutables []string) bool {


### PR DESCRIPTION
### Summary 💡

Update golangci-lint to 2.8.0


### Description 📝

Update golangci-lint to 2.8.0 + code alignments to new linters.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

