### PR TITLE
fix: correct error handling in state stores, async creator, and kubernetes phase

### DIFF
--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -34,8 +34,6 @@ import (
 	netx "github.com/sighupio/furyctl/pkg/x/net"
 )
 
-const WrappedErrMessage = "%w: %s"
-
 type ClusterCmdFlags struct {
 	Debug                 bool
 	FuryctlPath           string

--- a/cmd/renew/certificates.go
+++ b/cmd/renew/certificates.go
@@ -101,7 +101,7 @@ func NewCertificatesCmd() *cobra.Command {
 				cmdEvent.AddErrorMessage(err)
 				tracker.Track(cmdEvent)
 
-				return fmt.Errorf("%w", err)
+				return fmt.Errorf("error while parsing git protocol: %w", err)
 			}
 
 			// Init packages.

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -313,6 +313,8 @@ func (v *ClusterCreator) CreateAsync(
 	renderedConfig, err := v.RenderConfig()
 	if err != nil {
 		errCh <- fmt.Errorf("error while rendering config: %w", err)
+
+		return
 	}
 
 	status, err := phases.PreFlight.Exec(renderedConfig)
@@ -371,11 +373,15 @@ func (v *ClusterCreator) CreateAsync(
 	case cluster.OperationPhaseInfrastructure:
 		if err := v.infraPhase(phases.Infrastructure, vpnConnector); err != nil {
 			errCh <- err
+
+			return
 		}
 
 	case cluster.OperationPhaseKubernetes:
 		if err := v.kubernetesPhase(phases.Kubernetes, vpnConnector, renderedConfig); err != nil {
 			errCh <- err
+
+			return
 		}
 
 	case cluster.OperationPhaseDistribution:
@@ -383,24 +389,34 @@ func (v *ClusterCreator) CreateAsync(
 			confirm, err := cluster.AskConfirmation(cluster.IsForceEnabledForFeature(v.force, cluster.ForceFeatureMigrations))
 			if err != nil {
 				errCh <- err
+
+				return
 			}
 
 			if !confirm {
 				errCh <- ErrAbortedByUser
+
+				return
 			}
 		}
 
 		if err := v.distributionPhase(phases.Distribution, vpnConnector, rdcs, renderedConfig); err != nil {
 			errCh <- err
+
+			return
 		}
 
 	case cluster.OperationPhasePlugins:
 		if !distribution.HasFeature(v.kfdManifest, distribution.FeaturePlugins) {
 			errCh <- fmt.Errorf("error while executing plugins phase: %w", distribution.ErrPluginsFeatureNotSupported)
+
+			return
 		}
 
 		if err := phases.Plugins.Exec(); err != nil {
 			errCh <- err
+
+			return
 		}
 
 	case cluster.OperationPhaseAll:
@@ -408,10 +424,14 @@ func (v *ClusterCreator) CreateAsync(
 			confirm, err := cluster.AskConfirmation(cluster.IsForceEnabledForFeature(v.force, cluster.ForceFeatureMigrations))
 			if err != nil {
 				errCh <- err
+
+				return
 			}
 
 			if !confirm {
 				errCh <- ErrAbortedByUser
+
+				return
 			}
 		}
 
@@ -424,8 +444,12 @@ func (v *ClusterCreator) CreateAsync(
 			renderedConfig,
 		)
 
+		return
+
 	default:
 		errCh <- fmt.Errorf("%w: %s", ErrUnsupportedPhase, v.phase)
+
+		return
 	}
 }
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/phases/errors.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/phases/errors.go
@@ -9,12 +9,13 @@ import "errors"
 const SErrWrapWithStr = "%w: %s"
 
 var (
-	ErrVpcIDNotFound     = errors.New("vpc_id not found in infra output")
-	ErrVpcIDFromOut      = errors.New("cannot read vpc_id from infrastructure's output.json")
-	ErrWritingTfVars     = errors.New("error writing terraform variables file")
-	ErrCastingVpcIDToStr = errors.New("error casting vpc_id output to string")
-	ErrVpcCIDRNotFound   = errors.New("vpc_cidr_block not found in infra output")
-	ErrPvtSubnetFromOut  = errors.New("cannot read private_subnets from infrastructure's output.json")
-	ErrVpcCIDRFromOut    = errors.New("cannot read vpc_cidr_block from infrastructure's output.json")
-	ErrPvtSubnetNotFound = errors.New("private_subnets not found in infrastructure phase's output")
+	ErrVpcIDNotFound             = errors.New("vpc_id not found in infra output")
+	ErrVpcIDFromOut              = errors.New("cannot read vpc_id from infrastructure's output.json")
+	ErrCastingVpcIDToStr         = errors.New("error casting vpc_id output to string")
+	ErrVpcCIDRNotFound           = errors.New("vpc_cidr_block not found in infra output")
+	ErrPvtSubnetFromOut          = errors.New("cannot read private_subnets from infrastructure's output.json")
+	ErrVpcCIDRFromOut            = errors.New("cannot read vpc_cidr_block from infrastructure's output.json")
+	ErrPvtSubnetNotFound         = errors.New("private_subnets not found in infrastructure phase's output")
+	ErrGettingDistributionNS     = errors.New("error getting nodeSelector from distribution")
+	ErrGettingDistributionTolers = errors.New("error getting tolerations from distribution")
 )

--- a/internal/apis/kfd/v1alpha2/ekscluster/phases/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/phases/kubernetes.go
@@ -162,14 +162,22 @@ func (*Kubernetes) getCommonDataFromDistribution(furyctlCfg templatex.Config) (m
 	if commonData["nodeSelector"] != nil {
 		nodeSelector, ok = commonData["nodeSelector"].(map[any]any)
 		if !ok {
-			return nodeSelector, tolerations, fmt.Errorf("error getting nodeSelector from distribution: %w", err)
+			return nodeSelector, tolerations, fmt.Errorf(
+				"%w: unexpected type %T",
+				ErrGettingDistributionNS,
+				commonData["nodeSelector"],
+			)
 		}
 	}
 
 	if commonData["tolerations"] != nil {
 		tolerations, ok = commonData["tolerations"].([]any)
 		if !ok {
-			return nodeSelector, tolerations, fmt.Errorf("error getting tolerations from distribution: %w", err)
+			return nodeSelector, tolerations, fmt.Errorf(
+				"%w: unexpected type %T",
+				ErrGettingDistributionTolers,
+				commonData["tolerations"],
+			)
 		}
 	}
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -6,6 +6,7 @@ package state
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -17,6 +18,11 @@ import (
 	iox "github.com/sighupio/furyctl/internal/x/io"
 	kubex "github.com/sighupio/furyctl/internal/x/kube"
 	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
+)
+
+var (
+	errSecretDataNotFound      = errors.New("secret data not found")
+	errSecretConfigKeyNotFound = errors.New("secret config key not found")
 )
 
 type Storer interface {
@@ -139,12 +145,12 @@ func (s *Store) getBaseConfig(key string) ([]byte, error) {
 
 	data, ok := secret["data"].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("error while getting current cluster config: %w", err)
+		return nil, errSecretDataNotFound
 	}
 
 	configData, ok := data[key].(string)
 	if !ok {
-		return nil, fmt.Errorf("error while getting current cluster config: %w", err)
+		return nil, fmt.Errorf("%w: %q", errSecretConfigKeyNotFound, key)
 	}
 
 	decodedConfig, err := base64.StdEncoding.DecodeString(configData)

--- a/internal/upgrade/store.go
+++ b/internal/upgrade/store.go
@@ -5,6 +5,7 @@
 package upgrade
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -18,6 +19,11 @@ import (
 	iox "github.com/sighupio/furyctl/internal/x/io"
 	kubex "github.com/sighupio/furyctl/internal/x/kube"
 	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
+)
+
+var (
+	errStateDataNotFound = errors.New("upgrade state data not found")
+	errStateKeyNotFound  = errors.New("upgrade state key not found")
 )
 
 type PhaseStatus string
@@ -114,12 +120,12 @@ func (s *StateStore) Get() ([]byte, error) {
 
 	data, ok := configMap["data"].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("error while getting current cluster upgrade state: %w", err)
+		return nil, errStateDataNotFound
 	}
 
 	configData, ok := data["state"].(string)
 	if !ok {
-		return nil, fmt.Errorf("error while getting current cluster upgrade state: %w", err)
+		return nil, errStateKeyNotFound
 	}
 
 	return []byte(configData), nil


### PR DESCRIPTION
### Summary 💡

Correct error handling in state stores, async creator, and kubernetes phase


### Description 📝

Fixes:
- `state/store` and `upgrade/store`: `%w` was wrapping nil `err` in `!ok` branches, producing `%!w(<nil>)`
- `ekscluster/creator`: added missing `return` after `errCh <- err` in `CreateAsync` to prevent execution continuing after error send
- `ekscluster/phases/kubernetes`: `%w` wrapping nil `err` in type-assertion fallbacks
- `cmd/renew/certificates`: replaced bare `fmt.Errorf("%w", err)` with descriptive message
- Removed unused `WrappedErrMessage` and `ErrWritingTfVars` consts

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/furyctl/3888

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] ~I've updated the `docs/releases/unreleased.md` file (or equivalent)~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

