### PR TITLE
chore: update golangci-lint to 2.10.1

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -99,8 +99,10 @@ linters:
         - require-stdlib-doclink
     gosec:
       excludes:
-        - G204
-        - G101
+        - G101 # hardcoded credentials: false positives on token-shaped strings.
+        - G204 # subprocess launched with variable: furyctl runs external tools (terraform, kubectl, etc.) by design.
+        - G703 # path traversal via taint: paths come from user-provided furyctl.yaml or env (kubeconfig).
+        - G704 # SSRF via taint: URLs are hardcoded or from user config / curated distribution manifest; CLI tool by design.
     grouper:
       const-require-single-const: true
       const-require-grouping: false

--- a/cmd/serve/status_table.go
+++ b/cmd/serve/status_table.go
@@ -244,6 +244,7 @@ func (t *nodeStatusTable) termWidth() int {
 		return 0
 	}
 
+	//nolint:gosec // G115: fd fits in int on all supported platforms.
 	w, _, err := term.GetSize(int(f.Fd()))
 	if err != nil || w <= 0 {
 		return 0

--- a/internal/x/exec/executor.go
+++ b/internal/x/exec/executor.go
@@ -46,6 +46,6 @@ func (fe *FakeExecutor) Command(name string, arg ...string) *exec.Cmd {
 		arg,
 	)
 
-	//nolint:noctx // it requires a massive refactor
+	//nolint:gosec,noctx // G702: os.Args[0] is the test binary, never user-controlled. noctx: requires a massive refactor.
 	return exec.Command(os.Args[0], cs...)
 }

--- a/internal/x/exec/tty.go
+++ b/internal/x/exec/tty.go
@@ -22,5 +22,6 @@ func AnimationDisabled() bool {
 // ShouldAnimate reports whether f can carry animated, in-place terminal output: animation must not
 // be disabled (see AnimationDisabled) and f must be a real terminal.
 func ShouldAnimate(f *os.File) bool {
+	//nolint:gosec // G115: fd fits in int on all supported platforms.
 	return !AnimationDisabled() && term.IsTerminal(int(f.Fd()))
 }

--- a/internal/x/io/liveregion.go
+++ b/internal/x/io/liveregion.go
@@ -43,12 +43,14 @@ func NewLiveRegion(f *os.File, disable bool) *LiveRegion {
 		width:    0,
 	}
 
+	//nolint:gosec // G115: fd fits in int on all supported platforms.
 	if disable || f == nil || !term.IsTerminal(int(f.Fd())) {
 		return lr
 	}
 
 	lr.enabled = true
 
+	//nolint:gosec // G115: fd fits in int on all supported platforms.
 	if w, _, err := term.GetSize(int(f.Fd())); err == nil && w > minRegionWidth {
 		lr.width = w
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.9.0"
+golangci-lint = "2.10.1"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"


### PR DESCRIPTION
### Summary 💡

Update golangci-lint to 2.10.1


### Description 📝

Update golangci-lint to 2.10.1 + code alignments to new linters.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

