### PR TITLE
fix: missing flags configuration

### DIFF
--- a/docs/advanced/flags-configuration.md
+++ b/docs/advanced/flags-configuration.md
@@ -382,7 +382,7 @@ The flags configuration includes built-in validation that will **stop execution*
 - `etcd` (bool) - Create PKI only for etcd
 - `controlplane` (bool) - Create PKI only for Kubernetes control plane
 
-### Get, Diff, and Tools Command Flags
+### Get and Diff Command Flags
 
 **Get Command:**
 - `binPath` (string) - Binary path
@@ -400,11 +400,28 @@ The flags configuration includes built-in validation that will **stop execution*
 **Validate Command:**
 - `distroLocation` (string) - Distribution location
 - `distroPatches` (string) - Distribution patches location
+- `binPath` (string) - Binary path
 
 **Download Command:**
-- `binPath` (string) - Binary path  
+- `binPath` (string) - Binary path
 - `distroLocation` (string) - Distribution location
 - `distroPatches` (string) - Distribution patches location
+- `bundleOutput` (string) - Bundle tarball output path
 
-**Other Commands:**
-- `Connect`, `Renew`, `Dump` commands currently have no configurable flags - use `furyctl [command] --help` for details
+**Connect Command:**
+- `profile` (string) - OpenVPN profile name
+
+**Renew Command:**
+- `binPath` (string) - Binary path
+- `distroLocation` (string) - Distribution location
+- `skipDepsDownload` (bool) - Skip dependencies download
+- `skipDepsValidation` (bool) - Skip dependencies validation
+- `airgapBundle` (string) - Air-gapped bundle path
+- `forceExtract` (bool) - Force bundle re-extraction
+
+**Dump Command:**
+- `distroLocation` (string) - Distribution location
+- `distroPatches` (string) - Distribution patches location
+- `dryRun` (bool) - Dry run
+- `noOverwrite` (bool) - Do not overwrite existing files
+- `skipValidation` (bool) - Skip validation

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -11,6 +11,7 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 
 - [[#743](https://github.com/sighupio/furyctl/pull/743)] All kinds: `apply --start-from` now stops when the configuration has changes to a phase before the selected one. Before this fix furyctl skipped those changes and wrote the new configuration to the cluster, so the change was lost and the next `diff` did not show it as pending.
 - [[#746](https://github.com/sighupio/furyctl/issues/746)] All kinds: a flag that you give on the command line now has precedence over the same flag in the `flags` section of `furyctl.yaml`. The documented priority is `furyctl.yaml` < environment variable < command line. Before this release the commands `diff`, `create config`, `get cluster-info` and `get upgrade-paths` read the configuration file first, thus the configuration file had the precedence. If you want the value of the configuration file, do not give the flag on the command line.
+- [[#746](https://github.com/sighupio/furyctl/issues/746)] All kinds: the `validate`, `download`, `connect`, `renew` and `dump` sections of the `flags` field of `furyctl.yaml` now work. The documentation lists these sections. Before this release furyctl dropped them. The validation of the configuration file also stopped with `unsupported flags command`. furyctl does not accept a `tools` section any more, because it has no `tools` command.
 
 
 ## Breaking Changes 💔

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -320,26 +320,38 @@ func validateFlagsSection(flagsSection any) error {
 
 		// Set the command flags in the appropriate section.
 		switch command {
-		case "global":
+		case flags.CommandGlobal:
 			flagsConfig.Global = commandFlagsMap
 
-		case "apply":
+		case flags.CommandApply:
 			flagsConfig.Apply = commandFlagsMap
 
-		case "delete":
+		case flags.CommandDelete:
 			flagsConfig.Delete = commandFlagsMap
 
-		case "create":
+		case flags.CommandCreate:
 			flagsConfig.Create = commandFlagsMap
 
-		case "get":
+		case flags.CommandGet:
 			flagsConfig.Get = commandFlagsMap
 
-		case "diff":
+		case flags.CommandDiff:
 			flagsConfig.Diff = commandFlagsMap
 
-		case "tools":
-			flagsConfig.Tools = commandFlagsMap
+		case flags.CommandValidate:
+			flagsConfig.Validate = commandFlagsMap
+
+		case flags.CommandDownload:
+			flagsConfig.Download = commandFlagsMap
+
+		case flags.CommandConnect:
+			flagsConfig.Connect = commandFlagsMap
+
+		case flags.CommandRenew:
+			flagsConfig.Renew = commandFlagsMap
+
+		case flags.CommandDump:
+			flagsConfig.Dump = commandFlagsMap
 
 		default:
 			return fmt.Errorf("%w: %s", ErrUnsupportedFlagsCommand, command)

--- a/internal/flags/loader.go
+++ b/internal/flags/loader.go
@@ -123,10 +123,6 @@ func (l *Loader) processDynamicValues(flags *FlagsConfig) (*FlagsConfig, error) 
 		return nil, err
 	}
 
-	if err := l.processField(flags.Tools, &processed.Tools, "tools"); err != nil {
-		return nil, err
-	}
-
 	if err := l.processField(flags.Validate, &processed.Validate, "validate"); err != nil {
 		return nil, err
 	}

--- a/internal/flags/merger.go
+++ b/internal/flags/merger.go
@@ -15,15 +15,19 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Command name constants.
+// Command name constants. Each one is a section of the `flags` field of furyctl.yaml.
 const (
-	CommandGlobal = "global"
-	CommandApply  = "apply"
-	CommandDelete = "delete"
-	CommandCreate = "create"
-	CommandGet    = "get"
-	CommandDiff   = "diff"
-	CommandTools  = "tools"
+	CommandGlobal   = "global"
+	CommandApply    = "apply"
+	CommandDelete   = "delete"
+	CommandCreate   = "create"
+	CommandGet      = "get"
+	CommandDiff     = "diff"
+	CommandValidate = "validate"
+	CommandDownload = "download"
+	CommandConnect  = "connect"
+	CommandRenew    = "renew"
+	CommandDump     = "dump"
 )
 
 // Static error definitions for linting compliance.
@@ -94,8 +98,20 @@ func (m *Merger) MergeIntoViper(flags *FlagsConfig, command string) error {
 	case CommandDiff:
 		commandFlags = flags.Diff
 
-	case CommandTools:
-		commandFlags = flags.Tools
+	case CommandValidate:
+		commandFlags = flags.Validate
+
+	case CommandDownload:
+		commandFlags = flags.Download
+
+	case CommandConnect:
+		commandFlags = flags.Connect
+
+	case CommandRenew:
+		commandFlags = flags.Renew
+
+	case CommandDump:
+		commandFlags = flags.Dump
 
 	default:
 		// Unknown command, skip command-specific flags.
@@ -215,8 +231,20 @@ func (m *Merger) GetSupportedFlagsForCommand(command string) map[string]FlagInfo
 	case CommandDiff:
 		return m.supportedFlags.Diff
 
-	case CommandTools:
-		return m.supportedFlags.Tools
+	case CommandValidate:
+		return m.supportedFlags.Validate
+
+	case CommandDownload:
+		return m.supportedFlags.Download
+
+	case CommandConnect:
+		return m.supportedFlags.Connect
+
+	case CommandRenew:
+		return m.supportedFlags.Renew
+
+	case CommandDump:
+		return m.supportedFlags.Dump
 
 	default:
 		return nil
@@ -246,8 +274,20 @@ func (m *Merger) mergeCommandFlags(flagsMap map[string]any, command string) erro
 	case CommandDiff:
 		supportedFlagsMap = m.supportedFlags.Diff
 
-	case CommandTools:
-		supportedFlagsMap = m.supportedFlags.Tools
+	case CommandValidate:
+		supportedFlagsMap = m.supportedFlags.Validate
+
+	case CommandDownload:
+		supportedFlagsMap = m.supportedFlags.Download
+
+	case CommandConnect:
+		supportedFlagsMap = m.supportedFlags.Connect
+
+	case CommandRenew:
+		supportedFlagsMap = m.supportedFlags.Renew
+
+	case CommandDump:
+		supportedFlagsMap = m.supportedFlags.Dump
 
 	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedCommand, command)

--- a/internal/flags/sections_test.go
+++ b/internal/flags/sections_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package flags_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/flags"
+)
+
+// The merger must know each section of the `flags` field. The section must also have flags that
+// furyctl supports. furyctl parses a section with no map, or with an empty map, and then drops it.
+// The `tools` section had this fault.
+func TestEverySectionHasSupportedFlags(t *testing.T) {
+	t.Parallel()
+
+	merger := flags.NewMerger()
+	cfg := reflect.TypeOf(flags.FlagsConfig{})
+
+	for i := range cfg.NumField() {
+		section := strings.Split(cfg.Field(i).Tag.Get("yaml"), ",")[0]
+
+		t.Run(section, func(t *testing.T) {
+			t.Parallel()
+
+			supported := merger.GetSupportedFlagsForCommand(section)
+
+			require.NotNil(t, supported, "the merger does not know the %q section", section)
+			assert.NotEmpty(t, supported, "the %q section has no supported flags", section)
+		})
+	}
+}
+
+// A flag of a command section reaches viper. Before this change the merger dropped the sections
+// validate, download, connect, renew and dump. The validation of the configuration file also
+// stopped with "unsupported flags command".
+func TestMergeIntoViper_CommandSections(t *testing.T) {
+	tests := []struct {
+		section string
+		flag    string
+		key     string
+	}{
+		{flags.CommandValidate, "binPath", "bin-path"},
+		{flags.CommandDownload, "bundleOutput", "bundle-output"},
+		{flags.CommandConnect, "profile", "profile"},
+		{flags.CommandRenew, "distroLocation", "distro-location"},
+		{flags.CommandDump, "distroPatches", "distro-patches"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.section, func(t *testing.T) {
+			cmd := &cobra.Command{Use: tc.section}
+			cmd.Flags().String(tc.key, "", "")
+			require.NoError(t, cmd.ParseFlags([]string{}))
+
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+
+			require.NoError(t, viper.BindPFlags(cmd.Flags()))
+
+			cfg := sectionConfig(tc.section, map[string]any{tc.flag: "/from-config"})
+			require.NoError(t, flags.NewMerger().MergeIntoViper(cfg, tc.section))
+
+			assert.Equal(t, "/from-config", viper.GetString(tc.key))
+		})
+	}
+}
+
+// sectionConfig puts the given flags in the named section of a FlagsConfig.
+func sectionConfig(section string, values map[string]any) *flags.FlagsConfig {
+	cfg := &flags.FlagsConfig{}
+
+	switch section {
+	case flags.CommandValidate:
+		cfg.Validate = values
+
+	case flags.CommandDownload:
+		cfg.Download = values
+
+	case flags.CommandConnect:
+		cfg.Connect = values
+
+	case flags.CommandRenew:
+		cfg.Renew = values
+
+	case flags.CommandDump:
+		cfg.Dump = values
+	}
+
+	return cfg
+}

--- a/internal/flags/types.go
+++ b/internal/flags/types.go
@@ -14,7 +14,6 @@ type FlagsConfig struct {
 	Create   map[string]any `yaml:"create,omitempty"`
 	Get      map[string]any `yaml:"get,omitempty"`
 	Diff     map[string]any `yaml:"diff,omitempty"`
-	Tools    map[string]any `yaml:"tools,omitempty"`
 	Validate map[string]any `yaml:"validate,omitempty"`
 	Download map[string]any `yaml:"download,omitempty"`
 	Connect  map[string]any `yaml:"connect,omitempty"`
@@ -31,7 +30,6 @@ type SupportedFlags struct {
 	Create   map[string]FlagInfo
 	Get      map[string]FlagInfo
 	Diff     map[string]FlagInfo
-	Tools    map[string]FlagInfo
 	Validate map[string]FlagInfo
 	Download map[string]FlagInfo
 	Connect  map[string]FlagInfo
@@ -191,10 +189,10 @@ func GetSupportedFlags() SupportedFlags {
 			"airgapBundle":        {Type: FlagTypeString, DefaultValue: "", Description: "Air-gapped bundle path"},
 			"forceExtract":        {Type: FlagTypeBool, DefaultValue: false, Description: "Force bundle re-extraction"},
 		},
-		Tools: map[string]FlagInfo{},
 		Validate: map[string]FlagInfo{
 			"distroLocation": {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
 			"distroPatches":  {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
+			"binPath":        {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
 		},
 		Download: map[string]FlagInfo{
 			"binPath":        {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
@@ -202,11 +200,23 @@ func GetSupportedFlags() SupportedFlags {
 			"distroPatches":  {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
 			"bundleOutput":   {Type: FlagTypeString, DefaultValue: "", Description: "Bundle tarball output path"},
 		},
-		Connect: map[string]FlagInfo{},
-		Renew: map[string]FlagInfo{
-			"airgapBundle": {Type: FlagTypeString, DefaultValue: "", Description: "Air-gapped bundle path"},
-			"forceExtract": {Type: FlagTypeBool, DefaultValue: false, Description: "Force bundle re-extraction"},
+		Connect: map[string]FlagInfo{
+			"profile": {Type: FlagTypeString, DefaultValue: "", Description: "OpenVPN profile name"},
 		},
-		Dump: map[string]FlagInfo{},
+		Renew: map[string]FlagInfo{
+			"airgapBundle":       {Type: FlagTypeString, DefaultValue: "", Description: "Air-gapped bundle path"},
+			"forceExtract":       {Type: FlagTypeBool, DefaultValue: false, Description: "Force bundle re-extraction"},
+			"binPath":            {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
+			"distroLocation":     {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
+			"skipDepsDownload":   {Type: FlagTypeBool, DefaultValue: false, Description: "Skip dependencies download"},
+			"skipDepsValidation": {Type: FlagTypeBool, DefaultValue: false, Description: "Skip dependencies validation"},
+		},
+		Dump: map[string]FlagInfo{
+			"distroLocation": {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
+			"distroPatches":  {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
+			"dryRun":         {Type: FlagTypeBool, DefaultValue: false, Description: "Dry run"},
+			"noOverwrite":    {Type: FlagTypeBool, DefaultValue: false, Description: "Do not overwrite existing files"},
+			"skipValidation": {Type: FlagTypeBool, DefaultValue: false, Description: "Skip validation"},
+		},
 	}
 }

--- a/internal/flags/validator.go
+++ b/internal/flags/validator.go
@@ -71,8 +71,24 @@ func (v *Validator) Validate(flags *FlagsConfig) []ValidationError {
 		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Diff, CommandDiff)...)
 	}
 
-	if flags.Tools != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Tools, CommandTools)...)
+	if flags.Validate != nil {
+		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Validate, CommandValidate)...)
+	}
+
+	if flags.Download != nil {
+		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Download, CommandDownload)...)
+	}
+
+	if flags.Connect != nil {
+		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Connect, CommandConnect)...)
+	}
+
+	if flags.Renew != nil {
+		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Renew, CommandRenew)...)
+	}
+
+	if flags.Dump != nil {
+		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Dump, CommandDump)...)
 	}
 
 	// Cross-validation: check for conflicting flags.
@@ -111,8 +127,20 @@ func (v *Validator) validateCommandFlags(flagsMap map[string]any, command string
 	case CommandDiff:
 		supportedFlagsMap = v.supportedFlags.Diff
 
-	case CommandTools:
-		supportedFlagsMap = v.supportedFlags.Tools
+	case CommandValidate:
+		supportedFlagsMap = v.supportedFlags.Validate
+
+	case CommandDownload:
+		supportedFlagsMap = v.supportedFlags.Download
+
+	case CommandConnect:
+		supportedFlagsMap = v.supportedFlags.Connect
+
+	case CommandRenew:
+		supportedFlagsMap = v.supportedFlags.Renew
+
+	case CommandDump:
+		supportedFlagsMap = v.supportedFlags.Dump
 
 	default:
 		validationErrors = append(validationErrors, ValidationError{


### PR DESCRIPTION
### Summary 💡

Specifying command flags in the furyctl.yaml files was not working for some commands and being silently ignored for others. Add the logic for the missing commands.

Remove `tools` from the supported commands, it was never merged.

Closes #746

Relates:
- #619 

### Description 📝

The documentation lists validate, download, connect, renew and dump as sections of the flags field of furyctl.yaml. The merger and the validator did not know these sections. furyctl thus dropped them without a message. The validation of the configuration file also stopped with "unsupported flags command".

Add the five sections to the merger, to the validator and to the validation of the configuration file. Complete the supported flags of validate, connect, renew and dump.

Remove the tools section. That command is not in main: it lives on the branch feat/aliases-command. Its map of supported flags was empty, thus any key under flags.tools stopped every command that reads the configuration file. furyctl now rejects the section by name.

Add a test that keeps a map of supported flags for each section, and a test that merges a flag of each command section.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] `flags.renew.distroLocation` with `furyctl renew certificates`: the value is now used. Before this change furyctl dropped it without a message
- [x] `flags.renew` with `furyctl validate config`: the command now reaches the validation of the schema. Before this change it stopped with `unsupported flags command: renew`
- [x] `flags.renew.bogusFlag`: the command stops with `flag 'bogusFlag' is not supported for 'renew' command`, as the documentation says
- [x] `flags.tools.distroLocation`: the command stops with `unsupported flags command: tools`. Before this change the message named the flag instead of the section
- [x] `furyctl renew certificates --distro-location /tmp/FROM-CLI` with `flags.renew.distroLocation: /tmp/FROM-CONFIG`: the command line wins, thus #745 and the first part of #746 still hold
- [x] Regression check: the `flags.global` section still reaches `renew`, which is not a wired command section
- [x] Regression check: `flags.apply.distroLocation` with `furyctl apply` still works, thus the sections that already worked are not affected

### Future work 🔧

Seven places in the flags system each enumerate every section of the `flags` field:

| Location | Form |
|---|---|
| `Merger.MergeIntoViper` | switch, 10 arms |
| `Merger.GetSupportedFlagsForCommand` | switch, 11 arms |
| `Merger.mergeCommandFlags` | switch, 11 arms |
| `Validator.validateCommandFlags` | switch, 11 arms |
| `Validator.Validate` | if-chain, 11 blocks |
| `config.validateFlagsSection` | switch, 11 arms |
| `flags.sections_test.sectionConfig` | switch, 5 arms |

A new section needs a change in each one. #746 happened because five sections reached `FlagsConfig` and `SupportedFlags` but not the six switches. The test `TestEverySectionHasSupportedFlags` guards the result, not the cause.

Would be better if one place holds the sections. `SupportedFlags` becomes `map[string]map[string]FlagInfo`, keyed by the section name, and `FlagsConfig` gets a `Sections() map[string]map[string]any` method. The lookups then replace the switches with a map access, and the if-chain becomes a loop.

This removes about 120 lines. It also makes the fault of #746 impossible: a section that has no supported flags cannot reach the merger.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [X] My branch is up-to-date with the target branch and there are no conflicts
- [X] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

