### PR TITLE
feat(pki): check the PKI folder before an apply

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -471,9 +471,14 @@ func validatePostApplyPhasesFlag(phases []string) error {
 // infrastructure and kubernetes phases copy the CA certificates and keys to the nodes. The startFrom
 // flag also excludes the earlier phases when phase is empty, the value for all the phases.
 //
-// One case gives a false positive: a resumed upgrade. ClusterCreator.allPhases reads startFrom from the
-// stored upgrade state, after this function ran with the value of the flag. A resume at the
-// post-distribution sub-phase then checks a PKI folder that no phase reads.
+// One case gives a false positive: a resumed upgrade. ClusterCreator.allPhases reads startFrom from a
+// ConfigMap in the cluster, after this function ran with the value of the flag. The resume point is not
+// available here, because kubectl arrives with the dependencies, later. So an empty startFrom keeps the
+// check, and a resume at the post-distribution sub-phase checks a PKI folder that no phase reads.
+//
+// The user has a way past it. An explicit --start-from skips the check, and allPhases reads the
+// ConfigMap only when startFrom is empty. For example, `furyctl apply --upgrade --start-from
+// post-distribution` resumes at the same phase and does no check.
 func phasesReadPKI(phase, startFrom string, postApplyPhases []string) bool {
 	// The postApplyPhases flag repeats a phase after the apply, so a phase that startFrom excluded can
 	// still run. This flag and the phase flag cannot be used together, so phase is empty here. Only the

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -220,6 +220,28 @@ func NewApplyCmd() *cobra.Command {
 				return fmt.Errorf("error while validating configuration file: %w", err)
 			}
 
+			// The infrastructure and kubernetes phases copy the CA certificates and keys to the nodes.
+			// The check runs before the apply reaches Ansible. The other phases read no local PKI: an
+			// apply of the distribution phase alone must not ask for the CA keys.
+			switch {
+			case !phasesReadPKI(cmdFlags.Phase, cmdFlags.StartFrom, cmdFlags.PostApplyPhases):
+				logrus.Debug("The selected phases read no local PKI. The PKI folder check does not run")
+
+			case cmdFlags.DryRun:
+				// A dry run stops before Ansible, so it reads no CA file. The warning is necessary,
+				// because the folder can still stop the apply that comes after the dry run.
+				logrus.Warn("In dry run mode, the PKI folder check does not run. " +
+					"To check the folder, run `furyctl validate config`")
+
+			default:
+				if err := config.ValidatePKI(cmdFlags.FuryctlPath); err != nil {
+					cmdEvent.AddErrorMessage(err)
+					tracker.Track(cmdEvent)
+
+					return fmt.Errorf("the PKI folder check failed: %w", err)
+				}
+			}
+
 			// Download the dependencies.
 			if !cmdFlags.SkipDepsDownload {
 				logrus.Info("Downloading dependencies...")
@@ -443,6 +465,41 @@ func validatePostApplyPhasesFlag(phases []string) error {
 	}
 
 	return nil
+}
+
+// phasesReadPKI reports whether the phases that the apply runs read the local PKI folder. Only the
+// infrastructure and kubernetes phases copy the CA certificates and keys to the nodes. The startFrom
+// flag also excludes the earlier phases when phase is empty, the value for all the phases.
+//
+// One case gives a false positive: a resumed upgrade. ClusterCreator.allPhases reads startFrom from the
+// stored upgrade state, after this function ran with the value of the flag. A resume at the
+// post-distribution sub-phase then checks a PKI folder that no phase reads.
+func phasesReadPKI(phase, startFrom string, postApplyPhases []string) bool {
+	// The postApplyPhases flag repeats a phase after the apply, so a phase that startFrom excluded can
+	// still run. This flag and the phase flag cannot be used together, so phase is empty here. Only the
+	// kubernetes phase is relevant: ClusterCreator.extraPhases ignores an infrastructure value.
+	if slices.Contains(postApplyPhases, cluster.OperationPhaseKubernetes) {
+		return true
+	}
+
+	if phase != cluster.OperationPhaseAll {
+		return phaseReadsPKI(phase)
+	}
+
+	// A start from the post-kubernetes sub-phase skips apply.yaml, the playbook that copies the CA files.
+	// See Kubernetes.coreKubernetes.
+	return !slices.Contains([]string{
+		cluster.OperationSubPhasePostKubernetes,
+		cluster.OperationSubPhasePreDistribution,
+		cluster.OperationPhaseDistribution,
+		cluster.OperationSubPhasePostDistribution,
+		cluster.OperationPhasePlugins,
+	}, startFrom)
+}
+
+// phaseReadsPKI reports whether one phase copies the CA certificates and keys to the nodes.
+func phaseReadsPKI(phase string) bool {
+	return phase == cluster.OperationPhaseInfrastructure || phase == cluster.OperationPhaseKubernetes
 }
 
 func setupApplyCmdFlags(cmd *cobra.Command) {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sighupio/furyctl/internal/cluster"
+)
+
+func TestPhasesReadPKI(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc            string
+		phase           string
+		startFrom       string
+		postApplyPhases []string
+		want            bool
+	}{
+		{
+			desc:  "all the phases",
+			phase: cluster.OperationPhaseAll,
+			want:  true,
+		},
+		{
+			desc:  "the infrastructure phase alone",
+			phase: cluster.OperationPhaseInfrastructure,
+			want:  true,
+		},
+		{
+			desc:  "the kubernetes phase alone",
+			phase: cluster.OperationPhaseKubernetes,
+			want:  true,
+		},
+		{
+			desc:  "the distribution phase alone",
+			phase: cluster.OperationPhaseDistribution,
+			want:  false,
+		},
+		{
+			desc:  "the plugins phase alone",
+			phase: cluster.OperationPhasePlugins,
+			want:  false,
+		},
+		{
+			desc:      "all the phases from the kubernetes phase",
+			phase:     cluster.OperationPhaseAll,
+			startFrom: cluster.OperationPhaseKubernetes,
+			want:      true,
+		},
+		{
+			desc:      "all the phases from the distribution phase",
+			phase:     cluster.OperationPhaseAll,
+			startFrom: cluster.OperationPhaseDistribution,
+			want:      false,
+		},
+		{
+			desc:      "all the phases from the pre-distribution phase",
+			phase:     cluster.OperationPhaseAll,
+			startFrom: cluster.OperationSubPhasePreDistribution,
+			want:      false,
+		},
+		{
+			desc:      "all the phases from the post-distribution phase",
+			phase:     cluster.OperationPhaseAll,
+			startFrom: cluster.OperationSubPhasePostDistribution,
+			want:      false,
+		},
+		{
+			desc:      "all the phases from the plugins phase",
+			phase:     cluster.OperationPhaseAll,
+			startFrom: cluster.OperationPhasePlugins,
+			want:      false,
+		},
+		{
+			// coreKubernetes skips apply.yaml, the playbook that copies the CA files.
+			desc:      "all the phases from the post-kubernetes phase",
+			phase:     cluster.OperationPhaseAll,
+			startFrom: cluster.OperationSubPhasePostKubernetes,
+			want:      false,
+		},
+		{
+			desc:      "all the phases from the pre-kubernetes phase",
+			phase:     cluster.OperationPhaseAll,
+			startFrom: cluster.OperationSubPhasePreKubernetes,
+			want:      true,
+		},
+		{
+			// The extra phases run after the apply, so the kubernetes phase runs even when startFrom
+			// excluded it. See ClusterCreator.extraPhases.
+			desc:            "from the distribution phase, with the kubernetes phase after the apply",
+			phase:           cluster.OperationPhaseAll,
+			startFrom:       cluster.OperationPhaseDistribution,
+			postApplyPhases: []string{cluster.OperationPhaseKubernetes},
+			want:            true,
+		},
+		{
+			// extraPhases ignores an infrastructure value, so no phase reads the PKI here.
+			desc:            "from the distribution phase, with the infrastructure phase after the apply",
+			phase:           cluster.OperationPhaseAll,
+			startFrom:       cluster.OperationPhaseDistribution,
+			postApplyPhases: []string{cluster.OperationPhaseInfrastructure},
+			want:            false,
+		},
+		{
+			desc:            "from the distribution phase, with the distribution phase after the apply",
+			phase:           cluster.OperationPhaseAll,
+			startFrom:       cluster.OperationPhaseDistribution,
+			postApplyPhases: []string{cluster.OperationPhaseDistribution},
+			want:            false,
+		},
+		{
+			desc:            "from the plugins phase, with the plugins phase after the apply",
+			phase:           cluster.OperationPhaseAll,
+			startFrom:       cluster.OperationPhasePlugins,
+			postApplyPhases: []string{cluster.OperationPhasePlugins},
+			want:            false,
+		},
+		{
+			desc:            "all the phases, with the distribution phase after the apply",
+			phase:           cluster.OperationPhaseAll,
+			postApplyPhases: []string{cluster.OperationPhaseDistribution},
+			want:            true,
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tC.want, phasesReadPKI(tC.phase, tC.startFrom, tC.postApplyPhases))
+		})
+	}
+}

--- a/cmd/validate/config.go
+++ b/cmd/validate/config.go
@@ -122,6 +122,17 @@ func NewConfigCmd() *cobra.Command {
 				return ErrValidationFailed
 			}
 
+			// The PKI folder check is not a rule of config.Validate, because the other commands that
+			// validate a configuration do not read the PKI. See config.ValidatePKI.
+			if err := config.ValidatePKI(furyctlPath); err != nil {
+				logrus.Error(err)
+
+				cmdEvent.AddErrorMessage(ErrValidationFailed)
+				tracker.Track(cmdEvent)
+
+				return ErrValidationFailed
+			}
+
 			logrus.Info("configuration file validation succeeded")
 
 			cmdEvent.AddSuccessMessage("configuration file validation succeeded")

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,15 @@
+# furyctl release vTBD
+
+Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
+
+## New features 🌟
+
+- [[#741](https://github.com/sighupio/furyctl/pull/741)] Immutable, OnPremises: furyctl now checks the PKI folder from the configuration file before an apply. When the folder or one of its files is absent, the apply stops before it starts the playbooks, and the message names the `furyctl create pki` command to run. Before this release, the apply failed in the middle, inside an Ansible task, with a message that did not say how to correct the fault. `furyctl validate config` does the same check, so a pipeline that validates a configuration now needs the PKI folder on that machine.
+
+## Bug fixes 🐞
+
+TBD
+
+## Breaking Changes 💔
+
+None

--- a/internal/apis/kfd/v1alpha2/immutable/pki.go
+++ b/internal/apis/kfd/v1alpha2/immutable/pki.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package immutable
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable/public"
+	"github.com/sighupio/furyctl/internal/clusterpki"
+	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
+)
+
+// ErrPkiPath names the configuration field, so that the message of clusterpki points at it.
+var ErrPkiPath = errors.New(".spec.kubernetes.pkiPath")
+
+// PKIValidator checks the local PKI folder of an Immutable configuration.
+type PKIValidator struct{}
+
+// ValidatePKI checks that the folder in .spec.kubernetes.pkiPath holds the CA certificates and keys
+// that the playbooks read. The infrastructure phase reads `master/ca.crt` for the load balancers, and
+// the kubernetes phase reads the `master` and `etcd` folders. Without these files the apply fails
+// inside Ansible, after it reaches the nodes.
+func (*PKIValidator) ValidatePKI(confPath string) error {
+	conf, err := yamlx.FromFileV3[public.ImmutableKfdV1Alpha2](confPath)
+	if err != nil {
+		return err
+	}
+
+	var value string
+
+	if conf.Spec.Kubernetes.PkiPath != nil {
+		value = *conf.Spec.Kubernetes.PkiPath
+	}
+
+	pkiPath, err := clusterpki.ResolvePath(value, filepath.Dir(confPath))
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrPkiPath, err)
+	}
+
+	if err := clusterpki.Check(pkiPath); err != nil {
+		return fmt.Errorf("%w: %w", ErrPkiPath, err)
+	}
+
+	return nil
+}

--- a/internal/apis/kfd/v1alpha2/immutable/pki_test.go
+++ b/internal/apis/kfd/v1alpha2/immutable/pki_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package immutable_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable"
+	"github.com/sighupio/furyctl/internal/clusterpki"
+)
+
+// writeConf writes a configuration file that holds the given pkiPath value, and returns its path. An
+// empty value writes no field at all.
+func writeConf(t *testing.T, dir, value string) string {
+	t.Helper()
+
+	conf := "apiVersion: kfd.sighup.io/v1alpha2\nkind: Immutable\nspec:\n  kubernetes:\n"
+	if value != "" {
+		conf += "    pkiPath: " + value + "\n"
+	}
+
+	path := filepath.Join(dir, "furyctl.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(conf), 0o600))
+
+	return path
+}
+
+// writePKI writes a complete PKI folder at dir/pki.
+func writePKI(t *testing.T, dir string) {
+	t.Helper()
+
+	files := map[string][]string{
+		"master": {"ca.crt", "ca.key", "front-proxy-ca.crt", "front-proxy-ca.key", "sa.key", "sa.pub"},
+		"etcd":   {"ca.crt", "ca.key"},
+	}
+
+	for sub, names := range files {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "pki", sub), os.ModePerm))
+
+		for _, name := range names {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "pki", sub, name), []byte("x"), 0o600))
+		}
+	}
+}
+
+func TestPKIValidator_ValidatePKI_Complete(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	confPath := writeConf(t, dir, "./pki")
+	writePKI(t, dir)
+
+	validator := &immutable.PKIValidator{}
+
+	require.NoError(t, validator.ValidatePKI(confPath))
+}
+
+func TestPKIValidator_ValidatePKI_FolderMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	confPath := writeConf(t, dir, "./pki")
+
+	validator := &immutable.PKIValidator{}
+
+	err := validator.ValidatePKI(confPath)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, immutable.ErrPkiPath)
+
+	folderMissing := &clusterpki.FolderMissingError{}
+	require.ErrorAs(t, err, &folderMissing)
+	assert.Equal(t, filepath.Join(dir, "pki"), folderMissing.Path)
+}
+
+func TestPKIValidator_ValidatePKI_ValueErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc    string
+		value   string
+		wantErr error
+	}{
+		{
+			desc:    "the value is relative without a ./ prefix",
+			value:   "pki",
+			wantErr: clusterpki.ErrPathNotResolvable,
+		},
+		{
+			desc:    "the field is absent",
+			value:   "",
+			wantErr: clusterpki.ErrPathEmpty,
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			confPath := writeConf(t, dir, tC.value)
+			writePKI(t, dir)
+
+			validator := &immutable.PKIValidator{}
+
+			err := validator.ValidatePKI(confPath)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, immutable.ErrPkiPath)
+			assert.ErrorIs(t, err, tC.wantErr)
+		})
+	}
+}

--- a/internal/apis/kfd/v1alpha2/immutable/public/schema.go
+++ b/internal/apis/kfd/v1alpha2/immutable/public/schema.go
@@ -95,6 +95,9 @@ type SpecKubernetes struct {
 	ControlPlane SpecKubernetesControlPlane `yaml:"controlPlane"`
 	Etcd         *SpecKubernetesEtcd        `yaml:"etcd,omitempty"`
 	NodeGroups   []SpecKubernetesNodeGroup  `yaml:"nodeGroups,omitempty"`
+	// PkiPath is the folder that holds the CA certificates and keys for the control plane and etcd. The
+	// playbooks read them from the `master` and `etcd` subfolders.
+	PkiPath *string `yaml:"pkiPath,omitempty"`
 }
 
 // SpecKubernetesNodeGroup assigns nodes the worker role by hostname.

--- a/internal/apis/kfd/v1alpha2/onpremises/pki.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/pki.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package onpremises
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/onpremises/public"
+	"github.com/sighupio/furyctl/internal/clusterpki"
+	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
+)
+
+// ErrPkiFolder names the configuration field, so that the message of clusterpki points at it.
+var ErrPkiFolder = errors.New(".spec.kubernetes.pkiFolder")
+
+// PKIValidator checks the local PKI folder of an OnPremises configuration.
+type PKIValidator struct{}
+
+// ValidatePKI checks that the folder in .spec.kubernetes.pkiFolder holds the CA certificates and keys
+// that the kubernetes playbook reads. The etcd and control plane roles read the `etcd` and `master`
+// folders, and the playbook copies `master/ca.crt` to the load balancers. Without these files the apply
+// fails inside Ansible, after it reaches the nodes.
+func (*PKIValidator) ValidatePKI(confPath string) error {
+	conf, err := yamlx.FromFileV3[public.OnpremisesKfdV1Alpha2](confPath)
+	if err != nil {
+		return err
+	}
+
+	var value string
+
+	if conf.Spec.Kubernetes.PkiFolder != nil {
+		value = *conf.Spec.Kubernetes.PkiFolder
+	}
+
+	pkiPath, err := clusterpki.ResolvePath(value, filepath.Dir(confPath))
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrPkiFolder, err)
+	}
+
+	if err := clusterpki.Check(pkiPath); err != nil {
+		return fmt.Errorf("%w: %w", ErrPkiFolder, err)
+	}
+
+	return nil
+}

--- a/internal/apis/kfd/v1alpha2/onpremises/pki_test.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/pki_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package onpremises_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/onpremises"
+	"github.com/sighupio/furyctl/internal/clusterpki"
+)
+
+// writeConf writes a configuration file that holds the given pkiFolder value, and returns its path. An
+// empty value writes the field with an empty string, which the older schemas accept.
+func writeConf(t *testing.T, dir, value string) string {
+	t.Helper()
+
+	conf := "apiVersion: kfd.sighup.io/v1alpha2\nkind: OnPremises\nspec:\n  kubernetes:\n" +
+		"    pkiFolder: \"" + value + "\"\n"
+
+	path := filepath.Join(dir, "furyctl.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(conf), 0o600))
+
+	return path
+}
+
+// writePKI writes a complete PKI folder at dir/pki.
+func writePKI(t *testing.T, dir string) {
+	t.Helper()
+
+	files := map[string][]string{
+		"master": {"ca.crt", "ca.key", "front-proxy-ca.crt", "front-proxy-ca.key", "sa.key", "sa.pub"},
+		"etcd":   {"ca.crt", "ca.key"},
+	}
+
+	for sub, names := range files {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "pki", sub), os.ModePerm))
+
+		for _, name := range names {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "pki", sub, name), []byte("x"), 0o600))
+		}
+	}
+}
+
+func TestPKIValidator_ValidatePKI_Complete(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	confPath := writeConf(t, dir, "./pki")
+	writePKI(t, dir)
+
+	validator := &onpremises.PKIValidator{}
+
+	require.NoError(t, validator.ValidatePKI(confPath))
+}
+
+func TestPKIValidator_ValidatePKI_FilesMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	confPath := writeConf(t, dir, "./pki")
+	writePKI(t, dir)
+	require.NoError(t, os.Remove(filepath.Join(dir, "pki", "etcd", "ca.key")))
+
+	validator := &onpremises.PKIValidator{}
+
+	err := validator.ValidatePKI(confPath)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, onpremises.ErrPkiFolder)
+
+	filesMissing := &clusterpki.FilesMissingError{}
+	require.ErrorAs(t, err, &filesMissing)
+	assert.Equal(t, []string{filepath.Join("etcd", "ca.key")}, filesMissing.Missing)
+}
+
+func TestPKIValidator_ValidatePKI_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	confPath := writeConf(t, dir, "")
+	writePKI(t, dir)
+
+	validator := &onpremises.PKIValidator{}
+
+	err := validator.ValidatePKI(confPath)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, onpremises.ErrPkiFolder)
+	assert.ErrorIs(t, err, clusterpki.ErrPathEmpty)
+}

--- a/internal/apis/kfd/v1alpha2/onpremises/public/schema.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/public/schema.go
@@ -27,6 +27,9 @@ type Spec struct {
 
 type Kubernetes struct {
 	Advanced *Advanced `yaml:"advanced,omitempty"`
+	// PkiFolder is the folder that holds the CA certificates and keys for the control plane and etcd.
+	// The playbooks read them from the `master` and `etcd` subfolders.
+	PkiFolder *string `yaml:"pkiFolder,omitempty"`
 }
 
 type Advanced struct {

--- a/internal/apis/schema.go
+++ b/internal/apis/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/kfddistribution"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/onpremises"
+	"github.com/sighupio/furyctl/internal/distribution"
 )
 
 type ExtraSchemaValidator interface {
@@ -26,12 +27,12 @@ type PKIValidator interface {
 // `furyctl create config` writes a configuration whose PKI folder does not exist yet.
 func NewPKIValidatorFactory(apiVersion, kind string) PKIValidator {
 	switch apiVersion {
-	case "kfd.sighup.io/v1alpha2":
+	case distribution.APIVersionV1Alpha2:
 		switch kind {
-		case "OnPremises":
+		case distribution.OnPremisesKind:
 			return &onpremises.PKIValidator{}
 
-		case "Immutable":
+		case distribution.ImmutableKind:
 			return &immutable.PKIValidator{}
 
 		default:
@@ -45,18 +46,18 @@ func NewPKIValidatorFactory(apiVersion, kind string) PKIValidator {
 
 func NewExtraSchemaValidatorFactory(apiVersion, kind string) ExtraSchemaValidator {
 	switch apiVersion {
-	case "kfd.sighup.io/v1alpha2":
+	case distribution.APIVersionV1Alpha2:
 		switch kind {
-		case "EKSCluster":
+		case distribution.EKSClusterKind:
 			return &ekscluster.ExtraSchemaValidator{}
 
-		case "KFDDistribution":
+		case distribution.KFDDistributionKind:
 			return &kfddistribution.ExtraSchemaValidator{}
 
-		case "OnPremises":
+		case distribution.OnPremisesKind:
 			return &onpremises.ExtraSchemaValidator{}
 
-		case "Immutable":
+		case distribution.ImmutableKind:
 			return &immutable.ExtraSchemaValidator{}
 
 		default:

--- a/internal/apis/schema.go
+++ b/internal/apis/schema.go
@@ -15,6 +15,34 @@ type ExtraSchemaValidator interface {
 	Validate(confPath string) error
 }
 
+// PKIValidator checks the local PKI folder that a configuration points at.
+type PKIValidator interface {
+	ValidatePKI(confPath string) error
+}
+
+// NewPKIValidatorFactory returns the PKI validator of the kind, or nil for a kind that reads no local
+// PKI. This check is separate from ExtraSchemaValidator because only `furyctl apply` and
+// `furyctl validate config` run it. The other commands must not run it. For example,
+// `furyctl create config` writes a configuration whose PKI folder does not exist yet.
+func NewPKIValidatorFactory(apiVersion, kind string) PKIValidator {
+	switch apiVersion {
+	case "kfd.sighup.io/v1alpha2":
+		switch kind {
+		case "OnPremises":
+			return &onpremises.PKIValidator{}
+
+		case "Immutable":
+			return &immutable.PKIValidator{}
+
+		default:
+			return nil
+		}
+
+	default:
+		return nil
+	}
+}
+
 func NewExtraSchemaValidatorFactory(apiVersion, kind string) ExtraSchemaValidator {
 	switch apiVersion {
 	case "kfd.sighup.io/v1alpha2":

--- a/internal/clusterpki/check.go
+++ b/internal/clusterpki/check.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package clusterpki
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	parserx "github.com/sighupio/furyctl/internal/parser"
+	"github.com/sighupio/furyctl/pkg/template/mapper"
+)
+
+var (
+	// ErrPathEmpty reports a configuration field that is absent, or that holds an empty string. The
+	// schemas of the supported SD versions reject both, so this occurs only with an older schema.
+	ErrPathEmpty = errors.New("the configuration field has no value")
+
+	// ErrPathNotAFolder reports a PKI folder path that exists and is not a folder.
+	ErrPathNotAFolder = errors.New("the PKI folder path exists and is not a folder")
+
+	// ErrPathNotResolvable reports a relative path without a "./" or "../" prefix. The template mapper
+	// does not make such a value absolute, so the playbooks read it from the phase folder.
+	ErrPathNotResolvable = errors.New(
+		"the PKI folder path is relative without a \"./\" prefix. furyctl cannot resolve such a value. " +
+			"The playbooks then read it from a folder inside .furyctl/<cluster>/, and that folder is not the " +
+			"same for each phase. Write \"./<path>\" for a folder next to the configuration file, or write " +
+			"an absolute path",
+	)
+)
+
+// controlPlaneFiles returns the files that the kube-control-plane role of the installer copies to each
+// control plane node.
+func controlPlaneFiles() []string {
+	return []string{
+		ControlPlaneCaCrt,
+		ControlPlaneCaKey,
+		ControlPlaneFProxyCrt,
+		ControlPlaneFProxyKey,
+		ControlPlaneSaKey,
+		ControlPlaneSaPub,
+	}
+}
+
+// etcdFiles returns the files that the etcd role of the installer copies to each etcd node.
+func etcdFiles() []string {
+	return []string{
+		EtcdCaCrt,
+		EtcdCaKey,
+	}
+}
+
+// FolderMissingError reports a PKI folder that does not exist.
+type FolderMissingError struct {
+	Path string
+}
+
+func (e *FolderMissingError) Error() string {
+	return fmt.Sprintf(
+		"the PKI folder %s does not exist: the Kubernetes and etcd playbooks read the CA certificates "+
+			"and keys from it. To create it, run `furyctl create pki --path %s`",
+		e.Path,
+		e.Path,
+	)
+}
+
+// FilesMissingError reports a PKI folder that does not hold all the files that the playbooks read.
+type FilesMissingError struct {
+	Path    string
+	Missing []string
+}
+
+func (e *FilesMissingError) Error() string {
+	return fmt.Sprintf(
+		"the PKI folder %s is not complete. These files are absent or empty: %s. Restore them from your "+
+			"backup. furyctl does not write to a PKI folder that exists. If the cluster does not exist yet, "+
+			"delete the folder and run `furyctl create pki --path %s`",
+		e.Path,
+		strings.Join(e.Missing, ", "),
+		e.Path,
+	)
+}
+
+// ResolvePath returns the absolute PKI folder path for a value of a configuration file. It applies the
+// rules that the template mapper applies to the same value before it renders the playbooks. See
+// mapper.Mapper.injectDynamicValuesAndPathsString. An absolute path does not change. A path that starts
+// with "./" or "../" resolves against the folder of the configuration file. Any other relative path
+// stays relative in the rendered playbook, so this function rejects it.
+//
+// The result is always absolute, because the messages name the folder and give the command that creates
+// it. `furyctl validate config` does not make the path of the configuration file absolute. A relative
+// path here would give a message that is correct in one working folder only.
+func ResolvePath(value, confDir string) (string, error) {
+	if value == "" {
+		return "", ErrPathEmpty
+	}
+
+	absConfDir, err := filepath.Abs(confDir)
+	if err != nil {
+		return "", fmt.Errorf("error while getting the absolute path of the configuration folder: %w", err)
+	}
+
+	// The mapper expands the dynamic values of the configuration, for example "{env://PKI_DIR}" and
+	// "{path://pki}", before it applies the rules for a relative path. The same order is necessary here.
+	// Without it, this check rejects a value that the playbooks resolve.
+	expanded, err := parserx.NewConfigParser(absConfDir).ParseMultipleDynamicValues(value)
+	if err != nil {
+		return "", fmt.Errorf("error while expanding the dynamic values of the PKI folder path: %w", err)
+	}
+
+	if expanded == "" {
+		return "", ErrPathEmpty
+	}
+
+	if filepath.IsAbs(expanded) {
+		return filepath.Clean(expanded), nil
+	}
+
+	if !mapper.RelativePathRegexp.MatchString(expanded) {
+		return "", fmt.Errorf("%w: %s", ErrPathNotResolvable, expanded)
+	}
+
+	return filepath.Join(absConfDir, filepath.Clean(expanded)), nil
+}
+
+// Check reports whether absPath holds the master and etcd folders with the files that the installer
+// roles read. It returns a *FolderMissingError when the folder is absent, and ErrPathNotAFolder when the
+// path is not a folder. It returns a *FilesMissingError when one file or more is absent or empty. It
+// returns a read error when furyctl cannot read the folder or a file.
+func Check(absPath string) error {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &FolderMissingError{Path: absPath}
+		}
+
+		return fmt.Errorf("error while checking the PKI folder %s: %w", absPath, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s", ErrPathNotAFolder, absPath)
+	}
+
+	controlPlaneMissing, err := missingFiles(absPath, ControlPlanePath, controlPlaneFiles())
+	if err != nil {
+		return err
+	}
+
+	etcdMissing, err := missingFiles(absPath, etcdPath, etcdFiles())
+	if err != nil {
+		return err
+	}
+
+	missing := slices.Concat(controlPlaneMissing, etcdMissing)
+
+	if len(missing) > 0 {
+		return &FilesMissingError{Path: absPath, Missing: missing}
+	}
+
+	return nil
+}
+
+// missingFiles returns the files of dir that are absent, empty, or not a regular file. The returned
+// names hold the folder, for example "master/ca.crt", so that the message points at the file. A file
+// that furyctl cannot read gives an error, and not a name in the list. The message for an absent file
+// tells the user to delete the folder. That step destroys the CA of a cluster that exists.
+func missingFiles(absPath, dir string, files []string) ([]string, error) {
+	missing := []string{}
+
+	for _, file := range files {
+		path := filepath.Join(absPath, dir, file)
+
+		info, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				missing = append(missing, filepath.Join(dir, file))
+
+				continue
+			}
+
+			return nil, fmt.Errorf("error while reading the PKI file %s: %w", path, err)
+		}
+
+		if !info.Mode().IsRegular() || info.Size() == 0 {
+			missing = append(missing, filepath.Join(dir, file))
+		}
+	}
+
+	return missing, nil
+}

--- a/internal/clusterpki/check.go
+++ b/internal/clusterpki/check.go
@@ -170,15 +170,16 @@ func Check(absPath string) error {
 // that furyctl cannot read gives an error, and not a name in the list. The message for an absent file
 // tells the user to delete the folder. That step destroys the CA of a cluster that exists.
 func missingFiles(absPath, dir string, files []string) ([]string, error) {
-	missing := []string{}
+	var missing []string
 
 	for _, file := range files {
-		path := filepath.Join(absPath, dir, file)
+		relPath := filepath.Join(dir, file)
+		path := filepath.Join(absPath, relPath)
 
 		info, err := os.Stat(path)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				missing = append(missing, filepath.Join(dir, file))
+				missing = append(missing, relPath)
 
 				continue
 			}
@@ -187,7 +188,7 @@ func missingFiles(absPath, dir string, files []string) ([]string, error) {
 		}
 
 		if !info.Mode().IsRegular() || info.Size() == 0 {
-			missing = append(missing, filepath.Join(dir, file))
+			missing = append(missing, relPath)
 		}
 	}
 

--- a/internal/clusterpki/check_test.go
+++ b/internal/clusterpki/check_test.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package clusterpki_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/clusterpki"
+)
+
+// completePKI writes a PKI folder that holds every file the installer roles read.
+func completePKI(t *testing.T) string {
+	t.Helper()
+
+	base := filepath.Join(t.TempDir(), "pki")
+
+	files := map[string][]string{
+		"master": {"ca.crt", "ca.key", "front-proxy-ca.crt", "front-proxy-ca.key", "sa.key", "sa.pub"},
+		"etcd":   {"ca.crt", "ca.key"},
+	}
+
+	for dir, names := range files {
+		require.NoError(t, os.MkdirAll(filepath.Join(base, dir), os.ModePerm))
+
+		for _, name := range names {
+			require.NoError(t, os.WriteFile(filepath.Join(base, dir, name), []byte("x"), 0o600))
+		}
+	}
+
+	return base
+}
+
+func TestCheck_Complete(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, clusterpki.Check(completePKI(t)))
+}
+
+func TestCheck_FolderMissing(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "pki")
+
+	err := clusterpki.Check(path)
+
+	folderMissing := &clusterpki.FolderMissingError{}
+	require.ErrorAs(t, err, &folderMissing)
+	assert.Equal(t, path, folderMissing.Path)
+	assert.Contains(t, err.Error(), "furyctl create pki --path "+path)
+}
+
+func TestCheck_PathIsAFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "pki")
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+
+	err := clusterpki.Check(path)
+
+	require.ErrorIs(t, err, clusterpki.ErrPathNotAFolder)
+
+	// The folder exists, so the message must not tell the user to create it.
+	folderMissing := &clusterpki.FolderMissingError{}
+	assert.NotErrorAs(t, err, &folderMissing)
+}
+
+// furyctl must not report a file that it cannot read as absent. The message for an absent file tells the
+// user to delete the folder, and that step destroys the CA of a cluster that exists.
+func TestCheck_FileIsUnreadable(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a folder without the execute permission")
+	}
+
+	base := completePKI(t)
+	require.NoError(t, os.Chmod(filepath.Join(base, "master"), 0o000))
+
+	t.Cleanup(func() {
+		_ = os.Chmod(filepath.Join(base, "master"), 0o700)
+	})
+
+	err := clusterpki.Check(base)
+
+	require.Error(t, err)
+
+	filesMissing := &clusterpki.FilesMissingError{}
+	assert.NotErrorAs(t, err, &filesMissing)
+	assert.ErrorIs(t, err, os.ErrPermission)
+}
+
+func TestCheck_FilesMissing(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc        string
+		mutate      func(t *testing.T, base string)
+		wantMissing []string
+	}{
+		{
+			desc: "one file of the control plane is absent",
+			mutate: func(t *testing.T, base string) {
+				t.Helper()
+				require.NoError(t, os.Remove(filepath.Join(base, "master", "sa.pub")))
+			},
+			wantMissing: []string{filepath.Join("master", "sa.pub")},
+		},
+		{
+			desc: "one file is empty",
+			mutate: func(t *testing.T, base string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(base, "etcd", "ca.key"), []byte(""), 0o600))
+			},
+			wantMissing: []string{filepath.Join("etcd", "ca.key")},
+		},
+		{
+			desc: "one file is a folder",
+			mutate: func(t *testing.T, base string) {
+				t.Helper()
+				path := filepath.Join(base, "master", "ca.crt")
+				require.NoError(t, os.Remove(path))
+				require.NoError(t, os.Mkdir(path, os.ModePerm))
+			},
+			wantMissing: []string{filepath.Join("master", "ca.crt")},
+		},
+		{
+			desc: "the etcd folder is absent",
+			mutate: func(t *testing.T, base string) {
+				t.Helper()
+				require.NoError(t, os.RemoveAll(filepath.Join(base, "etcd")))
+			},
+			wantMissing: []string{filepath.Join("etcd", "ca.crt"), filepath.Join("etcd", "ca.key")},
+		},
+		{
+			desc: "the folder is empty",
+			mutate: func(t *testing.T, base string) {
+				t.Helper()
+				require.NoError(t, os.RemoveAll(filepath.Join(base, "master")))
+				require.NoError(t, os.RemoveAll(filepath.Join(base, "etcd")))
+			},
+			wantMissing: []string{
+				filepath.Join("master", "ca.crt"),
+				filepath.Join("master", "ca.key"),
+				filepath.Join("master", "front-proxy-ca.crt"),
+				filepath.Join("master", "front-proxy-ca.key"),
+				filepath.Join("master", "sa.key"),
+				filepath.Join("master", "sa.pub"),
+				filepath.Join("etcd", "ca.crt"),
+				filepath.Join("etcd", "ca.key"),
+			},
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			base := completePKI(t)
+			tC.mutate(t, base)
+
+			filesMissing := &clusterpki.FilesMissingError{}
+			require.ErrorAs(t, clusterpki.Check(base), &filesMissing)
+			assert.Equal(t, tC.wantMissing, filesMissing.Missing)
+		})
+	}
+}
+
+func TestResolvePath(t *testing.T) {
+	t.Parallel()
+
+	confDir := filepath.Join(string(os.PathSeparator), "home", "user", "lab")
+
+	testCases := []struct {
+		desc    string
+		confDir string
+		value   string
+		want    string
+		wantErr error
+	}{
+		{
+			desc:  "an absolute path does not change",
+			value: filepath.Join(string(os.PathSeparator), "opt", "pki"),
+			want:  filepath.Join(string(os.PathSeparator), "opt", "pki"),
+		},
+		{
+			desc:  "a path with a ./ prefix resolves against the folder of the configuration file",
+			value: "./pki",
+			want:  filepath.Join(confDir, "pki"),
+		},
+		{
+			desc:  "a path with a ../ prefix resolves against the folder of the configuration file",
+			value: "../secrets/pki",
+			want:  filepath.Join(string(os.PathSeparator), "home", "user", "secrets", "pki"),
+		},
+		{
+			desc:    "a relative folder of the configuration file gives an absolute path",
+			confDir: ".",
+			value:   "./pki",
+			want:    "pki",
+		},
+		{
+			// The mapper expands the dynamic values before it applies the rules for a relative path, so
+			// this check must expand them too.
+			desc:  "a path from a {path://} value resolves against the folder of the configuration file",
+			value: "{path://pki}",
+			want:  filepath.Join(confDir, "pki"),
+		},
+		{
+			desc:  "a path from a {path://} value with a subfolder",
+			value: "{path://secrets/pki}",
+			want:  filepath.Join(confDir, "secrets", "pki"),
+		},
+		{
+			desc:    "a relative path without a ./ prefix is an error",
+			value:   "pki",
+			wantErr: clusterpki.ErrPathNotResolvable,
+		},
+		{
+			desc:    "a relative path with a folder and without a ./ prefix is an error",
+			value:   "secrets/pki",
+			wantErr: clusterpki.ErrPathNotResolvable,
+		},
+		{
+			desc:    "an empty value is an error",
+			value:   "",
+			wantErr: clusterpki.ErrPathEmpty,
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			dir := confDir
+			if tC.confDir != "" {
+				dir = tC.confDir
+			}
+
+			got, err := clusterpki.ResolvePath(tC.value, dir)
+
+			if tC.wantErr != nil {
+				require.True(t, errors.Is(err, tC.wantErr), "got error %v", err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			// The result is always absolute, so compare against the absolute form of the wanted path.
+			want, absErr := filepath.Abs(tC.want)
+			require.NoError(t, absErr)
+
+			assert.Equal(t, want, got)
+			assert.True(t, filepath.IsAbs(got), "the result must be absolute, got %s", got)
+		})
+	}
+}
+
+// TestResolvePath_EnvValue covers a value that comes from an environment variable. The mapper expands
+// it before it renders the playbooks, so this check must accept it.
+func TestResolvePath_EnvValue(t *testing.T) {
+	pkiDir := filepath.Join(string(os.PathSeparator), "opt", "pki")
+	t.Setenv("FURYCTL_TEST_PKI_DIR", pkiDir)
+
+	got, err := clusterpki.ResolvePath("{env://FURYCTL_TEST_PKI_DIR}", filepath.Join("home", "user"))
+
+	require.NoError(t, err)
+	assert.Equal(t, pkiDir, got)
+}
+
+// TestResolvePath_EnvValueEmpty covers an environment variable that holds no value. The parser reports
+// it, so the message names the variable.
+func TestResolvePath_EnvValueEmpty(t *testing.T) {
+	t.Setenv("FURYCTL_TEST_PKI_DIR", "")
+
+	_, err := clusterpki.ResolvePath("{env://FURYCTL_TEST_PKI_DIR}", filepath.Join("home", "user"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "FURYCTL_TEST_PKI_DIR")
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -159,6 +159,31 @@ func Validate(path, repoPath string) error {
 	return validateToolsConfiguration(repoPath, rawConf)
 }
 
+// ValidatePKI checks the local PKI folder that the configuration points at, for each kind that reads a
+// local PKI. It is a separate function, and not a rule of Validate, because most commands that call
+// Validate read no local PKI. `furyctl create config` writes a configuration whose PKI folder does not
+// exist yet, and it deletes the file when Validate fails. Only `furyctl apply` and
+// `furyctl validate config` call this function.
+func ValidatePKI(path string) error {
+	miniConf, err := loadFromFile(path)
+	if err != nil {
+		return err
+	}
+
+	validator := apis.NewPKIValidatorFactory(miniConf.APIVersion, miniConf.Kind)
+	if validator == nil {
+		logrus.Debugf("kind %s reads no local PKI. The PKI folder check does not run", miniConf.Kind)
+
+		return nil
+	}
+
+	if err := validator.ValidatePKI(path); err != nil {
+		return fmt.Errorf("error while validating the PKI folder: %w", err)
+	}
+
+	return nil
+}
+
 // checkSchemaSupportsFlags determines if the schema includes support for the flags field.
 // This allows furyctl to work with both old schemas (without flags) and new schemas (with flags).
 func checkSchemaSupportsFlags(schemaPath string) bool {

--- a/internal/distribution/compatibility.go
+++ b/internal/distribution/compatibility.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	APIVersionV1Alpha2     = "kfd.sighup.io/v1alpha2"
 	EKSClusterKind         = "EKSCluster"
 	KFDDistributionKind    = "KFDDistribution"
 	OnPremisesKind         = "OnPremises"


### PR DESCRIPTION
### Summary 💡

furyctl did not check the folder in `.spec.kubernetes.pkiPath` (Immutable) or `.spec.kubernetes.pkiFolder` (OnPremises) before an apply.

When the folder or one of its files was absent, the apply failed in the middle with an Ansible error hard to understand.

Closes https://github.com/sighupio/distribution/issues/584

Relates:
- https://github.com/sighupio/distribution/pull/585
- https://github.com/sighupio/distribution/pull/583

### Description 📝

furyctl did not check the folder in `.spec.kubernetes.pkiPath` (Immutable) or `.spec.kubernetes.pkiFolder` (OnPremises) before an apply. When the folder or one of its files was absent, the apply failed in the middle, inside an Ansible task. The message did not say how to correct the fault.

`furyctl apply` and `furyctl validate config` now check that the folder holds the files that the installer roles copy to the nodes:

- under master/: ca.crt, ca.key, front-proxy-ca.crt, front-proxy-ca.key, sa.key and sa.pub
- under etcd/: ca.crt and ca.key

`furyctl apply` skips the check when the selected phases don't need the PKI. As a result, an apply of the distribution or the plugins phase alone does not ask for the CA keys. A dry run also skips the check, with a warning, because it stops before Ansible.

#### Failure modes

An absent folder names the `furyctl create pki` command to run.

An incomplete folder, names the files that are absent or empty.

A file that furyctl cannot read gives a read error, and not a name in that list. The message for an incomplete folder tells the user to delete the folder, and that step destroys the CA of a cluster that exists.

The table below gives the commands and the phases that do the check:

| Command | The check |
|---|---|
| `apply`, `apply --phase infrastructure\|kubernetes` | runs |
| `apply --phase distribution\|plugins` | does not run |
| `apply --start-from` a distribution or plugins sub-phase | does not run |
| `apply --start-from post-kubernetes` | does not run, because `coreKubernetes` skips `apply.yaml` |
| `apply --post-apply-phases kubernetes` | runs, because `extraPhases` repeats that phase |
| `apply --dry-run` | does not run, and gives a warning |
| `validate config` | runs |
| the other 6 commands that call `config.Validate` | do not run it |

Worth noting that during the resume of an upgrade the PKI check will be done because the start phase comes from the saved state in the configmap and is not known at validate config time. If the user specifies `--upgrade` and `--start-from` the starting phase will be known and the check will be skipped if not needed.

### Breaking Changes 💔

None. Each new check is preventive. The blocked cases make the apply fail later, inside an Ansible task.

A test in CI can fail if it does not create the PKI folder before it uses it. The correction is simple: create the pki first. From what I checked, distribution and furyctl tests are not affected.

### Tests performed 🧪

- [x] `furyctl create config --kind Immutable` and `--kind OnPremises`, against a local distribution: the file is written, and it is not deleted.
- [x] `validate config` with the folder absent, with a complete folder, and with 2 files removed.
- [x] `validate config` with `pkiPath: pki` (a relative value without a prefix), with `{path://realpki}` and with `{env://PKI_DIR}`.
- [x] `validate config` with a relative `--config` value from 2 different working folders: the message gives the same absolute path.
- [x] `validate config` with an Immutable configuration without `pkiPath`, against the schema of distribution#585: the schema reports the absent field first.
- [x] `apply --phase distribution` with an incomplete folder: the check does not run.
- [x] `apply --phase kubernetes` with an incomplete folder: exit code 1, with the message for an incomplete folder.
- [x] `apply --dry-run` with the folder absent: a warning, and the apply continues.
- [x] A folder that furyctl cannot read (mode `0o000`): a read error, and not a message for absent files.
- [x] `furyctl dump template` in `distribution/tests/templates/immutable/01-full-calico-nginx`, which holds `pkiPath: ./pki` and no `pki` folder: exit code 0, and the result is the same as the baseline. This is the command that `test:templates:regressions` runs.
- [x] An apply against a real Immutable cluster.

### Future work 🔧

- We could ask the user if wants to create the missing PKI folder instead of erroring out, but this feature needs some planning. Evaluate whether furyctl writes the path into `furyctl.yaml`.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change — `NewPKIValidatorFactory` returns nil for `EKSCluster` and `KFDDistribution`, so their behavior does not change
- [x] CI is green