### PR TITLE
chore: use distribution constants instead of hardcoded strings

### DIFF
--- a/cmd/create/config.go
+++ b/cmd/create/config.go
@@ -252,7 +252,7 @@ func NewConfigCmd() *cobra.Command {
 	configCmd.Flags().StringP(
 		"api-version",
 		"a",
-		"kfd.sighup.io/v1alpha2",
+		distribution.APIVersionV1Alpha2,
 		"Version of the API to use for the selected kind (eg: kfd.sighup.io/v1alpha2)",
 	)
 

--- a/internal/apis/kfd/v1alpha2/ekscluster/init.go
+++ b/internal/apis/kfd/v1alpha2/ekscluster/init.go
@@ -7,31 +7,32 @@ package ekscluster
 import (
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster/private"
 	"github.com/sighupio/furyctl/internal/cluster"
+	"github.com/sighupio/furyctl/internal/distribution"
 )
 
 //nolint:gochecknoinits // this pattern requires init function to work.
 func init() {
 	cluster.RegisterCreatorFactory(
-		"kfd.sighup.io/v1alpha2",
-		"EKSCluster",
+		distribution.APIVersionV1Alpha2,
+		distribution.EKSClusterKind,
 		cluster.NewCreatorFactory[*ClusterCreator, private.EksclusterKfdV1Alpha2](&ClusterCreator{}),
 	)
 
 	cluster.RegisterDeleterFactory(
-		"kfd.sighup.io/v1alpha2",
-		"EKSCluster",
+		distribution.APIVersionV1Alpha2,
+		distribution.EKSClusterKind,
 		cluster.NewDeleterFactory[*ClusterDeleter, private.EksclusterKfdV1Alpha2](&ClusterDeleter{}),
 	)
 
 	cluster.RegisterKubeconfigFactory(
-		"kfd.sighup.io/v1alpha2",
-		"EKSCluster",
+		distribution.APIVersionV1Alpha2,
+		distribution.EKSClusterKind,
 		cluster.NewKubeconfigFactory[*KubeconfigGetter, private.EksclusterKfdV1Alpha2](&KubeconfigGetter{}),
 	)
 
 	cluster.RegisterCertificatesRenewerFactory(
-		"kfd.sighup.io/v1alpha2",
-		"EKSCluster",
+		distribution.APIVersionV1Alpha2,
+		distribution.EKSClusterKind,
 		cluster.NewCertificatesRenewerFactory[*CertificatesRenewer, private.EksclusterKfdV1Alpha2](
 			&CertificatesRenewer{},
 		),

--- a/internal/apis/kfd/v1alpha2/immutable/init.go
+++ b/internal/apis/kfd/v1alpha2/immutable/init.go
@@ -7,31 +7,32 @@ package immutable
 import (
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/immutable/public"
 	"github.com/sighupio/furyctl/internal/cluster"
+	"github.com/sighupio/furyctl/internal/distribution"
 )
 
 //nolint:gochecknoinits // this pattern requires init function to work.
 func init() {
 	cluster.RegisterCreatorFactory(
-		"kfd.sighup.io/v1alpha2",
-		"Immutable",
+		distribution.APIVersionV1Alpha2,
+		distribution.ImmutableKind,
 		cluster.NewCreatorFactory[*ClusterCreator, public.ImmutableKfdV1Alpha2](&ClusterCreator{}),
 	)
 
 	cluster.RegisterDeleterFactory(
-		"kfd.sighup.io/v1alpha2",
-		"Immutable",
+		distribution.APIVersionV1Alpha2,
+		distribution.ImmutableKind,
 		cluster.NewDeleterFactory[*ClusterDeleter, public.ImmutableKfdV1Alpha2](&ClusterDeleter{}),
 	)
 
 	cluster.RegisterKubeconfigFactory(
-		"kfd.sighup.io/v1alpha2",
-		"Immutable",
+		distribution.APIVersionV1Alpha2,
+		distribution.ImmutableKind,
 		cluster.NewKubeconfigFactory[*KubeconfigGetter, public.ImmutableKfdV1Alpha2](&KubeconfigGetter{}),
 	)
 
 	cluster.RegisterCertificatesRenewerFactory(
-		"kfd.sighup.io/v1alpha2",
-		"Immutable",
+		distribution.APIVersionV1Alpha2,
+		distribution.ImmutableKind,
 		cluster.NewCertificatesRenewerFactory[*CertificatesRenewer, public.ImmutableKfdV1Alpha2](&CertificatesRenewer{}),
 	)
 }

--- a/internal/apis/kfd/v1alpha2/kfddistribution/init.go
+++ b/internal/apis/kfd/v1alpha2/kfddistribution/init.go
@@ -7,31 +7,32 @@ package kfddistribution
 import (
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/kfddistribution/public"
 	"github.com/sighupio/furyctl/internal/cluster"
+	"github.com/sighupio/furyctl/internal/distribution"
 )
 
 //nolint:gochecknoinits // this pattern requires init function to work.
 func init() {
 	cluster.RegisterCreatorFactory(
-		"kfd.sighup.io/v1alpha2",
-		"KFDDistribution",
+		distribution.APIVersionV1Alpha2,
+		distribution.KFDDistributionKind,
 		cluster.NewCreatorFactory[*ClusterCreator, public.KfddistributionKfdV1Alpha2](&ClusterCreator{}),
 	)
 
 	cluster.RegisterDeleterFactory(
-		"kfd.sighup.io/v1alpha2",
-		"KFDDistribution",
+		distribution.APIVersionV1Alpha2,
+		distribution.KFDDistributionKind,
 		cluster.NewDeleterFactory[*ClusterDeleter, public.KfddistributionKfdV1Alpha2](&ClusterDeleter{}),
 	)
 
 	cluster.RegisterKubeconfigFactory(
-		"kfd.sighup.io/v1alpha2",
-		"KFDDistribution",
+		distribution.APIVersionV1Alpha2,
+		distribution.KFDDistributionKind,
 		cluster.NewKubeconfigFactory[*KubeconfigGetter, public.KfddistributionKfdV1Alpha2](&KubeconfigGetter{}),
 	)
 
 	cluster.RegisterCertificatesRenewerFactory(
-		"kfd.sighup.io/v1alpha2",
-		"KFDDistribution",
+		distribution.APIVersionV1Alpha2,
+		distribution.KFDDistributionKind,
 		cluster.NewCertificatesRenewerFactory[*CertificatesRenewer, public.KfddistributionKfdV1Alpha2](
 			&CertificatesRenewer{},
 		),

--- a/internal/apis/kfd/v1alpha2/onpremises/init.go
+++ b/internal/apis/kfd/v1alpha2/onpremises/init.go
@@ -7,31 +7,32 @@ package onpremises
 import (
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/onpremises/public"
 	"github.com/sighupio/furyctl/internal/cluster"
+	"github.com/sighupio/furyctl/internal/distribution"
 )
 
 //nolint:gochecknoinits // this pattern requires init function to work.
 func init() {
 	cluster.RegisterCreatorFactory(
-		"kfd.sighup.io/v1alpha2",
-		"OnPremises",
+		distribution.APIVersionV1Alpha2,
+		distribution.OnPremisesKind,
 		cluster.NewCreatorFactory[*ClusterCreator, public.OnpremisesKfdV1Alpha2](&ClusterCreator{}),
 	)
 
 	cluster.RegisterDeleterFactory(
-		"kfd.sighup.io/v1alpha2",
-		"OnPremises",
+		distribution.APIVersionV1Alpha2,
+		distribution.OnPremisesKind,
 		cluster.NewDeleterFactory[*ClusterDeleter, public.OnpremisesKfdV1Alpha2](&ClusterDeleter{}),
 	)
 
 	cluster.RegisterKubeconfigFactory(
-		"kfd.sighup.io/v1alpha2",
-		"OnPremises",
+		distribution.APIVersionV1Alpha2,
+		distribution.OnPremisesKind,
 		cluster.NewKubeconfigFactory[*KubeconfigGetter, public.OnpremisesKfdV1Alpha2](&KubeconfigGetter{}),
 	)
 
 	cluster.RegisterCertificatesRenewerFactory(
-		"kfd.sighup.io/v1alpha2",
-		"OnPremises",
+		distribution.APIVersionV1Alpha2,
+		distribution.OnPremisesKind,
 		cluster.NewCertificatesRenewerFactory[*CertificatesRenewer, public.OnpremisesKfdV1Alpha2](&CertificatesRenewer{}),
 	)
 }

--- a/internal/apis/tool.go
+++ b/internal/apis/tool.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sighupio/furyctl/internal/apis/config"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/ekscluster"
 	"github.com/sighupio/furyctl/internal/apis/kfd/v1alpha2/onpremises"
+	"github.com/sighupio/furyctl/internal/distribution"
 	execx "github.com/sighupio/furyctl/internal/x/exec"
 )
 
@@ -23,12 +24,12 @@ func NewExtraToolsValidatorFactory(
 	binPath string,
 ) ExtraToolsValidator {
 	switch apiVersion {
-	case "kfd.sighup.io/v1alpha2":
+	case distribution.APIVersionV1Alpha2:
 		switch kind {
-		case "EKSCluster":
+		case distribution.EKSClusterKind:
 			return ekscluster.NewExtraToolsValidator(executor)
 
-		case "OnPremises":
+		case distribution.OnPremisesKind:
 			return onpremises.NewExtraToolsValidator(executor, kfdManifest, binPath)
 
 		default:

--- a/internal/clusterinfo/collector.go
+++ b/internal/clusterinfo/collector.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sighupio/furyctl/configs"
 	distroconf "github.com/sighupio/furyctl/internal/apis/config"
 	"github.com/sighupio/furyctl/internal/cluster"
+	"github.com/sighupio/furyctl/internal/distribution"
 	"github.com/sighupio/furyctl/internal/tool/kubectl"
 	"github.com/sighupio/furyctl/internal/upgrade"
 	execx "github.com/sighupio/furyctl/internal/x/exec"
@@ -452,7 +453,7 @@ func extractModules(configMap map[string]any, sd distroconf.KFD, kind string) []
 		},
 	}
 
-	if sd.Modules.Aws != "" && kind == "EKSCluster" {
+	if sd.Modules.Aws != "" && kind == distribution.EKSClusterKind {
 		specs = append(specs, moduleSpec{
 			name:       "AWS",
 			version:    sd.Modules.Aws,
@@ -522,10 +523,10 @@ func extractPlugins(configMap map[string]any) *PluginsInfo {
 
 func etcdTopology(kind string, configMap map[string]any) string {
 	switch kind {
-	case "OnPremises":
+	case distribution.OnPremisesKind:
 		return onPremisesEtcdTopology(configMap)
 
-	case "Immutable":
+	case distribution.ImmutableKind:
 		return immutableEtcdTopology(configMap)
 
 	default:
@@ -601,13 +602,13 @@ func memberHostnames(section map[string]any) []string {
 
 func installerVersion(kind string, sd distroconf.KFD) string {
 	switch kind {
-	case "OnPremises":
+	case distribution.OnPremisesKind:
 		return sd.Kubernetes.OnPremises.Installer
 
-	case "EKSCluster":
+	case distribution.EKSClusterKind:
 		return sd.Kubernetes.Eks.Installer
 
-	case "Immutable":
+	case distribution.ImmutableKind:
 		return sd.Kubernetes.Immutable.Installer
 
 	default:

--- a/internal/dependencies/envvars/validator.go
+++ b/internal/dependencies/envvars/validator.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/sighupio/furyctl/internal/distribution"
 )
 
 var (
@@ -23,7 +25,7 @@ func NewValidator() *Validator {
 }
 
 func (ev *Validator) Validate(kind string) ([]string, []error) {
-	if kind == "EKSCluster" {
+	if kind == distribution.EKSClusterKind {
 		return ev.checkEKSCluster()
 	}
 

--- a/internal/dependencies/tools/validator.go
+++ b/internal/dependencies/tools/validator.go
@@ -81,8 +81,7 @@ func (tv *Validator) Validate(kfdManifest config.KFD, miniConf config.Furyctl) (
 	oks = append(oks, cOks...)
 	errs = append(errs, cErrs...)
 
-	// Validate eks tools only if kind is EKSCluster.
-	if miniConf.Kind == "EKSCluster" {
+	if miniConf.Kind == distribution.EKSClusterKind {
 		cOks, cErrs := tv.validateTools(kfdManifest.Tools.Eks, kfdManifest)
 		oks = append(oks, cOks...)
 		errs = append(errs, cErrs...)

--- a/internal/distribution/iac.go
+++ b/internal/distribution/iac.go
@@ -97,7 +97,7 @@ func (m *IACBuilder) Build() error {
 
 	excluded := []string{"terraform", ".gitignore"}
 
-	if m.kind != "EKSCluster" {
+	if m.kind != EKSClusterKind {
 		excluded = append(excluded, "manifests/aws")
 	}
 
@@ -174,16 +174,16 @@ func (m *IACBuilder) defaultsFile() (map[any]any, error) {
 	var defaultsFileName string
 
 	switch m.kind {
-	case "EKSCluster":
+	case EKSClusterKind:
 		defaultsFileName = "ekscluster-kfd-v1alpha2.yaml"
 
-	case "KFDDistribution":
+	case KFDDistributionKind:
 		defaultsFileName = "kfddistribution-kfd-v1alpha2.yaml"
 
-	case "OnPremises":
+	case OnPremisesKind:
 		defaultsFileName = "onpremises-kfd-v1alpha2.yaml"
 
-	case "Immutable":
+	case ImmutableKind:
 		defaultsFileName = "immutable-kfd-v1alpha2.yaml"
 
 	default:


### PR DESCRIPTION
### Summary 💡

Use distribution package constants instead of hardcoded strings.

Relates:
- #741

### Description 📝


Follow-up to the review on #741 as asked in a comment by @marcopaggioro. That PR converted `internal/apis/schema.go` and added `APIVersionV1Alpha2`, but kept the rest out of scope. This commit does the repo-wide sweep of the remaining cluster-kind and apiVersion literals.

`internal/apis/config/validation.go` keeps its literals. The package `internal/distribution` imports `internal/apis/config`, so the opposite import makes a cycle.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Linting, building, unit-test passing.
- [x] All phases apply on a created Immutable cluster still work.

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~ N.A.
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

