### PR TITLE
fix(preflight): reject changes to skipped phases with --start-from

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -8,8 +8,10 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 
 ## Bug fixes 🐞
 
-TBD
+- [[#743](https://github.com/sighupio/furyctl/pull/743)] All kinds: `apply --start-from` now stops when the configuration has changes to a phase before the selected one. Before this fix furyctl skipped those changes and wrote the new configuration to the cluster, so the change was lost and the next `diff` did not show it as pending.
+
 
 ## Breaking Changes 💔
 
 None
+

--- a/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/create/preflight.go
@@ -54,10 +54,11 @@ type PreFlight struct {
 	paths          cluster.CreatorPaths
 	force          []string
 	phase          string
+	startFrom      string
 	upgradeEnabled bool
 }
 
-func NewPreFlight(
+func NewPreFlight( //nolint:revive // ignore maximum number of arguments
 	furyctlConf private.EksclusterKfdV1Alpha2,
 	kfdManifest config.KFD,
 	paths cluster.CreatorPaths,
@@ -67,6 +68,7 @@ func NewPreFlight(
 	force []string,
 	infraOutputsPath,
 	phase string,
+	startFrom string,
 	upgradeEnabled bool,
 ) (*PreFlight, error) {
 	p := cluster.NewOperationPhase(
@@ -143,6 +145,7 @@ func NewPreFlight(
 		paths:          paths,
 		force:          force,
 		phase:          phase,
+		startFrom:      startFrom,
 		upgradeEnabled: upgradeEnabled,
 	}, nil
 }
@@ -260,10 +263,10 @@ func (p *PreFlight) Exec(renderedConfig map[string]any) (*Status, error) {
 				return status, fmt.Errorf("error checking reducer diffs: %w", err)
 			}
 
-			if p.phase != cluster.OperationPhaseAll && !p.upgradeEnabled {
-				logrus.Info("Cluster configuration has changed, checking if changes are supported in the current phase...")
+			if (p.phase != cluster.OperationPhaseAll || p.startFrom != cluster.OperationPhaseAll) && !p.upgradeEnabled {
+				logrus.Info("Cluster configuration has changed, checking if changes are supported in the phases to apply...")
 
-				if err := cluster.AssertPhaseDiffs(d, p.phase, supported.Phases()); err != nil {
+				if err := cluster.AssertPhaseDiffs(d, p.phase, p.startFrom, supported.Phases()); err != nil {
 					return status, fmt.Errorf("error checking changes to other phases: %w", err)
 				}
 			}

--- a/internal/apis/kfd/v1alpha2/ekscluster/creator.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/creator.go
@@ -153,7 +153,7 @@ func (*ClusterCreator) GetPhasePath(phase string) (string, error) {
 func (v *ClusterCreator) Create(startFrom string, timeout, _ int) error {
 	upgr := upgrade.New(v.paths, string(v.furyctlConf.Kind))
 
-	infra, kube, distro, plugins, preflight, err := v.setupPhases(upgr, v.upgrade)
+	infra, kube, distro, plugins, preflight, err := v.setupPhases(upgr, v.upgrade, startFrom)
 	if err != nil {
 		return err
 	}
@@ -831,7 +831,7 @@ func (*ClusterCreator) getDistributionSubPhase(startFrom string) string {
 }
 
 //nolint:revive // ignore maximum number of return results
-func (v *ClusterCreator) setupPhases(upgr *upgrade.Upgrade, upgradeFlag bool) (
+func (v *ClusterCreator) setupPhases(upgr *upgrade.Upgrade, upgradeFlag bool, startFrom string) (
 	*upgrade.OperatorPhaseAsyncDecorator,
 	*upgrade.OperatorPhaseAsyncDecorator,
 	*upgrade.ReducerOperatorPhaseAsyncDecorator[reducers.Reducers],
@@ -898,6 +898,7 @@ func (v *ClusterCreator) setupPhases(upgr *upgrade.Upgrade, upgradeFlag bool) (
 		v.force,
 		infra.Self().TerraformOutputsPath,
 		v.phase,
+		startFrom,
 		upgradeFlag,
 	)
 	if err != nil {

--- a/internal/apis/kfd/v1alpha2/immutable/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/preflight.go
@@ -51,6 +51,7 @@ type PreFlight struct {
 	dryRun         bool
 	force          []string
 	phase          string
+	startFrom      string
 	upgradeEnabled bool
 }
 
@@ -62,6 +63,7 @@ func NewPreFlight(
 	stateStore state.Storer,
 	force []string,
 	phase string,
+	startFrom string,
 	upgradeEnabled bool,
 ) *PreFlight {
 	p := cluster.NewOperationPhase(
@@ -93,6 +95,7 @@ func NewPreFlight(
 		dryRun:         dryRun,
 		force:          force,
 		phase:          phase,
+		startFrom:      startFrom,
 		upgradeEnabled: upgradeEnabled,
 	}
 }
@@ -198,10 +201,10 @@ func (p *PreFlight) Exec(renderedConfig map[string]any) (*Status, error) {
 				return status, fmt.Errorf("error checking reducer diffs: %w", err)
 			}
 
-			if p.phase != cluster.OperationPhaseAll && !p.upgradeEnabled {
-				logrus.Info("Cluster configuration has changed, checking if changes are supported in the current phase...")
+			if (p.phase != cluster.OperationPhaseAll || p.startFrom != cluster.OperationPhaseAll) && !p.upgradeEnabled {
+				logrus.Info("Cluster configuration has changed, checking if changes are supported in the phases to apply...")
 
-				if err := cluster.AssertPhaseDiffs(d, p.phase, supported.Phases()); err != nil {
+				if err := cluster.AssertPhaseDiffs(d, p.phase, p.startFrom, supported.Phases()); err != nil {
 					return status, fmt.Errorf("error checking changes to other phases: %w", err)
 				}
 			}

--- a/internal/apis/kfd/v1alpha2/immutable/creator.go
+++ b/internal/apis/kfd/v1alpha2/immutable/creator.go
@@ -183,6 +183,7 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 		c.stateStore,
 		c.force,
 		c.phase,
+		startFrom,
 		c.upgrade,
 	)
 

--- a/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/create/preflight.go
@@ -52,6 +52,7 @@ type PreFlight struct {
 	dryRun          bool
 	force           []string
 	phase           string
+	startFrom       string
 	upgradeEnabled  bool
 }
 
@@ -63,6 +64,7 @@ func NewPreFlight(
 	stateStore state.Storer,
 	force []string,
 	phase string,
+	startFrom string,
 	upgradeEnabled bool,
 ) *PreFlight {
 	p := cluster.NewOperationPhase(
@@ -92,6 +94,7 @@ func NewPreFlight(
 		dryRun:         dryRun,
 		force:          force,
 		phase:          phase,
+		startFrom:      startFrom,
 		upgradeEnabled: upgradeEnabled,
 	}
 }
@@ -183,10 +186,10 @@ func (p *PreFlight) Exec(renderedConfig map[string]any) (*Status, error) {
 				return status, fmt.Errorf("error checking reducer diffs: %w", err)
 			}
 
-			if p.phase != cluster.OperationPhaseAll && !p.upgradeEnabled {
-				logrus.Info("Cluster configuration has changed, checking if changes are supported in the current phase...")
+			if (p.phase != cluster.OperationPhaseAll || p.startFrom != cluster.OperationPhaseAll) && !p.upgradeEnabled {
+				logrus.Info("Cluster configuration has changed, checking if changes are supported in the phases to apply...")
 
-				if err := cluster.AssertPhaseDiffs(d, p.phase, supported.Phases()); err != nil {
+				if err := cluster.AssertPhaseDiffs(d, p.phase, p.startFrom, supported.Phases()); err != nil {
 					return status, fmt.Errorf("error checking changes to other phases: %w", err)
 				}
 			}

--- a/internal/apis/kfd/v1alpha2/kfddistribution/creator.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/creator.go
@@ -150,6 +150,7 @@ func (c *ClusterCreator) Create(startFrom string, _, _ int) error {
 		c.stateStore,
 		c.force,
 		c.phase,
+		startFrom,
 		c.upgrade,
 	)
 

--- a/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/create/preflight.go
@@ -50,6 +50,7 @@ type PreFlight struct {
 	dryRun         bool
 	force          []string
 	phase          string
+	startFrom      string
 	upgradeEnabled bool
 }
 
@@ -61,6 +62,7 @@ func NewPreFlight(
 	stateStore state.Storer,
 	force []string,
 	phase string,
+	startFrom string,
 	upgradeEnabled bool,
 ) *PreFlight {
 	p := cluster.NewOperationPhase(
@@ -92,6 +94,7 @@ func NewPreFlight(
 		dryRun:         dryRun,
 		force:          force,
 		phase:          phase,
+		startFrom:      startFrom,
 		upgradeEnabled: upgradeEnabled,
 	}
 }
@@ -198,10 +201,10 @@ func (p *PreFlight) Exec(renderedConfig map[string]any) (*Status, error) {
 				return status, fmt.Errorf("error checking reducer diffs: %w", err)
 			}
 
-			if p.phase != cluster.OperationPhaseAll && !p.upgradeEnabled {
-				logrus.Info("Cluster configuration has changed, checking if changes are supported in the current phase...")
+			if (p.phase != cluster.OperationPhaseAll || p.startFrom != cluster.OperationPhaseAll) && !p.upgradeEnabled {
+				logrus.Info("Cluster configuration has changed, checking if changes are supported in the phases to apply...")
 
-				if err := cluster.AssertPhaseDiffs(d, p.phase, supported.Phases()); err != nil {
+				if err := cluster.AssertPhaseDiffs(d, p.phase, p.startFrom, supported.Phases()); err != nil {
 					return status, fmt.Errorf("error checking changes to other phases: %w", err)
 				}
 			}

--- a/internal/apis/kfd/v1alpha2/onpremises/creator.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/creator.go
@@ -178,6 +178,7 @@ func (c *ClusterCreator) Create(startFrom string, _, podRunningCheckTimeout int)
 		c.stateStore,
 		c.force,
 		c.phase,
+		startFrom,
 		c.upgrade,
 	)
 

--- a/internal/cluster/phase.go
+++ b/internal/cluster/phase.go
@@ -54,6 +54,9 @@ var (
 	ErrChangesToOtherPhases = errors.New("changes to other phases detected. When using the --phase flag, changes " +
 		"only to the section corresponding to the selected phase are accepted. ",
 	)
+	ErrChangesToSkippedPhases = errors.New("changes to skipped phases detected. When using the --start-from flag, " +
+		"changes only to the sections corresponding to the phases that will be applied are accepted. ",
+	)
 )
 
 func CheckPhase(phase string) error {
@@ -413,28 +416,62 @@ func (*OperationPhase) CreateFuryctlMerger(
 	return reverseMerger, nil
 }
 
-func AssertPhaseDiffs(d r3diff.Changelog, currentPhase string, supportedPhases []string) error {
-	unsupportedChanges := make([]string, 0)
+// AssertPhaseDiffs checks that the changelog has no changes to phases that the current run does not apply,
+// either because --phase selects a single phase or because --start-from skips the phases before it.
+func AssertPhaseDiffs(d r3diff.Changelog, currentPhase, startFrom string, supportedPhases []string) error {
+	if currentPhase != OperationPhaseAll {
+		if changes := changesToPhases(d, slicesx.Difference(supportedPhases, []string{currentPhase})); len(changes) > 0 {
+			logrus.Debugf("unsupported changes to other phases: %s", changes)
 
-	otherPhases := slicesx.Map(slicesx.Difference(supportedPhases, []string{currentPhase}), func(s string) string {
+			return ErrChangesToOtherPhases
+		}
+	}
+
+	if startFrom != OperationPhaseAll {
+		if changes := changesToPhases(d, skippedPhases(startFrom, supportedPhases)); len(changes) > 0 {
+			logrus.Debugf("unsupported changes to skipped phases: %s", changes)
+
+			return ErrChangesToSkippedPhases
+		}
+	}
+
+	return nil
+}
+
+// skippedPhases returns the supported phases that a run with --start-from does not apply.
+func skippedPhases(startFrom string, supportedPhases []string) []string {
+	mainPhase := strings.TrimPrefix(strings.TrimPrefix(startFrom, "pre-"), "post-")
+
+	idx := slices.Index(supportedPhases, mainPhase)
+	if idx < 0 {
+		return nil
+	}
+
+	// Starting from a post sub-phase also skips the phase it belongs to.
+	if strings.HasPrefix(startFrom, "post-") {
+		idx++
+	}
+
+	return supportedPhases[:idx]
+}
+
+// changesToPhases returns the paths in the changelog that belong to one of the given phases.
+func changesToPhases(d r3diff.Changelog, phases []string) []string {
+	changes := make([]string, 0)
+
+	prefixes := slicesx.Map(phases, func(s string) string {
 		return fmt.Sprintf(".spec.%s.", s)
 	})
 
 	for _, dfs := range d {
 		joinedPath := "." + strings.Join(dfs.Path, ".")
 
-		if slices.ContainsFunc(otherPhases, func(s string) bool {
+		if slices.ContainsFunc(prefixes, func(s string) bool {
 			return strings.HasPrefix(joinedPath, s)
 		}) {
-			unsupportedChanges = append(unsupportedChanges, joinedPath)
+			changes = append(changes, joinedPath)
 		}
 	}
 
-	if len(unsupportedChanges) > 0 {
-		logrus.Debugf("unsupported changes to other phases: %s", unsupportedChanges)
-
-		return ErrChangesToOtherPhases
-	}
-
-	return nil
+	return changes
 }

--- a/internal/cluster/phase_test.go
+++ b/internal/cluster/phase_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package cluster_test
+
+import (
+	"testing"
+
+	r3diff "github.com/r3labs/diff/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/cluster"
+)
+
+func TestAssertPhaseDiffs(t *testing.T) {
+	t.Parallel()
+
+	allPhases := []string{
+		cluster.OperationPhaseInfrastructure,
+		cluster.OperationPhaseKubernetes,
+		cluster.OperationPhaseDistribution,
+		cluster.OperationPhasePlugins,
+	}
+
+	changelog := func(phase string) r3diff.Changelog {
+		return r3diff.Changelog{{Path: []string{"spec", phase, "someField"}}}
+	}
+
+	testCases := []struct {
+		desc      string
+		changed   string
+		phase     string
+		startFrom string
+		phases    []string
+		wantErr   error
+	}{
+		{
+			desc:    "no phase and no start-from accepts any change",
+			changed: "infrastructure",
+			phases:  allPhases,
+		},
+		{
+			desc:    "phase rejects changes to another phase",
+			changed: "kubernetes",
+			phase:   cluster.OperationPhaseDistribution,
+			phases:  allPhases,
+			wantErr: cluster.ErrChangesToOtherPhases,
+		},
+		{
+			desc:    "phase accepts changes to the selected phase",
+			changed: "distribution",
+			phase:   cluster.OperationPhaseDistribution,
+			phases:  allPhases,
+		},
+		{
+			desc:      "start-from rejects changes to an earlier phase",
+			changed:   "kubernetes",
+			startFrom: cluster.OperationPhaseDistribution,
+			phases:    allPhases,
+			wantErr:   cluster.ErrChangesToSkippedPhases,
+		},
+		{
+			desc:      "start-from accepts changes to the phase it starts from",
+			changed:   "distribution",
+			startFrom: cluster.OperationPhaseDistribution,
+			phases:    allPhases,
+		},
+		{
+			desc:      "start-from accepts changes to a later phase",
+			changed:   "plugins",
+			startFrom: cluster.OperationPhaseDistribution,
+			phases:    allPhases,
+		},
+		{
+			desc:      "start-from on a pre sub-phase accepts changes to its own phase",
+			changed:   "kubernetes",
+			startFrom: cluster.OperationSubPhasePreKubernetes,
+			phases:    allPhases,
+			wantErr:   nil,
+		},
+		{
+			desc:      "start-from on a post sub-phase rejects changes to its own phase",
+			changed:   "kubernetes",
+			startFrom: cluster.OperationSubPhasePostKubernetes,
+			phases:    allPhases,
+			wantErr:   cluster.ErrChangesToSkippedPhases,
+		},
+		{
+			desc:      "start-from of a phase the kind does not support is ignored",
+			changed:   "kubernetes",
+			startFrom: cluster.OperationPhaseInfrastructure,
+			phases:    []string{cluster.OperationPhaseDistribution, cluster.OperationPhasePlugins},
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := cluster.AssertPhaseDiffs(changelog(tC.changed), tC.phase, tC.startFrom, tC.phases)
+
+			if tC.wantErr == nil {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorIs(t, err, tC.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
### Summary 💡

`furyctl apply --start-from <phase>` did not look for changes to the phases before the selected one. The apply skipped those changes and then wrote the new configuration to the cluster secret. As a result the change was lost, and the next `furyctl diff` did not show it as pending.

Closes #657

Relates: 
- #744


### Description 📝

The preflight check that stops an apply with changes to phases that will not be applied ran only for the `--phase` flag:

```go
if p.phase != cluster.OperationPhaseAll && !p.upgradeEnabled {
```

The value of `--start-from` never got to `PreFlight`. It arrives as an argument of `ClusterCreator.Create(startFrom, ...)`, and the constructor of the preflight got called without it. All four kinds have the same block, **so all four had the fault**.

With this PR when `--start-from` is set, furyctl rejects changes to the phases before the selected one with the new error `ErrChangesToSkippedPhases`.

The guard is now `(phase != all || startFrom != all) && !upgradeEnabled`.

### Breaking Changes 💔

None for the API or the configuration format.

Note a change of behavior: an apply with `--start-from` that has changes to an earlier phase now stops with an error. Before this fix the same command completed and lost the change.

Users who did not know about the fault can now see a new error. The correct action is to run the apply without `--start-from`, or to revert the change to the earlier phase.

### Tests performed 🧪

Manual, with a `furyctl` build from this branch, on the Immutable kind:

- [x] Created an Immutable cluster
- [x] Ran an apply after the creation with changes to the phase selected with `--phase`
- [x] Ran an apply with changes to a phase other than the one selected with `--phase`
- [x] Ran an apply with changes to a phase before the one selected with `--start-from`

All four cases behaved as expected.

### Future work 🔧

The block that calls `AssertPhaseDiffs` is identical in the four `create/preflight.go` files, and differs only by `supported.Phases()`. A shared helper can remove this duplication. This PR keeps the duplication to hold the scope to the fault.

`ValidateOperationPhase` in `cmd/apply.go` validates `--start-from` against the global list of phases, not against the phases that the kind supports. A per-kind validation can stop an invalid value earlier, with a clearer message. See the linked issue.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
