### PR TITLE
feat(immutable): download python sysext with checksum verification

### DIFF
--- a/docs/releases/v0.35.1.md
+++ b/docs/releases/v0.35.1.md
@@ -12,6 +12,7 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 
 - [[#695](https://github.com/sighupio/furyctl/pull/695)] Immutable: fixed a panic that may occur if the user pressed ENTER to while waiting the nodes to be provisioned and a node sent a status update in the 5 seconds shutdown window.
 - [[#697](https://github.com/sighupio/furyctl/pull/697)] EKSCluster: `openvpn` is now validated as a dependency whenever a VPN is configured (not only with `--vpn-auto-connect`), failing fast with a clear error instead of a silent furyagent retry loop; `--vpn-auto-connect` without a configured VPN is now rejected up front.
+- [[#728](https://github.com/sighupio/furyctl/pull/728)] Immutable: sysext packages that pin a `sha256` in the manifest are now verified against it right after download; packages without a pin keep the previous behaviour.
 - [[#730](https://github.com/sighupio/furyctl/pull/730)] Immutable: `diff` command does not fail any more when no phase (`-p | --phase`) is specified.
 - [[#732](https://github.com/sighupio/furyctl/pull/732)] Immutable: fixed `furyctl renew certificates` that was failing while rendering the cluster inventory file.
 

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
@@ -852,7 +852,7 @@ func (*Infrastructure) downloadSysextPackages(
 
 			// Only packages that pin a sha256 are verified; the rest keep the previous behaviour.
 			if archInfo.SHA256 == "" {
-				logrus.Warnf("Sysext package %s (%s) has no pinned sha256, skipping verification", pkg.Name, arch)
+				logrus.Debugf("Sysext package %s (%s) has no pinned sha256, skipping verification", pkg.Name, arch)
 
 				continue
 			}

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
@@ -7,9 +7,12 @@ package create
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +37,7 @@ var (
 	ErrButaneConversionFatal     = errors.New("butane conversion fatal errors")
 	ErrButaneFatalErrors         = errors.New("butane translation has fatal errors")
 	ErrImmutableConfigMalformed  = errors.New("immutable furyctl config is malformed")
+	ErrSysextChecksumMismatch    = errors.New("sysext package checksum mismatch")
 )
 
 // defaultNodeArch mirrors the schema default of spec.infrastructure.nodes[].arch
@@ -72,6 +76,29 @@ type sysextPackage struct {
 // sysextArchInfo contains architecture-specific information.
 type sysextArchInfo struct {
 	URL string `yaml:"url"`
+	// SHA256 optionally pins the .raw content; packages without one are downloaded unverified.
+	SHA256 string `yaml:"sha256"`
+}
+
+// verifySHA256 streams the file and checks it against its pinned digest.
+func verifySHA256(path, want string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("error opening %s for checksum verification: %w", path, err)
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return fmt.Errorf("error reading %s for checksum verification: %w", path, err)
+	}
+
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("%w: %s: want %s, got %s", ErrSysextChecksumMismatch, path, want, got)
+	}
+
+	return nil
 }
 
 // flatcarRelease represents a Flatcar Container Linux version.
@@ -202,15 +229,16 @@ func (i *Infrastructure) getSSHPublicKeyContent() (string, error) {
 // versionVarsFromAssets turns the selected immutable.yaml block into the "versions" template data.
 // Callers reach it through VersionVarsForPhase, which handles selection/validation.
 func versionVarsFromAssets(version, kubectlBin string, a assets) map[any]any {
-	// Carry the explicit per-arch .raw URL from immutable.yaml (not just the version) so the sysext role
+	// Carry the explicit per-arch .raw URL + sha256 from immutable.yaml (not just the version) so the sysext role
 	// downloads exactly what the manifest pins, instead of reconstructing the URL from a release-base
 	// convention — the same URL the butane/Ignition install path already uses (kills the two-dialects smell).
 	sysextTargets := make(map[string]any, len(a.Sysext))
 
 	for _, pkg := range a.Sysext {
 		arch := make(map[string]any, len(pkg.Arch))
+
 		for name, info := range pkg.Arch {
-			arch[name] = map[string]string{"url": info.URL}
+			arch[name] = map[string]string{"url": info.URL, "sha256": info.SHA256}
 		}
 
 		sysextTargets[pkg.Name] = map[string]any{
@@ -821,6 +849,19 @@ func (*Infrastructure) downloadSysextPackages(
 			); err != nil {
 				return fmt.Errorf("error downloading %s for %s: %w", pkg.Name, arch, err)
 			}
+
+			// Only packages that pin a sha256 are verified; the rest keep the previous behaviour.
+			if archInfo.SHA256 == "" {
+				logrus.Warnf("Sysext package %s (%s) has no pinned sha256, skipping verification", pkg.Name, arch)
+
+				continue
+			}
+
+			if err := verifySHA256(destPath, archInfo.SHA256); err != nil {
+				return fmt.Errorf("error verifying %s for %s: %w", pkg.Name, arch, err)
+			}
+
+			logrus.Debugf("Verified %s against pinned sha256", filename)
 		}
 
 		logrus.Infof("%s sysext package downloaded successfully", pkg.Name)

--- a/internal/apis/kfd/v1alpha2/immutable/create/sysext_checksum_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/sysext_checksum_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package create //nolint:testpackage // exercises the unexported verifySHA256 helper.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVerifySHA256(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "artifact.raw")
+	data := []byte("sysext bytes")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(data)
+	want := hex.EncodeToString(sum[:])
+
+	if err := verifySHA256(path, want); err != nil {
+		t.Errorf("matching digest: got %v, want nil", err)
+	}
+
+	if err := verifySHA256(path, "deadbeef"); !errors.Is(err, ErrSysextChecksumMismatch) {
+		t.Errorf("wrong digest: got %v, want ErrSysextChecksumMismatch", err)
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### Summary 💡

Sysext packages are downloaded by furyctl and staged on the boot server, but nothing checked that what
landed on disk is what the manifest pins. This verifies every sysext package that declares a `sha256`
in `immutable.yaml` right after download, failing the phase on mismatch. Packages without a pin keep
the previous behaviour, so nothing changes for the manifests in use today.

Motivation is air-gap safety: the Python sysext is moving off the public Flatcar release server onto
our own infrastructure, and an artifact we serve ourselves should be checked against a digest that
travels with the manifest instead of being trusted blindly.

Closes:

Relates: sighupio/distribution#571, sighupio/installer-immutable#18, sighupio/distribution#567

### Description 📝

Two files under `internal/apis/kfd/v1alpha2/immutable/create/`:

- `sysextArchInfo` gains an optional `sha256` field, matching the key used by the manifest entries in
  sighupio/installer-immutable#18. Decoding is a non-strict `yaml.Unmarshal`, so old and new manifests
  work against old and new furyctl.
- New `verifySHA256` helper: streams the file through `sha256.New()` with `io.Copy` (a `.raw` is
  hundreds of MB, never held in memory) and compares hex with `strings.EqualFold`. On mismatch it
  returns a wrapped `ErrSysextChecksumMismatch` carrying wanted and actual digests, matchable with
  `errors.Is`.
- `downloadSysextPackages` verifies right after `DownloadWithMode`. No pin → logs that verification
  was skipped and continues; pin that does not match → aborts the phase.
- The per-arch `sha256` is also carried into `sysext_targets` next to the existing `url`.
- Unit test covering matching and mismatching digests.

### Breaking Changes 💔

None. The field is optional in both directions: furyctl with this change against a manifest without
`sha256` behaves as before; furyctl without it against a manifest with `sha256` ignores the unknown
key.

### Tests performed 🧪

- [x] `mise run test-unit`, `mise run lint` (0 issues), `mise run license-check`,
      `mise run test-integration`, `mise run test-flags`, `go build ./...` — all pass on the rebased branch
- [x] Live install on a 6-node Immutable cluster (k8s 1.34.8 / Flatcar 4593.2.1): the pinned
      `flatcar-python` was verified (`Verified flatcar-python-4593.2.1-x86-64.raw against pinned sha256`),
      the on-disk sha256 matches the manifest pin, and the 5 unpinned packages downloaded unchanged
- [x] All 8 nodes fetched the sysext from the local PXE asset server (8/8 HTTP 200), 0 requests to the
      public Flatcar release server; `flatcar-python` merged on the nodes and `python3` available
- [x] Live upgrade path (Flatcar 4593.2.1 → 4593.2.3)
- [ ] CI is green

### Future work 🔧

The Ansible `sysext` role still verifies node-side downloads against a `SHA256SUMS` file served from
the same host as the artifact. Consuming the per-arch `sha256` the manifest already pins would be
stronger, since the digest would no longer come from the host being verified.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change — only Immutable is affected
- [ ] CI is green
