### PR TITLE
 chore: update golangci-lint to 2.11.4

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -103,6 +103,11 @@ linters:
         - G204 # subprocess launched with variable: furyctl runs external tools (terraform, kubectl, etc.) by design.
         - G703 # path traversal via taint: paths come from user-provided furyctl.yaml or env (kubeconfig).
         - G704 # SSRF via taint: URLs are hardcoded or from user config / curated distribution manifest; CLI tool by design.
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment # this is a CLI, not a long-running process; struct memory savings are irrelevant
+        - shadow # too noisy
     grouper:
       const-require-single-const: true
       const-require-grouping: false

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/distribution.go
@@ -135,7 +135,7 @@ func (d *Distribution) Exec(
 	startFrom string,
 	upgradeState *upgrade.State,
 ) error {
-	timestamp := time.Now().Unix()
+	timestampSec := time.Now().Unix()
 
 	logrus.Info("Installing SIGHUP Distribution...")
 
@@ -163,7 +163,7 @@ func (d *Distribution) Exec(
 		upgradeState,
 		preTfMerger,
 		furyctlMerger,
-		timestamp,
+		timestampSec,
 	); err != nil {
 		return fmt.Errorf("error running core distribution phase: %w", err)
 	}
@@ -251,14 +251,14 @@ func (d *Distribution) coreDistribution(
 	upgradeState *upgrade.State,
 	preTfMerger *merge.Merger,
 	furyctlMerger *merge.Merger,
-	timestamp int64,
+	timestampSec int64,
 ) error {
 	if startFrom != cluster.OperationSubPhasePostDistribution {
 		if err := d.runReducers(rdcs, tfCfg, LifecyclePreTf, []string{"manifests", ".gitignore"}); err != nil {
 			return fmt.Errorf("error running pre-tf reducers: %w", err)
 		}
 
-		if _, err := d.TFRunner.Plan(timestamp); err != nil && !d.DryRun {
+		if _, err := d.TFRunner.Plan(timestampSec); err != nil && !d.DryRun {
 			return fmt.Errorf("error running terraform plan: %w", err)
 		}
 
@@ -298,7 +298,7 @@ func (d *Distribution) coreDistribution(
 
 		logrus.Warn("Creating cloud resources, this could take a while...")
 
-		if err := d.TFRunner.Apply(timestamp); err != nil {
+		if err := d.TFRunner.Apply(timestampSec); err != nil {
 			return fmt.Errorf("cannot create cloud resources: %w", err)
 		}
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/infrastructure.go
@@ -85,7 +85,7 @@ func (i *Infrastructure) Self() *cluster.OperationPhase {
 func (i *Infrastructure) Exec(startFrom string, upgradeState *upgrade.State) error {
 	logrus.Info("Creating infrastructure...")
 
-	timestamp := time.Now().Unix()
+	timestampSec := time.Now().Unix()
 
 	if err := i.Prepare(); err != nil {
 		return fmt.Errorf("error preparing infrastructure phase: %w", err)
@@ -99,7 +99,7 @@ func (i *Infrastructure) Exec(startFrom string, upgradeState *upgrade.State) err
 		return fmt.Errorf("error running pre-infrastructure phase: %w", err)
 	}
 
-	if err := i.coreInfrastructure(startFrom, upgradeState, timestamp); err != nil {
+	if err := i.coreInfrastructure(startFrom, upgradeState, timestampSec); err != nil {
 		return fmt.Errorf("error running core infrastructure phase: %w", err)
 	}
 
@@ -152,10 +152,10 @@ func (i *Infrastructure) preInfrastructure(
 func (i *Infrastructure) coreInfrastructure(
 	startFrom string,
 	upgradeState *upgrade.State,
-	timestamp int64,
+	timestampSec int64,
 ) error {
 	if startFrom != cluster.OperationSubPhasePostInfrastructure {
-		plan, err := i.tfRunner.Plan(timestamp)
+		plan, err := i.tfRunner.Plan(timestampSec)
 		if err != nil {
 			return fmt.Errorf("error running terraform/tofu plan: %w", err)
 		}
@@ -189,7 +189,7 @@ func (i *Infrastructure) coreInfrastructure(
 
 		logrus.Warn("Creating cloud resources, this could take a while...")
 
-		if err := i.tfRunner.Apply(timestamp); err != nil {
+		if err := i.tfRunner.Apply(timestampSec); err != nil {
 			if i.upgrade.Enabled {
 				upgradeState.Phases.Infrastructure.Status = upgrade.PhaseStatusFailed
 			}

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/kubernetes.go
@@ -107,7 +107,7 @@ func (k *Kubernetes) Self() *cluster.OperationPhase {
 }
 
 func (k *Kubernetes) Exec(startFrom string, upgradeState *upgrade.State) error {
-	timestamp := time.Now().Unix()
+	timestampSec := time.Now().Unix()
 
 	logrus.Info("Configuring SIGHUP Distribution cluster...")
 
@@ -123,7 +123,7 @@ func (k *Kubernetes) Exec(startFrom string, upgradeState *upgrade.State) error {
 		return fmt.Errorf("error running pre-kubernetes phase: %w", err)
 	}
 
-	if err := k.coreKubernetes(startFrom, upgradeState, timestamp); err != nil {
+	if err := k.coreKubernetes(startFrom, upgradeState, timestampSec); err != nil {
 		return fmt.Errorf("error running core kubernetes phase: %w", err)
 	}
 
@@ -195,10 +195,10 @@ func (k *Kubernetes) preKubernetes(
 func (k *Kubernetes) coreKubernetes(
 	startFrom string,
 	upgradeState *upgrade.State,
-	timestamp int64,
+	timestampSec int64,
 ) error {
 	if startFrom != cluster.OperationSubPhasePostKubernetes {
-		plan, err := k.tfRunner.Plan(timestamp)
+		plan, err := k.tfRunner.Plan(timestampSec)
 		if err != nil {
 			return fmt.Errorf("error running terraform plan: %w", err)
 		}
@@ -249,7 +249,7 @@ func (k *Kubernetes) coreKubernetes(
 
 		logrus.Warn("Creating cloud resources, this could take a while...")
 
-		if err := k.tfRunner.Apply(timestamp); err != nil {
+		if err := k.tfRunner.Apply(timestampSec); err != nil {
 			if k.upgrade.Enabled {
 				upgradeState.Phases.Kubernetes.Status = upgrade.PhaseStatusFailed
 			}

--- a/internal/apis/kfd/v1alpha2/ekscluster/delete/distribution.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/delete/distribution.go
@@ -138,9 +138,9 @@ func (d *Distribution) Exec() error {
 	}
 
 	if d.dryRun {
-		timestamp := time.Now().Unix()
+		timestampSec := time.Now().Unix()
 
-		if _, err := d.TFRunner.Plan(timestamp, "-destroy"); err != nil {
+		if _, err := d.TFRunner.Plan(timestampSec, "-destroy"); err != nil {
 			return fmt.Errorf("error running terraform plan: %w", err)
 		}
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/delete/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/delete/kubernetes.go
@@ -91,7 +91,7 @@ func NewKubernetes(
 func (k *Kubernetes) Exec() error {
 	logrus.Info("Deleting SIGHUP Distribution cluster...")
 
-	timestamp := time.Now().Unix()
+	timestampSec := time.Now().Unix()
 
 	if err := k.Prepare(); err != nil {
 		return fmt.Errorf("error preparing kubernetes phase: %w", err)
@@ -118,12 +118,12 @@ func (k *Kubernetes) Exec() error {
 		return fmt.Errorf("error running terraform init: %w", err)
 	}
 
-	if _, err := k.tfRunner.Plan(timestamp, "-destroy"); err != nil {
+	if _, err := k.tfRunner.Plan(timestampSec, "-destroy"); err != nil {
 		return fmt.Errorf("error running terraform plan: %w", err)
 	}
 
 	if k.DryRun {
-		if _, err := k.tfRunner.Plan(timestamp, "-destroy"); err != nil {
+		if _, err := k.tfRunner.Plan(timestampSec, "-destroy"); err != nil {
 			return fmt.Errorf("error running terraform plan: %w", err)
 		}
 

--- a/internal/clusterinfo/collector.go
+++ b/internal/clusterinfo/collector.go
@@ -12,7 +12,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -290,9 +290,7 @@ func (c *Collector) fetchNodes() (*NodesSummary, error) {
 		totals.RAMGb += ramGb
 	}
 
-	sort.Slice(roleOrder, func(i, j int) bool {
-		return roleSort(roleOrder[i], roleOrder[j])
-	})
+	slices.SortFunc(roleOrder, roleSort)
 
 	roles := make([]NodeRoleGroup, 0, len(roleOrder))
 	for _, r := range roleOrder {
@@ -664,37 +662,45 @@ func primaryRole(labels map[string]string) string {
 		return roleNone
 	}
 
-	sort.Slice(roles, func(i, j int) bool { return roleSort(roles[i], roles[j]) })
+	slices.SortFunc(roles, roleSort)
 
 	return roles[0]
 }
 
-func roleSort(a, b string) bool {
+func roleSort(a, b string) int {
+	if a == b {
+		return 0
+	}
+
 	if a == roleControlPlane {
-		return true
+		return -1
 	}
 
 	if b == roleControlPlane {
-		return false
+		return 1
 	}
 
 	if a == roleMaster {
-		return true
+		return -1
 	}
 
 	if b == roleMaster {
-		return false
+		return 1
 	}
 
 	if a == roleNone {
-		return false
+		return 1
 	}
 
 	if b == roleNone {
-		return true
+		return -1
 	}
 
-	return a < b
+	if a < b {
+		return -1
+	}
+
+	return 1
 }
 
 // parseCPU converts a Kubernetes CPU quantity string (e.g. "4" or "500m") to an integer vCPU count.

--- a/internal/clusterinfo/collector_test.go
+++ b/internal/clusterinfo/collector_test.go
@@ -8,7 +8,7 @@
 package clusterinfo
 
 import (
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -52,7 +52,7 @@ func TestRoleSort(t *testing.T) {
 	input := []string{"<none>", "worker", "master", "infra", "control-plane", "b", "a"}
 	want := []string{"control-plane", "master", "a", "b", "infra", "worker", "<none>"}
 
-	sort.Slice(input, func(i, j int) bool { return roleSort(input[i], input[j]) })
+	slices.SortFunc(input, roleSort)
 
 	require.Equal(t, want, input, "roleSort order")
 }

--- a/internal/distribution/supported_versions.go
+++ b/internal/distribution/supported_versions.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -43,6 +42,28 @@ func IsNotRelease(ghRelease git.Release) bool {
 	return false
 }
 
+func releaseSort(a, b git.Release) int {
+	aVersion, err := VersionFromString(a.TagName)
+	if err != nil {
+		return 1
+	}
+
+	bVersion, err := VersionFromString(b.TagName)
+	if err != nil {
+		return -1
+	}
+
+	if bVersion.LessThan(&aVersion) {
+		return -1
+	}
+
+	if aVersion.LessThan(&bVersion) {
+		return 1
+	}
+
+	return 0
+}
+
 // GetSupportedVersions retrieves all distro releases filtering out prereleases and invalid versions.
 func GetSupportedVersions(ghClient git.RepoClient) ([]KFDRelease, error) {
 	releases := []KFDRelease{}
@@ -53,22 +74,7 @@ func GetSupportedVersions(ghClient git.RepoClient) ([]KFDRelease, error) {
 		return releases, fmt.Errorf("error getting releases from GitHub: %w", err)
 	}
 
-	sort.Slice(ghReleases, func(i, j int) bool {
-		iRelease := ghReleases[i]
-		jRelease := ghReleases[j]
-
-		iVersion, err := VersionFromString(iRelease.TagName)
-		if err != nil {
-			return false
-		}
-
-		jVersion, err := VersionFromString(jRelease.TagName)
-		if err != nil {
-			return true
-		}
-
-		return jVersion.LessThan(&iVersion)
-	})
+	slices.SortFunc(ghReleases, releaseSort)
 
 	ghReleases = slices.DeleteFunc(ghReleases, IsReleaseUnsupportedByFuryctl)
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.10.1"
+golangci-lint = "2.11.4"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"


### PR DESCRIPTION
### Summary 💡

Update golangci-lint to 2.11.4


### Description 📝

Update golangci-lint to 2.11.4 + code alignments to new linters.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update to next version

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

