### PR TITLE
fix(immutable): diff without specific phase

### DIFF
--- a/docs/releases/v0.35.1.md
+++ b/docs/releases/v0.35.1.md
@@ -12,6 +12,7 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 
 - [[#695](https://github.com/sighupio/furyctl/pull/695)] Immutable: fixed a panic that may occur if the user pressed ENTER to while waiting the nodes to be provisioned and a node sent a status update in the 5 seconds shutdown window.
 - [[#697](https://github.com/sighupio/furyctl/pull/697)] EKSCluster: `openvpn` is now validated as a dependency whenever a VPN is configured (not only with `--vpn-auto-connect`), failing fast with a clear error instead of a silent furyagent retry loop; `--vpn-auto-connect` without a configured VPN is now rejected up front.
+- [[#730](https://github.com/sighupio/furyctl/pull/730)] Immutable: `diff` command does not fail any more when no phase (`-p | --phase`) is specified.
 
 ## Breaking Changes 💔
 

--- a/internal/apis/kfd/v1alpha2/immutable/creator.go
+++ b/internal/apis/kfd/v1alpha2/immutable/creator.go
@@ -155,6 +155,14 @@ func (c *ClusterCreator) SetProperty(name string, value any) {
 }
 
 func (*ClusterCreator) GetPhasePath(phase string) (string, error) {
+	// An empty phase is the "all phases" sentinel (cluster.OperationPhaseAll),
+	// used e.g. by `furyctl diff` without the --phase flag. In that case there
+	// is no single schema path to scope to, so we return AllPhaseSchemaPath and
+	// let the diff be computed against the whole configuration.
+	if phase == cluster.OperationPhaseAll {
+		return AllPhaseSchemaPath, nil
+	}
+
 	schemaPath, ok := supported.GetSchemaPath(phase)
 	if !ok {
 		return "", fmt.Errorf("%w: %s", ErrUnsupportedPhase, phase)

--- a/internal/apis/kfd/v1alpha2/immutable/creator_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/creator_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package immutable_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable"
+)
+
+func Test_ClusterCreator_GetPhasePath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc     string
+		phase    string
+		wantPath string
+		wantErr  bool
+	}{
+		{
+			desc:     "empty phase (all phases) returns the all-phase schema path",
+			phase:    "",
+			wantPath: "",
+		},
+		{
+			desc:     "infrastructure phase",
+			phase:    "infrastructure",
+			wantPath: ".spec.infrastructure",
+		},
+		{
+			desc:     "kubernetes phase",
+			phase:    "kubernetes",
+			wantPath: ".spec.kubernetes",
+		},
+		{
+			desc:     "distribution phase",
+			phase:    "distribution",
+			wantPath: ".spec.distribution",
+		},
+		{
+			desc:     "plugins phase",
+			phase:    "plugins",
+			wantPath: ".spec.plugins",
+		},
+		{
+			desc:    "unsupported phase",
+			phase:   "bogus",
+			wantErr: true,
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			creator := &immutable.ClusterCreator{}
+
+			path, err := creator.GetPhasePath(tC.phase)
+
+			if tC.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tC.wantPath, path)
+		})
+	}
+}


### PR DESCRIPTION
### Summary 💡

Make the diff command work for Immutable clusters even when no phase is specified.

### Description 📝

Running the `furyctl diff` command without specifying a particular phase was failing with this error:

```
ERRO error while getting phase path: error while getting phase path: unsupported phase:
```

This PR handles the case when the phase is not specified (`""`) and makes the `diff` command work.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested `furyctl diff` against a real cluster with changes -> right output
- [x] Tested `furyctl diff` against a real cluster without changes -> right output
- [x] Tested `furyctl diff -p {infrastructure,kubernetes,distribution,plugins}` against a real cluster -> right output with and without changes

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [X] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

