### PR TITLE
fix(immutable): renew certificates

### DIFF
--- a/cmd/renew/certificates.go
+++ b/cmd/renew/certificates.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sighupio/furyctl/internal/app"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/config"
+	"github.com/sighupio/furyctl/internal/distribution"
 	"github.com/sighupio/furyctl/internal/flags"
 	"github.com/sighupio/furyctl/internal/git"
 	cobrax "github.com/sighupio/furyctl/internal/x/cobra"
@@ -163,6 +164,24 @@ func NewCertificatesCmd() *cobra.Command {
 
 					return fmt.Errorf("%w: %v", ErrDownloadDependenciesFailed, err)
 				}
+
+				// Only immutable renew needs the vendored immutable.yaml (hosts.yaml "versions"); others skip it.
+				if res.MinimalConf.Kind == distribution.ImmutableKind {
+					gitPrefix, err := git.RepoPrefixByProtocol(typedGitProtocol)
+					if err != nil {
+						cmdEvent.AddErrorMessage(err)
+						tracker.Track(cmdEvent)
+
+						return fmt.Errorf("%w", err)
+					}
+
+					if err := depsdl.DownloadInstallers(res.DistroManifest.Kubernetes, gitPrefix, res.MinimalConf.Kind); err != nil {
+						cmdEvent.AddErrorMessage(ErrDownloadDependenciesFailed)
+						tracker.Track(cmdEvent)
+
+						return fmt.Errorf("%w: %v", ErrDownloadDependenciesFailed, err)
+					}
+				}
 			} else {
 				logrus.Info("Dependencies download skipped")
 			}
@@ -186,6 +205,11 @@ func NewCertificatesCmd() *cobra.Command {
 				tracker.Track(cmdEvent)
 
 				return fmt.Errorf("error while creating the certificates renewer: %w", err)
+			}
+
+			// Immutable-only: the renewer uses workDir to find the vendored immutable.yaml.
+			if res.MinimalConf.Kind == distribution.ImmutableKind {
+				renewer.SetProperty(cluster.CertificatesRenewerPropertyWorkDir, basePath)
 			}
 
 			if err := renewer.Renew(); err != nil {

--- a/docs/releases/v0.35.1.md
+++ b/docs/releases/v0.35.1.md
@@ -13,6 +13,7 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 - [[#695](https://github.com/sighupio/furyctl/pull/695)] Immutable: fixed a panic that may occur if the user pressed ENTER to while waiting the nodes to be provisioned and a node sent a status update in the 5 seconds shutdown window.
 - [[#697](https://github.com/sighupio/furyctl/pull/697)] EKSCluster: `openvpn` is now validated as a dependency whenever a VPN is configured (not only with `--vpn-auto-connect`), failing fast with a clear error instead of a silent furyagent retry loop; `--vpn-auto-connect` without a configured VPN is now rejected up front.
 - [[#730](https://github.com/sighupio/furyctl/pull/730)] Immutable: `diff` command does not fail any more when no phase (`-p | --phase`) is specified.
+- [[#732](https://github.com/sighupio/furyctl/pull/732)] Immutable: fixed `furyctl renew certificates` that was failing while rendering the cluster inventory file.
 
 ## Breaking Changes 💔
 

--- a/internal/apis/kfd/v1alpha2/immutable/certificates_renewer.go
+++ b/internal/apis/kfd/v1alpha2/immutable/certificates_renewer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/sighupio/furyctl/internal/apis/config"
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable/create"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable/public"
 	"github.com/sighupio/furyctl/internal/cluster"
 	"github.com/sighupio/furyctl/internal/tool/ansible"
@@ -28,6 +29,7 @@ type CertificatesRenewer struct {
 	distroPath  string
 	configPath  string
 	binPath     string
+	workDir     string
 }
 
 func (c *CertificatesRenewer) SetProperties(props []cluster.CertificatesRenewerProperty) {
@@ -50,6 +52,8 @@ func (c *CertificatesRenewer) SetProperty(name string, value any) {
 		cluster.SetPropertyValue(value, &c.distroPath)
 	case cluster.CertificatesRenewerPropertyBinPath:
 		cluster.SetPropertyValue(value, &c.binPath)
+	case cluster.CertificatesRenewerPropertyWorkDir:
+		cluster.SetPropertyValue(value, &c.workDir)
 	default:
 		logrus.Debugf("ignoring unknown property %q", name)
 	}
@@ -64,6 +68,14 @@ func (c *CertificatesRenewer) Renew() error {
 	}
 
 	defer os.RemoveAll(tmpDir)
+
+	// Root the phase at workDir/kubernetes so version vars resolve the vendored immutable.yaml and
+	// KubectlPath, like the create phase (hosts.yaml reads .versions.kubectl_bin under missingkey=error).
+	c.OperationPhase = cluster.NewOperationPhase(
+		path.Join(c.workDir, cluster.OperationPhaseKubernetes),
+		c.kfdManifest.Tools,
+		c.binPath,
+	)
 
 	ansibleRunner := ansible.NewRunner(
 		execx.NewStdExecutor(),
@@ -85,9 +97,19 @@ func (c *CertificatesRenewer) Renew() error {
 		return fmt.Errorf("error creating template config: %w", err)
 	}
 
+	version := c.kfdManifest.Kubernetes.Immutable.Version
+
 	mCfg.Data["kubernetes"] = map[any]any{
-		"version": c.kfdManifest.Kubernetes.OnPremises.Version,
+		"version": version,
 	}
+
+	// Inject the same "versions" data as the create phase; hosts.yaml fails on the missing key otherwise.
+	versionVars, err := create.VersionVarsForPhase(c.Path, version, c.KubectlPath)
+	if err != nil {
+		return fmt.Errorf("error building version vars: %w", err)
+	}
+
+	mCfg.Data["versions"] = versionVars
 
 	mCfg.Data["paths"] = map[any]any{
 		"helm":       "",

--- a/internal/apis/kfd/v1alpha2/immutable/create/immutable_assets.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/immutable_assets.go
@@ -47,3 +47,14 @@ func selectImmutableAssets(phasePath, kubeVersion string) (assets, error) {
 
 	return immutableAssets, nil
 }
+
+// VersionVarsForPhase resolves the immutable.yaml pins for kubeVersion (from phasePath/../vendor)
+// into the "versions" template data shared by the create phases and the certificates renewer.
+func VersionVarsForPhase(phasePath, kubeVersion, kubectlBin string) (map[any]any, error) {
+	immutableAssets, err := selectImmutableAssets(phasePath, kubeVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error selecting immutable assets: %w", err)
+	}
+
+	return versionVarsFromAssets(kubeVersion, kubectlBin, immutableAssets), nil
+}

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure.go
@@ -121,16 +121,10 @@ func (i *Infrastructure) Exec(_ string, upgradeState *upgrade.State) error {
 		"version": i.kfdManifest.Kubernetes.Immutable.Version,
 	}
 
-	// Inject the immutable.yaml version data; the infra hosts.yaml renders containerd_sandbox_tag,
-	// kubernetes_image_registry and the haproxy image/tag inline, consumed by the apply.yaml roles.
-	immutableAssets, err := selectImmutableAssets(i.Path, i.kfdManifest.Kubernetes.Immutable.Version)
+	// Inject the immutable.yaml version data; the infra hosts.yaml renders the pins consumed by apply.yaml.
+	versionVars, err := VersionVarsForPhase(i.Path, i.kfdManifest.Kubernetes.Immutable.Version, i.KubectlPath)
 	if err != nil {
-		return fmt.Errorf("error selecting immutable assets: %w", err)
-	}
-
-	versionVars := map[any]any{}
-	for name, value := range buildVersionVars(i.kfdManifest.Kubernetes.Immutable.Version, i.KubectlPath, immutableAssets) {
-		versionVars[name] = value
+		return fmt.Errorf("error building version vars: %w", err)
 	}
 
 	mCfg.Data["versions"] = versionVars

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go
@@ -199,11 +199,9 @@ func (i *Infrastructure) getSSHPublicKeyContent() (string, error) {
 	return sshPublicKeyContent, nil
 }
 
-// buildVersionVars turns the selected immutable.yaml block into the data the version vars template
-// consumes. Both the kubernetes and infrastructure phases inject this under "versions" into the
-// generic template walk, so each phase renders the version vars inline in its hosts.yaml.
-// Selection/validation stays in Go (selectImmutableAssets).
-func buildVersionVars(version, kubectlBin string, a assets) map[string]any {
+// versionVarsFromAssets turns the selected immutable.yaml block into the "versions" template data.
+// Callers reach it through VersionVarsForPhase, which handles selection/validation.
+func versionVarsFromAssets(version, kubectlBin string, a assets) map[any]any {
 	// Carry the explicit per-arch .raw URL from immutable.yaml (not just the version) so the sysext role
 	// downloads exactly what the manifest pins, instead of reconstructing the URL from a release-base
 	// convention — the same URL the butane/Ignition install path already uses (kills the two-dialects smell).
@@ -221,7 +219,7 @@ func buildVersionVars(version, kubectlBin string, a assets) map[string]any {
 		}
 	}
 
-	vars := map[string]any{
+	vars := map[any]any{
 		"kubernetes_version":        version,
 		"containerd_sandbox_tag":    a.SandboxTag,
 		"coredns_image_prefix":      a.CorednsImagePrefix,

--- a/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/kubernetes.go
@@ -149,16 +149,10 @@ func (k *Kubernetes) prepare() error {
 	)
 	mCfg.Data["options"]["podRunningTimeout"] = k.podRunningTimeout / FromSecondsToHalfMinuteRetries
 
-	// Inject the immutable.yaml version data under "versions" so the generic walk renders the
-	// version vars inline in hosts.yaml alongside the playbooks (selection/validation stays in Go).
-	immutableAssets, err := selectImmutableAssets(k.Path, k.kfdManifest.Kubernetes.Immutable.Version)
+	// Inject the immutable.yaml version data under "versions" so hosts.yaml renders the pins inline.
+	versionVars, err := VersionVarsForPhase(k.Path, version, k.KubectlPath)
 	if err != nil {
-		return fmt.Errorf("error selecting immutable assets: %w", err)
-	}
-
-	versionVars := map[any]any{}
-	for name, value := range buildVersionVars(version, k.KubectlPath, immutableAssets) {
-		versionVars[name] = value
+		return fmt.Errorf("error building version vars: %w", err)
 	}
 
 	mCfg.Data["versions"] = versionVars

--- a/internal/apis/kfd/v1alpha2/immutable/create/version_vars_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/version_vars_test.go
@@ -82,8 +82,8 @@ func TestSelectImmutableAssets(t *testing.T) {
 	assert.Error(t, err, "expected error for missing version, got nil")
 }
 
-// TestBuildVersionVars checks the infra roles' required vars (sandbox tag, haproxy image/tag) are emitted.
-func TestBuildVersionVars(t *testing.T) {
+// TestVersionVarsFromAssets checks the infra roles' required vars (sandbox tag, haproxy image/tag) are emitted.
+func TestVersionVarsFromAssets(t *testing.T) {
 	t.Parallel()
 
 	phaseDir := writeManifest(t)
@@ -91,7 +91,7 @@ func TestBuildVersionVars(t *testing.T) {
 	a, err := selectImmutableAssets(phaseDir, "1.34.8")
 	require.NoError(t, err)
 
-	vars := buildVersionVars("1.34.8", "/usr/bin/kubectl", a)
+	vars := versionVarsFromAssets("1.34.8", "/usr/bin/kubectl", a)
 
 	want := map[string]string{
 		"containerd_sandbox_tag":  "3.10.1",
@@ -101,12 +101,30 @@ func TestBuildVersionVars(t *testing.T) {
 
 	for key, exp := range want {
 		got, ok := vars[key]
-		assert.True(t, ok, "buildVersionVars missing %q", key)
+		assert.True(t, ok, "versionVarsFromAssets missing %q", key)
 
 		if !ok {
 			continue
 		}
 
-		assert.Equal(t, exp, got, "buildVersionVars[%q]", key)
+		assert.Equal(t, exp, got, "versionVarsFromAssets[%q]", key)
 	}
+}
+
+// TestVersionVarsForPhaseKubectlBin: kubectl_bin is set when a bin path is given (hosts.yaml reads it
+// under missingkey=error) and omitted when empty.
+func TestVersionVarsForPhaseKubectlBin(t *testing.T) {
+	t.Parallel()
+
+	phaseDir := writeManifest(t)
+
+	withBin, err := VersionVarsForPhase(phaseDir, "1.34.8", "/opt/bin/kubectl")
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/bin/kubectl", withBin["kubectl_bin"], "kubectl_bin must be set when a bin path is given")
+
+	noBin, err := VersionVarsForPhase(phaseDir, "1.34.8", "")
+	require.NoError(t, err)
+
+	_, ok := noBin["kubectl_bin"]
+	assert.False(t, ok, "kubectl_bin must be omitted when the bin path is empty")
 }

--- a/internal/cluster/certificates_renewer.go
+++ b/internal/cluster/certificates_renewer.go
@@ -18,6 +18,7 @@ const (
 	CertificatesRenewerPropertyKfdManifest = "kfdmanifest"
 	CertificatesRenewerPropertyDistroPath  = "distropath"
 	CertificatesRenewerPropertyBinPath     = "binpath"
+	CertificatesRenewerPropertyWorkDir     = "workdir"
 )
 
 var certificatesRenewerFactories = make(map[string]map[string]CertificatesRenewerFactory) //nolint:gochecknoglobals, lll // This patterns requires certificatesRenewerFactories as global to work with init function.


### PR DESCRIPTION
### Summary 💡

Fix `furyctl renew certificates` for Immutable clusters.

Relates:
- #688

Closes #731 

### Description 📝

Renewing certificates on an Immutable cluster failed while rendering `templates/kubernetes/immutable/hosts.yaml.tpl`:

```
error while renewing certificates: error copying from template: template: hosts.yaml.tpl:204: executing "hosts.yaml.tpl" at <.versions.kubernetes_image_registry>: map has no entry for key "versions"
```

That template renders the `immutable.yaml` version pins inline under `.versions.*`
(added for the create/apply phase) to be consumed by the `hosts.yaml` template for Ansible, but the certificates renewer never supplied that data.

The renew path now mirrors the create phase:
- Vendors the immutable installer (`DownloadInstallers`), **guarded to the Immutable kind**, so `immutable.yaml` is available for the renewer to read.
- Builds the kubernetes `OperationPhase` from the workdir so version vars resolve the vendored `immutable.yaml` and `KubectlPath`.
- Injects the `versions` template data through the shared `create.VersionVarsForPhase`.

Additionally:
- Fixes the kubernetes version field on the renewer (`Immutable`, not `OnPremises`).
- Refactors the version-data plumbing so it lives in one place: `VersionVarsForPhase`
(load + build) is the single entry point.

### Notes for reviewers 👀

- This touches the create/apply path (`create/kubernetes.go`, `create/infrastructure.go`, `versionVarsFromAssets`) only to route it through the new shared `VersionVarsForPhase` helper.
- **Merge interaction with #727:** the new `WorkDir` case in the immutable renewer's `SetProperty` uses the current type-assertion style (`if s, ok := value.(string); ok`) because `cluster.SetPropertyValue` isn't on this branch yet. #727 converts these cases to `SetPropertyValue` — whichever of the two PRs merges second should convert this one case in the trivial conflict.

### Breaking Changes 💔

None

### Tests performed 🧪

- [X] Tested full apply on an Immutable cluster
- [x] Tested certificates renew on an Immutable cluster

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

