### PR TITLE
chore: update golangci-lint to 2.12.2

### DIFF
--- a/.rules/.golangci.yml
+++ b/.rules/.golangci.yml
@@ -14,6 +14,8 @@ linters:
     - depguard
     - exhaustruct
     - forbidigo
+    - goconst # flags repeated string literals that are not actually meant to be a shared constant
+    - gomodguard # deprecated, replaced by gomodguard_v2 since golangci-lint v2.12.0
     - ireturn
     - maintidx
     - nlreturn # too strict and mostly code is not more readable
@@ -102,7 +104,6 @@ linters:
         - G101 # hardcoded credentials: false positives on token-shaped strings.
         - G204 # subprocess launched with variable: furyctl runs external tools (terraform, kubectl, etc.) by design.
         - G703 # path traversal via taint: paths come from user-provided furyctl.yaml or env (kubeconfig).
-        - G704 # SSRF via taint: URLs are hardcoded or from user config / curated distribution manifest; CLI tool by design.
     govet:
       enable-all: true
       disable:

--- a/cmd/serve/status_table.go
+++ b/cmd/serve/status_table.go
@@ -244,7 +244,6 @@ func (t *nodeStatusTable) termWidth() int {
 		return 0
 	}
 
-	//nolint:gosec // G115: fd fits in int on all supported platforms.
 	w, _, err := term.GetSize(int(f.Fd()))
 	if err != nil || w <= 0 {
 		return 0

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -39,7 +39,7 @@ This guide covers development setup, building from source, and contributing to f
 5. **Find built binary**:
    The built binary will be in the `dist/` directory after running `mise run build`.
 
-> **What gets installed**: `mise install` automatically installs Go 1.25.12, golangci-lint 1.64.8, goreleaser, awscli, addlicense, gofumpt, gci, goimports, formattag, ginkgo, and go-cover-treemap - everything you need for development.
+> **What gets installed**: `mise install` automatically installs Go 1.25.12, golangci-lint 2.12.2, goreleaser, awscli, addlicense, gofumpt, gci, goimports, formattag, ginkgo, and go-cover-treemap - everything you need for development.
 
 ## Development Workflow
 
@@ -49,7 +49,7 @@ The project uses **mise** for task and tool management. Here are the essential c
 
 #### Setup and Tools
 - `mise install`: Installs ALL development tools automatically:
-  - **Native tools**: Go 1.25.12, golangci-lint 1.64.8, goreleaser, awscli 2.15.17
+  - **Native tools**: Go 1.25.12, golangci-lint 2.12.2, goreleaser, awscli 2.15.17
   - **UBI tools**: addlicense v1.1.1, gofumpt v0.6.0  
   - **Go tools**: gci v0.13.4, goimports v0.22.0, formattag v0.0.9, ginkgo v2.19.0, go-cover-treemap v1.4.2
 - `mise run setup`: Downloads and tidies Go module dependencies (`go mod download` + `go mod tidy`).

--- a/internal/x/exec/tty.go
+++ b/internal/x/exec/tty.go
@@ -20,8 +20,7 @@ func AnimationDisabled() bool {
 }
 
 // ShouldAnimate reports whether f can carry animated, in-place terminal output: animation must not
-// be disabled (see AnimationDisabled) and f must be a real terminal.
+// be disabled (see AnimationDisabled), and f must be a real terminal.
 func ShouldAnimate(f *os.File) bool {
-	//nolint:gosec // G115: fd fits in int on all supported platforms.
 	return !AnimationDisabled() && term.IsTerminal(int(f.Fd()))
 }

--- a/internal/x/io/liveregion.go
+++ b/internal/x/io/liveregion.go
@@ -43,14 +43,12 @@ func NewLiveRegion(f *os.File, disable bool) *LiveRegion {
 		width:    0,
 	}
 
-	//nolint:gosec // G115: fd fits in int on all supported platforms.
 	if disable || f == nil || !term.IsTerminal(int(f.Fd())) {
 		return lr
 	}
 
 	lr.enabled = true
 
-	//nolint:gosec // G115: fd fits in int on all supported platforms.
 	if w, _, err := term.GetSize(int(f.Fd())); err == nil && w > minRegionWidth {
 		lr.width = w
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.25.12"
-golangci-lint = "2.11.4"
+golangci-lint = "2.12.2"
 goreleaser = "2.15.4"
 awscli = "2.15.17"
 "ubi:google/addlicense" = "v1.1.1"

--- a/pkg/x/map/build.go
+++ b/pkg/x/map/build.go
@@ -52,7 +52,7 @@ func (b *Builder) FromStruct(s any, tagType string) map[any]any {
 
 		val := sVal.Field(i)
 
-		if val.Kind() == reflect.Ptr {
+		if val.Kind() == reflect.Pointer {
 			val = reflect.Indirect(val)
 		}
 


### PR DESCRIPTION
### Summary 💡

Update golangci-lint to 2.12.2


### Description 📝

Update golangci-lint to 2.12.2 + code alignments to new linters.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- mise run lint

### Future work 🔧

Update mise.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

