### PR TITLE
fix(configs/patches): patch v1.35.0 to prevent HAProxy LoadBalancer Service recreation on EKS

### DIFF
--- a/configs/patches/v1.35.0/templates/distribution/manifests/ingress/kustomization.yaml.tpl
+++ b/configs/patches/v1.35.0/templates/distribution/manifests/ingress/kustomization.yaml.tpl
@@ -1,0 +1,177 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+{{- $vendorPrefix := print "../" .spec.distribution.common.relativeVendorPath }}
+{{- $haproxyType := .spec.distribution.modules.ingress.haproxy.type }}
+{{- $nginxUsesCertManager := and (ne .spec.distribution.modules.ingress.nginx.type "none") (eq .spec.distribution.modules.ingress.nginx.tls.provider "certManager") }}
+{{- $haproxyUsesCertManager := and (ne $haproxyType "none") (eq .spec.distribution.modules.ingress.haproxy.tls.provider "certManager") }}
+{{- $usesCertManager := or $nginxUsesCertManager $haproxyUsesCertManager }}
+{{- $isBYOIC := .spec.distribution.modules.ingress.byoic.enabled }}
+{{- $hasAnyIngress := or (ne .spec.distribution.modules.ingress.nginx.type "none") (ne $haproxyType "none") $isBYOIC }}
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+{{- if eq .spec.distribution.modules.ingress.nginx.type "dual" }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/dual-nginx" }}
+{{- else if eq .spec.distribution.modules.ingress.nginx.type "single" }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/nginx" }}
+{{- end }}
+
+{{/* HAProxy Ingress Controller */}}
+{{- if eq $haproxyType "dual" }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/haproxy/dual" }}
+{{- else if eq $haproxyType "single" }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/haproxy/single" }}
+{{- end }}
+
+{{/* External-dns for EKS */}}
+{{- if eq .spec.distribution.common.provider.type "eks" }}
+  {{- $isDual := or (eq .spec.distribution.modules.ingress.nginx.type "dual") (eq $haproxyType "dual") }}
+  {{- $isSingle := and (not $isDual) (or (eq .spec.distribution.modules.ingress.nginx.type "single") (eq $haproxyType "single")) }}
+  {{- if $isDual }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/external-dns/namespace" }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/external-dns/private" }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/external-dns/public" }}
+  {{- else if $isSingle }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/external-dns/namespace" }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/external-dns/public" }}
+  {{- end }}
+{{- end }}
+
+{{- if and (eq .spec.distribution.common.networkPoliciesEnabled true) (or $usesCertManager $hasAnyIngress) }}
+  - policies
+{{- end }}
+
+{{/* Forecastle is enabled if any ingress controller is active or BYOIC */}}
+{{- if $hasAnyIngress }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/forecastle" }}
+{{- end }}
+  - {{ print $vendorPrefix "/modules/ingress/katalog/cert-manager" }}
+
+{{- if $usesCertManager }}
+  - resources/cert-manager-clusterissuer.yml
+{{- end }}
+
+{{- if $hasAnyIngress }}
+  - resources/ingress-infra.yml
+{{- end }}
+
+{{- if and (eq .spec.distribution.common.provider.type "eks") (ne $haproxyType "none") }}
+  - resources/haproxy-loadbalancerclass-rebase.yml
+{{- end }}
+
+{{- $nginxUsesSecret := and (ne .spec.distribution.modules.ingress.nginx.type "none") (eq .spec.distribution.modules.ingress.nginx.tls.provider "secret") }}
+{{- $haproxyUsesSecret := and (ne $haproxyType "none") (eq .spec.distribution.modules.ingress.haproxy.tls.provider "secret") }}
+{{- if or $nginxUsesSecret $haproxyUsesSecret }}
+  - secrets/tls.yml
+{{- end }}
+
+{{/* This patches section can probably be refactored */}}
+patches:
+{{- if and .spec.distribution.modules.ingress.certManager .spec.distribution.modules.ingress.certManager.clusterIssuer }}
+  {{- if and $usesCertManager (eq .spec.distribution.modules.ingress.certManager.clusterIssuer.type "dns01") }}
+  - path: patches/cert-manager-sa-route53-role-arn.yml
+  {{- end }}
+  - path: patches/cert-manager-kapp-group.yml
+  # cert-manager is always deployed, so we need to patch at least it to include the selectors
+  - path: patches/infra-nodes.yml
+{{- end }}
+
+{{- if ne .spec.distribution.modules.ingress.nginx.type "none" }}
+  - path: patches/nginx-kapp-group.yml
+{{- end }}
+
+{{- if eq .spec.distribution.common.provider.type "eks" }}
+  {{- if eq .spec.distribution.modules.ingress.nginx.type "dual" }}
+  - path: patches/eks-ingress-nginx-external.yml
+  - path: patches/eks-ingress-nginx-internal.yml
+  {{- else if eq .spec.distribution.modules.ingress.nginx.type "single" }}
+  - path: patches/eks-ingress-nginx.yml
+  {{- end }}
+
+  {{/* EKS-specific patches for HAProxy */}}
+  {{- if eq $haproxyType "dual" }}
+  - path: patches/eks-haproxy-ingress-external.yml
+  - path: patches/eks-haproxy-ingress-internal.yml
+  {{- else if eq $haproxyType "single" }}
+  - path: patches/eks-haproxy-ingress.yml
+  {{- end }}
+
+  {{- if or (ne .spec.distribution.modules.ingress.nginx.type "none") (ne $haproxyType "none") }}
+  - path: patches/external-dns.yml
+  {{- end }}
+{{- end }}
+
+{{- if $usesCertManager }}
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: cert-manager
+      namespace: cert-manager
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: "--dns01-recursive-nameservers-only"
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+{{- end }}
+
+{{- if and (ne .spec.distribution.modules.ingress.nginx.type "none") (eq .spec.distribution.modules.ingress.nginx.tls.provider "secret") }}
+  {{- if eq .spec.distribution.modules.ingress.nginx.type "dual" }}
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: ingress-nginx-controller-external
+      namespace: ingress-nginx
+    path: patchesJson/ingress-nginx.yml
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: ingress-nginx-controller-internal
+      namespace: ingress-nginx
+    path: patchesJson/ingress-nginx.yml
+  {{- else if eq .spec.distribution.modules.ingress.nginx.type "single" }}
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: ingress-nginx-controller
+      namespace: ingress-nginx
+    path: patchesJson/ingress-nginx.yml
+  {{- end }}
+{{- end }}
+
+{{- if and (ne $haproxyType "none") (eq .spec.distribution.modules.ingress.haproxy.tls.provider "secret") }}
+  {{- if eq $haproxyType "dual" }}
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: haproxy-ingress-external
+      namespace: ingress-haproxy
+    path: patchesJson/haproxy-ingress.yml
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: haproxy-ingress-internal
+      namespace: ingress-haproxy
+    path: patchesJson/haproxy-ingress.yml
+  {{- else if eq $haproxyType "single" }}
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: haproxy-ingress
+      namespace: ingress-haproxy
+    path: patchesJson/haproxy-ingress.yml
+  {{- end }}
+{{- end }}

--- a/configs/patches/v1.35.0/templates/distribution/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml.tpl
+++ b/configs/patches/v1.35.0/templates/distribution/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml.tpl
@@ -1,0 +1,24 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+{{- if eq .spec.distribution.common.provider.type "eks" }}
+{{- if ne .spec.distribution.modules.ingress.haproxy.type "none" }}
+---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+metadata:
+  # this resource has no metadata of its own; this is only here
+  # because kustomize requires metadata.name on every resource it accumulates.
+  name: haproxy-loadbalancerclass-rebase
+
+rebaseRules:
+  - path: [spec, loadBalancerClass]
+    type: copy
+    sources: [existing]
+    resourceMatchers:
+      - apiVersionKindMatcher:
+          apiVersion: v1
+          kind: Service
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Summary 💡

Patch SD v1.35.0 to prevent HAProxy LoadBalancer Services on EKS from being deleted and recreated, with a new NLB, on furyctl apply.

Closes:

Relates: https://github.com/sighupio/distribution/pull/580

Description 📝

See above.

Breaking Changes 💔

None. 

Tests performed 🧪

- [x] Reproduced with the local code end to end on an EKS cluster with SD v1.35.0

Future work 🔧

None.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
