### PR TITLE
chore: improve air-gap-bundle messages

### DIFF
--- a/cmd/download/airgappedbundle.go
+++ b/cmd/download/airgappedbundle.go
@@ -84,11 +84,13 @@ func NewAirGappedBundleCmd() *cobra.Command {
 	airGappedBundleCmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "air-gapped-bundle",
-		Short: "Build a self-contained tarball with the distribution, modules, installers and tools to run furyctl offline",
-		Long: "Build a self-contained tarball with everything needed to run furyctl on an air-gapped machine: " +
-			"the distribution manifests, modules, installers and all the tools installed via the bundled mise. " +
-			"The bundle is built for the host platform only. On the target machine, extract it in the working " +
-			"directory and run 'furyctl apply --skip-deps-download --distro-location ./distro'.",
+		Short: "Build a self-contained bundle with the distribution, modules, installers and tools to run furyctl offline",
+		Long: "Build a self-contained bundle with everything necessary to run furyctl on an air-gapped machine. " +
+			"The bundle holds the distribution manifests, the modules, the installers and all the tools from " +
+			"the bundled mise. furyctl builds the bundle for the host platform only. " +
+			"On the target machine, copy the bundle and your furyctl.yaml. " +
+			"Then run 'furyctl apply --airgap-bundle /path/to/bundle.tar.gz'. " +
+			"furyctl extracts the bundle in the working directory and runs offline.",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			cmdEvent = analytics.NewCommandEvent(cobrax.GetFullname(cmd))
 
@@ -226,9 +228,12 @@ func NewAirGappedBundleCmd() *cobra.Command {
 				return fmt.Errorf("error creating air-gapped bundle: %w", err)
 			}
 
-			logrus.Infof("Air-gapped bundle ready: %s", bundleOutput)
-			logrus.Info("On the target machine: extract it in the working directory, then run " +
-				"'furyctl apply --skip-deps-download --distro-location ./distro'")
+			logrus.Infof("The air-gapped bundle is ready: %s", bundleOutput)
+			logrus.Infof("On the target machine, copy the bundle and your furyctl.yaml. "+
+				"Then run: furyctl apply --airgap-bundle %s", bundleOutput)
+			logrus.Info("furyctl extracts the bundle in the working directory and runs offline. " +
+				"You can use the same --airgap-bundle flag with these commands: diff, delete cluster, " +
+				"get kubeconfig, get upgrade-paths, renew certificates.")
 
 			cmdEvent.AddSuccessMessage("Air-gapped bundle created successfully")
 			tracker.Track(cmdEvent)
@@ -247,7 +252,7 @@ func NewAirGappedBundleCmd() *cobra.Command {
 	airGappedBundleCmd.Flags().String(
 		"bundle-output",
 		"",
-		"Path of the air-gapped bundle tarball to create (eg: ./cluster-airgap.tar.gz)",
+		"Path of the air-gapped bundle to create (eg: ./cluster-airgap.tar.gz)",
 	)
 
 	airGappedBundleCmd.Flags().StringP(

--- a/internal/airgap/airgap.go
+++ b/internal/airgap/airgap.go
@@ -46,15 +46,15 @@ func RegisterFlags(cmd *cobra.Command) {
 	cmd.Flags().String(
 		"airgap-bundle",
 		"",
-		"Path to an air-gapped bundle (.tar.gz) produced by 'furyctl download air-gapped-bundle'. "+
-			"When set, furyctl extracts it into the working directory and runs fully offline "+
-			"(implies --skip-deps-download and --distro-location)",
+		"Path to an air-gapped bundle (.tar.gz) that 'furyctl download air-gapped-bundle' creates. "+
+			"If you set this flag, furyctl extracts the bundle in the working directory and runs offline. "+
+			"furyctl also sets --skip-deps-download and --distro-location",
 	)
 
 	cmd.Flags().Bool(
 		"force-extract",
 		false,
-		"Force re-extraction of the --airgap-bundle even when it was already extracted",
+		"Extract the --airgap-bundle again, also when furyctl extracted it before",
 	)
 }
 
@@ -103,7 +103,7 @@ func prepare(bundle, outDir string, force bool) (string, error) {
 	distroLocation := filepath.Join(outDir, DistroSubdir)
 
 	if !force && bundleAlreadyExtracted(marker, sum) {
-		logrus.Infof("Air-gapped bundle already extracted, reusing it (use --force-extract to re-extract)")
+		logrus.Info("Air-gapped bundle already extracted, reusing it (use --force-extract to re-extract)")
 
 		return distroLocation, nil
 	}


### PR DESCRIPTION
### Summary 💡

Improve air-gap-bundle command help messages and instructions showed to the user.

Usage instructions where not pointing the user to the right flags to set.

Closes #734 

Relates:
- #673 

### Description 📝

Creating an air-gap-bundle with the new feature printed the wrong instructions on how to use the bundle, misleading the user into a usage error.

This PR updates the logged instructions, help messages and aligns the terms used.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested bundle creation, then `diff` and `apply` using the bundle.

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~ I don't think is relevant to the release notes.
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

