### PR TITLE
feat(immutable): validate node roles

### DIFF
--- a/docs/releases/v0.35.1.md
+++ b/docs/releases/v0.35.1.md
@@ -6,6 +6,7 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 
 - [[#696](https://github.com/sighupio/furyctl/pull/696)] Immutable: show a dynamic table for the nodes provisioning phase instead of single line logs so the user does not need to mentally track the status of the nodes.
 - [[#710](https://github.com/sighupio/furyctl/pull/710)] Immutable: add support for `furyctl dump template` command.
+- [[#725](https://github.com/sighupio/furyctl/pull/725)] Immutable: validate nodes have one and only one role and that all nodes are managed by furyctl.
 
 ## Bug fixes 🐞
 

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
@@ -101,36 +101,6 @@ type assetDownloader struct {
 	assetsPath     string
 }
 
-// getNodeRole determines the role of a node based on its hostname by checking the cluster configuration.
-// It returns "controlplane", "loadbalancer", "etcd", or "worker".
-func (i *Infrastructure) getNodeRole(node string) string {
-	// There must be at least one control plane member.
-	for _, controlPlaneNode := range i.furyctlConf.Spec.Kubernetes.ControlPlane.Members {
-		if node == controlPlaneNode.Hostname {
-			return "controlplane"
-		}
-	}
-
-	if i.furyctlConf.Spec.Infrastructure.LoadBalancers != nil &&
-		i.furyctlConf.Spec.Infrastructure.LoadBalancers.Members != nil {
-		for _, loadBalancerNode := range i.furyctlConf.Spec.Infrastructure.LoadBalancers.Members {
-			if node == loadBalancerNode.Hostname {
-				return "loadbalancer"
-			}
-		}
-	}
-
-	if i.furyctlConf.Spec.Kubernetes.Etcd != nil && i.furyctlConf.Spec.Kubernetes.Etcd.Members != nil {
-		for _, etcdNode := range i.furyctlConf.Spec.Kubernetes.Etcd.Members {
-			if node == etcdNode.Hostname {
-				return "etcd"
-			}
-		}
-	}
-
-	return "worker"
-}
-
 // rawNodesByHostname indexes the nodes from an already-parsed furyctl.yaml (as an
 // opaque map) by hostname.
 //
@@ -382,7 +352,9 @@ func (i *Infrastructure) renderButaneTemplates() error {
 	}
 
 	for _, node := range i.furyctlConf.Spec.Infrastructure.Nodes {
-		nodeRole := i.getNodeRole(node.Hostname)
+		// Roles are guaranteed assigned by the ExtraSchemaValidator at validate time.
+		nodeRole := i.furyctlConf.NodeRole(node.Hostname)
+
 		normalizedMAC := strings.ToUpper(strings.ReplaceAll(string(node.MacAddress), ":", "-"))
 
 		rawNode, ok := rawNodes[node.Hostname]

--- a/internal/apis/kfd/v1alpha2/immutable/public/schema.go
+++ b/internal/apis/kfd/v1alpha2/immutable/public/schema.go
@@ -94,6 +94,13 @@ type SpecKubernetes struct {
 	Advanced     *SpecKubernetesAdvanced    `yaml:"advanced,omitempty"`
 	ControlPlane SpecKubernetesControlPlane `yaml:"controlPlane"`
 	Etcd         *SpecKubernetesEtcd        `yaml:"etcd,omitempty"`
+	NodeGroups   []SpecKubernetesNodeGroup  `yaml:"nodeGroups,omitempty"`
+}
+
+// SpecKubernetesNodeGroup assigns nodes the worker role by hostname.
+type SpecKubernetesNodeGroup struct {
+	Name  string   `yaml:"name,omitempty"`
+	Nodes []Member `yaml:"nodes,omitempty"`
 }
 
 type SpecKubernetesAdvanced struct {
@@ -116,4 +123,60 @@ type SpecKubernetesEtcd struct {
 // reads only the hostname.
 type Member struct {
 	Hostname string `yaml:"hostname"`
+}
+
+// Node roles. The value also names the node's butane template (<role>.bu.tpl).
+const (
+	NodeRoleNone         = "" // hostname not referenced by any role list
+	NodeRoleControlPlane = "controlplane"
+	NodeRoleLoadBalancer = "loadbalancer"
+	NodeRoleEtcd         = "etcd"
+	NodeRoleWorker       = "worker"
+)
+
+// RoleAssignment pairs a hostname with a role it is listed under.
+type RoleAssignment struct {
+	Hostname string
+	Role     string
+}
+
+// RoleAssignments returns one (hostname, role) pair per membership-list entry, in
+// role order (control plane, load balancer, etcd, node groups). Single source of
+// truth for role derivation; a new role list only needs adding here.
+func (c *ImmutableKfdV1Alpha2) RoleAssignments() []RoleAssignment {
+	var assignments []RoleAssignment
+
+	add := func(role string, members []Member) {
+		for _, m := range members {
+			assignments = append(assignments, RoleAssignment{Hostname: m.Hostname, Role: role})
+		}
+	}
+
+	add(NodeRoleControlPlane, c.Spec.Kubernetes.ControlPlane.Members)
+
+	if lb := c.Spec.Infrastructure.LoadBalancers; lb != nil {
+		add(NodeRoleLoadBalancer, lb.Members)
+	}
+
+	if etcd := c.Spec.Kubernetes.Etcd; etcd != nil {
+		add(NodeRoleEtcd, etcd.Members)
+	}
+
+	for _, ng := range c.Spec.Kubernetes.NodeGroups {
+		add(NodeRoleWorker, ng.Nodes)
+	}
+
+	return assignments
+}
+
+// NodeRole returns hostname's role, or NodeRoleNone if none. Role order makes the
+// first match the effective role (a control-plane host stays controlplane).
+func (c *ImmutableKfdV1Alpha2) NodeRole(hostname string) string {
+	for _, ra := range c.RoleAssignments() {
+		if ra.Hostname == hostname {
+			return ra.Role
+		}
+	}
+
+	return NodeRoleNone
 }

--- a/internal/apis/kfd/v1alpha2/immutable/public/schema_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/public/schema_test.go
@@ -102,3 +102,52 @@ spec:
 		t.Errorf("LoadBalancers.Members did not decode")
 	}
 }
+
+// TestNodeRole covers role derivation from the four role lists and NodeRoleNone
+// for a node not referenced by any of them.
+func TestNodeRole(t *testing.T) {
+	t.Parallel()
+
+	c := public.ImmutableKfdV1Alpha2{
+		Spec: public.Spec{
+			Infrastructure: public.SpecInfrastructure{
+				LoadBalancers: &public.SpecInfrastructureLoadBalancers{
+					Members: []public.Member{{Hostname: "lb01"}},
+				},
+			},
+			Kubernetes: public.SpecKubernetes{
+				ControlPlane: public.SpecKubernetesControlPlane{
+					Members: []public.Member{{Hostname: "ctrl01"}},
+				},
+				Etcd: &public.SpecKubernetesEtcd{
+					Members: []public.Member{{Hostname: "etcd01"}},
+				},
+				NodeGroups: []public.SpecKubernetesNodeGroup{
+					{Name: "workers", Nodes: []public.Member{{Hostname: "worker01"}}},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc     string
+		hostname string
+		want     string
+	}{
+		{desc: "control plane member", hostname: "ctrl01", want: public.NodeRoleControlPlane},
+		{desc: "load balancer member", hostname: "lb01", want: public.NodeRoleLoadBalancer},
+		{desc: "etcd member", hostname: "etcd01", want: public.NodeRoleEtcd},
+		{desc: "node group member", hostname: "worker01", want: public.NodeRoleWorker},
+		{desc: "unassigned node has no role", hostname: "orphan01", want: public.NodeRoleNone},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if got := c.NodeRole(tC.hostname); got != tC.want {
+				t.Errorf("NodeRole(%q) = %q, want %q", tC.hostname, got, tC.want)
+			}
+		})
+	}
+}

--- a/internal/apis/kfd/v1alpha2/immutable/schema.go
+++ b/internal/apis/kfd/v1alpha2/immutable/schema.go
@@ -4,8 +4,136 @@
 
 package immutable
 
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable/public"
+	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
+)
+
+// roleListPaths names the config paths that assign roles, shared by the messages below.
+const roleListPaths = ".spec.kubernetes.controlPlane.members, .spec.kubernetes.etcd.members, " +
+	".spec.kubernetes.nodeGroups[].nodes or .spec.infrastructure.loadBalancers.members"
+
+var (
+	ErrNodeWithoutRole = errors.New(
+		"every node defined in .spec.infrastructure.nodes must be assigned at least one role " +
+			"(referenced in " + roleListPaths + ")",
+	)
+	ErrNodeNotDefined = errors.New(
+		"every hostname referenced by a role (" + roleListPaths +
+			") must have a matching entry in .spec.infrastructure.nodes",
+	)
+	ErrNodeMultipleRoles = errors.New(
+		"a node must be assigned a single role, but these hostnames are referenced by more than one of " +
+			roleListPaths +
+			" (for stacked etcd omit the .spec.kubernetes.etcd block instead of repeating hostnames)",
+	)
+)
+
 type ExtraSchemaValidator struct{}
 
-func (*ExtraSchemaValidator) Validate(_ string) error {
+func (*ExtraSchemaValidator) Validate(confPath string) error {
+	conf, err := yamlx.FromFileV3[public.ImmutableKfdV1Alpha2](confPath)
+	if err != nil {
+		return err
+	}
+
+	// Cross-check node lists and role lists: every node has a role, every referenced
+	// hostname is a defined node, and no hostname holds more than one role. Report
+	// them together to surface all issues at once.
+	return errors.Join(
+		validateNodeRoles(&conf),
+		validateNodeReferences(&conf),
+		validateSingleRole(&conf),
+	)
+}
+
+// validateNodeRoles asserts every node in .spec.infrastructure.nodes is assigned
+// a role; an unreferenced node has no role (public.NodeRole returns NodeRoleNone).
+func validateNodeRoles(conf *public.ImmutableKfdV1Alpha2) error {
+	var orphans []string
+
+	for _, node := range conf.Spec.Infrastructure.Nodes {
+		if conf.NodeRole(node.Hostname) == public.NodeRoleNone {
+			orphans = append(orphans, node.Hostname)
+		}
+	}
+
+	if len(orphans) > 0 {
+		return fmt.Errorf("%w: %s", ErrNodeWithoutRole, strings.Join(orphans, ", "))
+	}
+
+	return nil
+}
+
+// validateNodeReferences asserts every hostname referenced by a role list has a
+// matching entry in .spec.infrastructure.nodes.
+func validateNodeReferences(conf *public.ImmutableKfdV1Alpha2) error {
+	defined := make(map[string]struct{}, len(conf.Spec.Infrastructure.Nodes))
+	for _, node := range conf.Spec.Infrastructure.Nodes {
+		defined[node.Hostname] = struct{}{}
+	}
+
+	var (
+		dangling []string
+		seen     = make(map[string]struct{})
+	)
+
+	for _, ra := range conf.RoleAssignments() {
+		if _, ok := defined[ra.Hostname]; ok {
+			continue
+		}
+
+		// A hostname wrongly listed under several roles (see validateSingleRole)
+		// would recur here; report it once.
+		if _, dup := seen[ra.Hostname]; dup {
+			continue
+		}
+
+		seen[ra.Hostname] = struct{}{}
+		dangling = append(dangling, ra.Hostname)
+	}
+
+	if len(dangling) > 0 {
+		return fmt.Errorf("%w: %s", ErrNodeNotDefined, strings.Join(dangling, ", "))
+	}
+
+	return nil
+}
+
+// validateSingleRole asserts no hostname is referenced by more than one role list.
+// Roles are gathered per hostname (first-seen order) for a message like
+// "ctrl01 (controlplane, etcd)".
+func validateSingleRole(conf *public.ImmutableKfdV1Alpha2) error {
+	roles := make(map[string][]string)
+
+	var order []string
+
+	for _, ra := range conf.RoleAssignments() {
+		if _, seen := roles[ra.Hostname]; !seen {
+			order = append(order, ra.Hostname)
+		}
+
+		if !slices.Contains(roles[ra.Hostname], ra.Role) {
+			roles[ra.Hostname] = append(roles[ra.Hostname], ra.Role)
+		}
+	}
+
+	var offenders []string
+
+	for _, hostname := range order {
+		if len(roles[hostname]) > 1 {
+			offenders = append(offenders, fmt.Sprintf("%s (%s)", hostname, strings.Join(roles[hostname], ", ")))
+		}
+	}
+
+	if len(offenders) > 0 {
+		return fmt.Errorf("%w: %s", ErrNodeMultipleRoles, strings.Join(offenders, ", "))
+	}
+
 	return nil
 }

--- a/internal/apis/kfd/v1alpha2/immutable/schema.go
+++ b/internal/apis/kfd/v1alpha2/immutable/schema.go
@@ -7,7 +7,6 @@ package immutable
 import (
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable/public"
@@ -27,10 +26,11 @@ var (
 		"every hostname referenced by a role (" + roleListPaths +
 			") must have a matching entry in .spec.infrastructure.nodes",
 	)
-	ErrNodeMultipleRoles = errors.New(
-		"a node must be assigned a single role, but these hostnames are referenced by more than one of " +
+	ErrNodeMultipleReferences = errors.New(
+		"a node must be referenced exactly once, but these hostnames appear more than once across " +
 			roleListPaths +
-			" (for stacked etcd omit the .spec.kubernetes.etcd block instead of repeating hostnames)",
+			" (a node belongs to a single role, and to a single node group; for stacked etcd omit " +
+			"the .spec.kubernetes.etcd block instead of repeating hostnames)",
 	)
 )
 
@@ -43,12 +43,12 @@ func (*ExtraSchemaValidator) Validate(confPath string) error {
 	}
 
 	// Cross-check node lists and role lists: every node has a role, every referenced
-	// hostname is a defined node, and no hostname holds more than one role. Report
+	// hostname is a defined node, and no hostname is referenced more than once. Report
 	// them together to surface all issues at once.
 	return errors.Join(
 		validateNodeRoles(&conf),
 		validateNodeReferences(&conf),
-		validateSingleRole(&conf),
+		validateSingleReference(&conf),
 	)
 }
 
@@ -88,8 +88,8 @@ func validateNodeReferences(conf *public.ImmutableKfdV1Alpha2) error {
 			continue
 		}
 
-		// A hostname wrongly listed under several roles (see validateSingleRole)
-		// would recur here; report it once.
+		// A hostname referenced more than once (see validateSingleReference) would
+		// recur here; report it once.
 		if _, dup := seen[ra.Hostname]; dup {
 			continue
 		}
@@ -105,34 +105,32 @@ func validateNodeReferences(conf *public.ImmutableKfdV1Alpha2) error {
 	return nil
 }
 
-// validateSingleRole asserts no hostname is referenced by more than one role list.
-// Roles are gathered per hostname (first-seen order) for a message like
-// "ctrl01 (controlplane, etcd)".
-func validateSingleRole(conf *public.ImmutableKfdV1Alpha2) error {
-	roles := make(map[string][]string)
+// validateSingleReference asserts no hostname is referenced more than once across
+// all role lists (whether by two node groups, or by a control-plane host repeated
+// under a dedicated etcd block).
+func validateSingleReference(conf *public.ImmutableKfdV1Alpha2) error {
+	count := make(map[string]int)
 
 	var order []string
 
 	for _, ra := range conf.RoleAssignments() {
-		if _, seen := roles[ra.Hostname]; !seen {
+		if count[ra.Hostname] == 0 {
 			order = append(order, ra.Hostname)
 		}
 
-		if !slices.Contains(roles[ra.Hostname], ra.Role) {
-			roles[ra.Hostname] = append(roles[ra.Hostname], ra.Role)
-		}
+		count[ra.Hostname]++
 	}
 
 	var offenders []string
 
 	for _, hostname := range order {
-		if len(roles[hostname]) > 1 {
-			offenders = append(offenders, fmt.Sprintf("%s (%s)", hostname, strings.Join(roles[hostname], ", ")))
+		if count[hostname] > 1 {
+			offenders = append(offenders, hostname)
 		}
 	}
 
 	if len(offenders) > 0 {
-		return fmt.Errorf("%w: %s", ErrNodeMultipleRoles, strings.Join(offenders, ", "))
+		return fmt.Errorf("%w: %s", ErrNodeMultipleReferences, strings.Join(offenders, ", "))
 	}
 
 	return nil

--- a/internal/apis/kfd/v1alpha2/immutable/schema_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/schema_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package immutable_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable"
+)
+
+func Test_ExtraSchemaValidator_Validate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc       string
+		confPath   string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			desc:     "every node is assigned at least one role",
+			confPath: "test/schema/all_nodes_have_role.yaml",
+		},
+		{
+			desc:     "a node is not assigned any role",
+			confPath: "test/schema/node_without_role.yaml",
+			wantErr:  true,
+			wantErrMsg: "every node defined in .spec.infrastructure.nodes must be assigned at least one role " +
+				"(referenced in .spec.kubernetes.controlPlane.members, .spec.kubernetes.etcd.members, " +
+				".spec.kubernetes.nodeGroups[].nodes or .spec.infrastructure.loadBalancers.members): orphan01",
+		},
+		{
+			desc:     "multiple nodes are not assigned any role",
+			confPath: "test/schema/multiple_nodes_without_role.yaml",
+			wantErr:  true,
+			wantErrMsg: "every node defined in .spec.infrastructure.nodes must be assigned at least one role " +
+				"(referenced in .spec.kubernetes.controlPlane.members, .spec.kubernetes.etcd.members, " +
+				".spec.kubernetes.nodeGroups[].nodes or .spec.infrastructure.loadBalancers.members): orphan01, orphan02",
+		},
+		{
+			desc:     "a referenced hostname has no matching node",
+			confPath: "test/schema/dangling_node_reference.yaml",
+			wantErr:  true,
+			wantErrMsg: "every hostname referenced by a role (.spec.kubernetes.controlPlane.members, " +
+				".spec.kubernetes.etcd.members, .spec.kubernetes.nodeGroups[].nodes or " +
+				".spec.infrastructure.loadBalancers.members) must have a matching entry in " +
+				".spec.infrastructure.nodes: ghost01",
+		},
+		{
+			desc:     "multiple referenced hostnames have no matching node",
+			confPath: "test/schema/multiple_dangling_node_references.yaml",
+			wantErr:  true,
+			wantErrMsg: "every hostname referenced by a role (.spec.kubernetes.controlPlane.members, " +
+				".spec.kubernetes.etcd.members, .spec.kubernetes.nodeGroups[].nodes or " +
+				".spec.infrastructure.loadBalancers.members) must have a matching entry in " +
+				".spec.infrastructure.nodes: ghost01, ghost02",
+		},
+		{
+			desc:     "both an unassigned node and a dangling reference are reported",
+			confPath: "test/schema/orphan_and_dangling.yaml",
+			wantErr:  true,
+			wantErrMsg: "every node defined in .spec.infrastructure.nodes must be assigned at least one role " +
+				"(referenced in .spec.kubernetes.controlPlane.members, .spec.kubernetes.etcd.members, " +
+				".spec.kubernetes.nodeGroups[].nodes or .spec.infrastructure.loadBalancers.members): orphan01\n" +
+				"every hostname referenced by a role (.spec.kubernetes.controlPlane.members, " +
+				".spec.kubernetes.etcd.members, .spec.kubernetes.nodeGroups[].nodes or " +
+				".spec.infrastructure.loadBalancers.members) must have a matching entry in " +
+				".spec.infrastructure.nodes: ghost01",
+		},
+		{
+			desc:     "a hostname is referenced by more than one role",
+			confPath: "test/schema/node_with_multiple_roles.yaml",
+			wantErr:  true,
+			wantErrMsg: "a node must be assigned a single role, but these hostnames are referenced by more than " +
+				"one of .spec.kubernetes.controlPlane.members, .spec.kubernetes.etcd.members, " +
+				".spec.kubernetes.nodeGroups[].nodes or .spec.infrastructure.loadBalancers.members " +
+				"(for stacked etcd omit the .spec.kubernetes.etcd block instead of repeating hostnames): " +
+				"ctrl01 (controlplane, etcd)",
+		},
+		{
+			desc:     "furyctl config is invalid",
+			confPath: "test/schema/invalid.yaml",
+			wantErr:  true,
+		},
+	}
+
+	esv := &immutable.ExtraSchemaValidator{}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := esv.Validate(tC.confPath)
+
+			if tC.wantErr {
+				require.Error(t, err)
+
+				if tC.wantErrMsg != "" {
+					assert.Equal(t, tC.wantErrMsg, err.Error())
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/apis/kfd/v1alpha2/immutable/schema_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/schema_test.go
@@ -78,11 +78,21 @@ func Test_ExtraSchemaValidator_Validate(t *testing.T) {
 			desc:     "a hostname is referenced by more than one role",
 			confPath: "test/schema/node_with_multiple_roles.yaml",
 			wantErr:  true,
-			wantErrMsg: "a node must be assigned a single role, but these hostnames are referenced by more than " +
-				"one of .spec.kubernetes.controlPlane.members, .spec.kubernetes.etcd.members, " +
+			wantErrMsg: "a node must be referenced exactly once, but these hostnames appear more than once " +
+				"across .spec.kubernetes.controlPlane.members, .spec.kubernetes.etcd.members, " +
 				".spec.kubernetes.nodeGroups[].nodes or .spec.infrastructure.loadBalancers.members " +
-				"(for stacked etcd omit the .spec.kubernetes.etcd block instead of repeating hostnames): " +
-				"ctrl01 (controlplane, etcd)",
+				"(a node belongs to a single role, and to a single node group; for stacked etcd omit " +
+				"the .spec.kubernetes.etcd block instead of repeating hostnames): ctrl01",
+		},
+		{
+			desc:     "a hostname is referenced by more than one node group",
+			confPath: "test/schema/node_in_multiple_node_groups.yaml",
+			wantErr:  true,
+			wantErrMsg: "a node must be referenced exactly once, but these hostnames appear more than once " +
+				"across .spec.kubernetes.controlPlane.members, .spec.kubernetes.etcd.members, " +
+				".spec.kubernetes.nodeGroups[].nodes or .spec.infrastructure.loadBalancers.members " +
+				"(a node belongs to a single role, and to a single node group; for stacked etcd omit " +
+				"the .spec.kubernetes.etcd block instead of repeating hostnames): worker01",
 		},
 		{
 			desc:     "furyctl config is invalid",

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/all_nodes_have_role.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/all_nodes_have_role.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes:
+      - hostname: lb01
+      - hostname: ctrl01
+      - hostname: etcd01
+      - hostname: worker01
+    loadBalancers:
+      members:
+        - hostname: lb01
+  kubernetes:
+    controlPlane:
+      members:
+        - hostname: ctrl01
+    etcd:
+      members:
+        - hostname: etcd01
+    nodeGroups:
+      - name: workers
+        nodes:
+          - hostname: worker01

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/dangling_node_reference.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/dangling_node_reference.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes:
+      - hostname: ctrl01
+  kubernetes:
+    controlPlane:
+      members:
+        - hostname: ctrl01
+        - hostname: ghost01

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/invalid.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/invalid.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes: {

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/multiple_dangling_node_references.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/multiple_dangling_node_references.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes:
+      - hostname: ctrl01
+  kubernetes:
+    controlPlane:
+      members:
+        - hostname: ctrl01
+    nodeGroups:
+      - name: workers
+        nodes:
+          - hostname: ghost01
+          - hostname: ghost02

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/multiple_nodes_without_role.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/multiple_nodes_without_role.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes:
+      - hostname: ctrl01
+      - hostname: orphan01
+      - hostname: orphan02
+  kubernetes:
+    controlPlane:
+      members:
+        - hostname: ctrl01

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/node_in_multiple_node_groups.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/node_in_multiple_node_groups.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes:
+      - hostname: ctrl01
+      - hostname: worker01
+  kubernetes:
+    controlPlane:
+      members:
+        - hostname: ctrl01
+    nodeGroups:
+      - name: workers-a
+        nodes:
+          - hostname: worker01
+      - name: workers-b
+        nodes:
+          - hostname: worker01

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/node_with_multiple_roles.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/node_with_multiple_roles.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes:
+      - hostname: ctrl01
+      - hostname: etcd01
+  kubernetes:
+    controlPlane:
+      members:
+        - hostname: ctrl01
+    etcd:
+      members:
+        - hostname: ctrl01
+        - hostname: etcd01

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/node_without_role.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/node_without_role.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes:
+      - hostname: ctrl01
+      - hostname: orphan01
+  kubernetes:
+    controlPlane:
+      members:
+        - hostname: ctrl01

--- a/internal/apis/kfd/v1alpha2/immutable/test/schema/orphan_and_dangling.yaml
+++ b/internal/apis/kfd/v1alpha2/immutable/test/schema/orphan_and_dangling.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+spec:
+  infrastructure:
+    nodes:
+      - hostname: ctrl01
+      - hostname: orphan01
+  kubernetes:
+    controlPlane:
+      members:
+        - hostname: ctrl01
+        - hostname: ghost01

--- a/test/data/immutable/complete-cluster.yaml
+++ b/test/data/immutable/complete-cluster.yaml
@@ -17,7 +17,12 @@ spec:
 
     ssh:
       username: "core"
-      keyPath: "${HOME}/.ssh/id_ed25519.pub"
+      privateKeyPath: "${HOME}/.ssh/id_ed25519"
+
+    loadBalancers:
+      members:
+        - hostname: "lb01.k8s.test.local"
+        - hostname: "lb02.k8s.test.local"
 
     nodes:
       # Load Balancer Node 1
@@ -149,12 +154,6 @@ spec:
       podCIDR: "10.244.0.0/16"
       serviceCIDR: "10.96.0.0/12"
 
-    loadBalancers:
-      virtualIP: "192.168.1.5"
-      members:
-        - hostname: "lb01.k8s.test.local"
-        - hostname: "lb02.k8s.test.local"
-
     controlPlane:
       address: "192.168.1.5:6443"
       members:
@@ -199,6 +198,7 @@ spec:
 
       dr:
         type: on-premises
+        velero: {}
 
       auth:
         provider:

--- a/test/data/immutable/minimal-cluster.yaml
+++ b/test/data/immutable/minimal-cluster.yaml
@@ -17,7 +17,7 @@ spec:
 
     ssh:
       username: "core"
-      keyPath: "${HOME}/.ssh/id_ed25519.pub"
+      privateKeyPath: "${HOME}/.ssh/id_ed25519"
 
     nodes:
       # Control Plane Node
@@ -64,9 +64,8 @@ spec:
       members:
         - hostname: "ctrl01.k8s.test.local"
 
-    etcd:
-      members:
-        - hostname: "ctrl01.k8s.test.local"
+    # Stacked etcd: co-located on the control-plane nodes by omitting the
+    # .spec.kubernetes.etcd block (an explicit etcd block means dedicated nodes).
 
     nodeGroups:
       - name: workers
@@ -101,6 +100,7 @@ spec:
 
       dr:
         type: on-premises
+        velero: {}
 
       auth:
         provider:


### PR DESCRIPTION
### Summary 💡

Validate that:
- Nodes have one and only one role defined in the furyctl.yaml file.
- There are no references to nodes not managed by furyctl.

### Description 📝

Validate (during the validate config step) that the configuration file for an Immutable cluster that:
- All nodes in `.spec.infrastructre.nodes` have _one and only one_ role assigned (i.e. they are referenced as members of load balancers, the control plane, etcd, or node groups).
- All referenced nodes/members in load balancers, the control plane, etcd, and node groups have the corresponding node definition in `.spec.infrastructre.nodes`; i.e. all nodes are managed by furyctl.

With this validation, there's no more risk of defining a node in `.spec.infrastructre.nodes` and then forgetting to use it afterward as member of some role.

Also, we had a fallback to the worker role when the node was not in the other categories. This is not possible anymore, a node that has no role will trigger an error instead of silently being used as a worker and generating all (wrong and unused) the butane/ignition configuration for it.

New errors:
- **`validateNodeRoles`** — every node in `.spec.infrastructure.nodes` is
  referenced by at least one role list; otherwise it errors listing the orphan
  hostnames.
- **`validateNodeReferences`** — every hostname referenced by a role list has a
  matching `.spec.infrastructure.nodes` entry; dangling references are reported.
- **`validateSingleRole`** — a hostname must not appear in more than one role
  list, e.g. `ctrl01 (controlplane, etcd)`. Stacked etcd is expressed by
  **omitting** the `.spec.kubernetes.etcd` block (etcd co-located on the control
  plane); an explicit `etcd` block means dedicated etcd nodes and must not repeat
  control-plane hostnames.

Supporting changes:

- **Single source of truth for role derivation** in the curated public config
  (`public.ImmutableKfdV1Alpha2`): `RoleAssignments()` enumerates every
  `(hostname, role)` pair in role order, and `NodeRole()` / the validators derive
  from it. Added the `NodeRoleNone/ControlPlane/LoadBalancer/Etcd/Worker`
  constants.
- **Schema**: added `SpecKubernetes.NodeGroups` (`SpecKubernetesNodeGroup`),
  mirroring the distribution's `immutable-kfd-v1alpha2.json`. The four role-list
  paths were verified against that schema (they are exactly its four
  `Spec.Kubernetes.Member` references).



Updated some test cases that had outdated structure.

### Breaking Changes 💔

None, this is the right behaviour, any other configuration should have resulted in an error at runtime (e.g. nodes not being used, configured, etc.) that should have been detected by the operator.

### Tests performed 🧪

- [x] Successfuly created an Immutable cluster from scratch.
- [x] Tested adding a node without using it as a member of the roles produces the right error message via `furyctl validate config`.
- [x] Tested adding a node with more than one role produces the right error message via `furyctl validate config`.
- [x] Tested that referencing a hostname that is not declared as node produces the right error message via `furyctl validate config`.

### Future work 🔧

None

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change — scoped to Immutable only
- [x] CI is green