### PR TITLE
refactor(flags): key the flag sections by the command name

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -31,7 +31,6 @@ import (
 // Static error definitions for linting compliance.
 var (
 	ErrFlagsMustBeObject            = errors.New("flags section must be an object")
-	ErrUnsupportedFlagsCommand      = errors.New("unsupported flags command")
 	ErrFlagsValidationFailed        = errors.New("flags validation failed")
 	ErrExpandedConfigurationNotAMap = errors.New("expanded configuration is not a map[string]any")
 	ErrReadingSpec                  = errors.New("error reading spec from kfd.yaml")
@@ -302,60 +301,22 @@ func containsDynamicPattern(s string) bool {
 
 // validateFlagsSection validates the flags section using furyctl-specific validation rules.
 func validateFlagsSection(flagsSection any) error {
-	// Convert to FlagsConfig type for validation.
 	flagsMap, ok := flagsSection.(map[string]any)
 	if !ok {
 		return ErrFlagsMustBeObject
 	}
 
-	// Convert to internal flags structure for validation.
-	flagsConfig := &flags.FlagsConfig{}
+	// Convert to the internal flags structure for validation. The validator reports a section
+	// that furyctl does not support.
+	flagsConfig := flags.FlagsConfig{}
 
-	// Extract and validate each command section.
-	for command, commandFlags := range flagsMap {
-		commandFlagsMap, ok := commandFlags.(map[string]any)
+	for section, sectionFlags := range flagsMap {
+		values, ok := sectionFlags.(map[string]any)
 		if !ok {
-			return fmt.Errorf("%w: flags.%s must be an object", ErrFlagsMustBeObject, command)
+			return fmt.Errorf("%w: flags.%s must be an object", ErrFlagsMustBeObject, section)
 		}
 
-		// Set the command flags in the appropriate section.
-		switch command {
-		case flags.CommandGlobal:
-			flagsConfig.Global = commandFlagsMap
-
-		case flags.CommandApply:
-			flagsConfig.Apply = commandFlagsMap
-
-		case flags.CommandDelete:
-			flagsConfig.Delete = commandFlagsMap
-
-		case flags.CommandCreate:
-			flagsConfig.Create = commandFlagsMap
-
-		case flags.CommandGet:
-			flagsConfig.Get = commandFlagsMap
-
-		case flags.CommandDiff:
-			flagsConfig.Diff = commandFlagsMap
-
-		case flags.CommandValidate:
-			flagsConfig.Validate = commandFlagsMap
-
-		case flags.CommandDownload:
-			flagsConfig.Download = commandFlagsMap
-
-		case flags.CommandConnect:
-			flagsConfig.Connect = commandFlagsMap
-
-		case flags.CommandRenew:
-			flagsConfig.Renew = commandFlagsMap
-
-		case flags.CommandDump:
-			flagsConfig.Dump = commandFlagsMap
-
-		default:
-			return fmt.Errorf("%w: %s", ErrUnsupportedFlagsCommand, command)
-		}
+		flagsConfig[section] = values
 	}
 
 	// Validate flags using the flags package validator.

--- a/internal/flags/loader.go
+++ b/internal/flags/loader.go
@@ -7,8 +7,10 @@ package flags
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 
 	parserx "github.com/sighupio/furyctl/internal/parser"
 	yamlx "github.com/sighupio/furyctl/pkg/x/yaml"
@@ -95,52 +97,16 @@ func (l *Loader) LoadFromDirectory(dir string) (*LoadResult, error) {
 	return result, nil
 }
 
-// processDynamicValues processes dynamic values like {env://VAR} and {file://path} in the flags configuration.
-func (l *Loader) processDynamicValues(flags *FlagsConfig) (*FlagsConfig, error) {
-	processed := &FlagsConfig{}
+func (l *Loader) processDynamicValues(flags FlagsConfig) (FlagsConfig, error) {
+	processed := FlagsConfig{}
 
-	if err := l.processField(flags.Global, &processed.Global, "global"); err != nil {
-		return nil, err
-	}
+	for _, section := range slices.Sorted(maps.Keys(flags)) {
+		values, err := l.processCommandFlags(flags[section])
+		if err != nil {
+			return nil, fmt.Errorf("error processing %s flags: %w", section, err)
+		}
 
-	if err := l.processField(flags.Apply, &processed.Apply, "apply"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Delete, &processed.Delete, "delete"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Create, &processed.Create, "create"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Get, &processed.Get, "get"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Diff, &processed.Diff, "diff"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Validate, &processed.Validate, "validate"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Download, &processed.Download, "download"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Connect, &processed.Connect, "connect"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Renew, &processed.Renew, "renew"); err != nil {
-		return nil, err
-	}
-
-	if err := l.processField(flags.Dump, &processed.Dump, "dump"); err != nil {
-		return nil, err
+		processed[section] = values
 	}
 
 	return processed, nil
@@ -160,19 +126,4 @@ func (l *Loader) processCommandFlags(flagsMap map[string]any) (map[string]any, e
 	}
 
 	return processed, nil
-}
-
-func (l *Loader) processField(src map[string]any, dst *map[string]any, name string) error {
-	if src == nil {
-		return nil
-	}
-
-	var err error
-
-	*dst, err = l.processCommandFlags(src)
-	if err != nil {
-		return fmt.Errorf("error processing %s flags: %w", name, err)
-	}
-
-	return nil
 }

--- a/internal/flags/loader_test.go
+++ b/internal/flags/loader_test.go
@@ -21,7 +21,7 @@ func TestLoader_LoadFromFile(t *testing.T) {
 	tests := []struct {
 		name           string
 		configContent  string
-		expectedFlags  *flags.FlagsConfig
+		expectedFlags  flags.FlagsConfig
 		expectedErrors int
 	}{
 		{
@@ -40,12 +40,12 @@ flags:
     skipDepsValidation: true
     distroLocation: "/tmp/test"
     dryRun: false`,
-			expectedFlags: &flags.FlagsConfig{
-				Global: map[string]any{
+			expectedFlags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"debug":            true,
 					"disableAnalytics": false,
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"skipDepsValidation": true,
 					"distroLocation":     "/tmp/test",
 					"dryRun":             false,
@@ -77,11 +77,11 @@ flags:
     outdir: "{env://TEST_OUTDIR}"
   apply:
     distroPatches: "{env://TEST_PATCHES}"`,
-			expectedFlags: &flags.FlagsConfig{
-				Global: map[string]any{
+			expectedFlags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"outdir": "/test/output",
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"distroPatches": "/test/patches",
 				},
 			},
@@ -117,8 +117,8 @@ flags:
 				assert.Nil(t, result.Flags, "Expected no flags but got: %+v", result.Flags)
 			} else {
 				require.NotNil(t, result.Flags, "Expected flags but got nil")
-				assert.Equal(t, tt.expectedFlags.Global, result.Flags.Global)
-				assert.Equal(t, tt.expectedFlags.Apply, result.Flags.Apply)
+				assert.Equal(t, tt.expectedFlags[flags.CommandGlobal], result.Flags[flags.CommandGlobal])
+				assert.Equal(t, tt.expectedFlags[flags.CommandApply], result.Flags[flags.CommandApply])
 			}
 		})
 	}
@@ -158,9 +158,9 @@ flags:
 
 	assert.Empty(t, result.Errors)
 	require.NotNil(t, result.Flags)
-	require.NotNil(t, result.Flags.Global)
+	require.NotNil(t, result.Flags[flags.CommandGlobal])
 
-	debugValue := result.Flags.Global["debug"]
+	debugValue := result.Flags[flags.CommandGlobal]["debug"]
 	// The value might be parsed as a string "true" or boolean true depending on YAML parser
 	assert.Contains(t, []any{true, "true"}, debugValue)
 }

--- a/internal/flags/manager.go
+++ b/internal/flags/manager.go
@@ -126,17 +126,15 @@ func (m *Manager) LoadAndMergeGlobalFlags(configPath string) error {
 	}
 
 	// Validate only global flags.
-	if result.Flags.Global != nil {
-		validationErrors := m.validator.validateCommandFlags(result.Flags.Global, "global")
-		if err := m.handleValidationErrors(
-			validationErrors, ErrGlobalFlagsValidationFailed, "global flags configuration",
-		); err != nil {
-			return err
-		}
+	validationErrors := m.validator.validateCommandFlags(result.Flags[CommandGlobal], CommandGlobal)
+	if err := m.handleValidationErrors(
+		validationErrors, ErrGlobalFlagsValidationFailed, "global flags configuration",
+	); err != nil {
+		return err
 	}
 
 	// Merge only global flags.
-	if err := m.merger.MergeGlobalFlags(result.Flags); err != nil {
+	if err := m.merger.mergeCommandFlags(result.Flags[CommandGlobal], CommandGlobal); err != nil {
 		return fmt.Errorf("failed to merge global flags: %w", err)
 	}
 

--- a/internal/flags/merger.go
+++ b/internal/flags/merger.go
@@ -36,7 +36,6 @@ var (
 	ErrUnsupportedFlagType = errors.New("unsupported flag type")
 	ErrBoolConversion      = errors.New("cannot convert to bool")
 	ErrIntConversion       = errors.New("cannot convert to int")
-	ErrUnsupportedCommand  = errors.New("unsupported command")
 )
 
 // Merger handles merging flags from configuration file into viper with proper priority.
@@ -69,59 +68,20 @@ func CamelToKebab(s string) string {
 
 // MergeIntoViper merges flags from the configuration into viper with the lowest priority.
 // This ensures the priority order: furyctl.yaml < environment variables < command line flags.
-func (m *Merger) MergeIntoViper(flags *FlagsConfig, command string) error {
-	if flags == nil {
-		return nil
-	}
-
-	// Merge global flags first.
-	if err := m.mergeCommandFlags(flags.Global, CommandGlobal); err != nil {
+func (m *Merger) MergeIntoViper(flags FlagsConfig, command string) error {
+	// Merge the global flags first.
+	if err := m.mergeCommandFlags(flags[CommandGlobal], CommandGlobal); err != nil {
 		return fmt.Errorf("error merging global flags: %w", err)
 	}
 
-	// Merge command-specific flags.
-	var commandFlags map[string]any
-
-	switch command {
-	case CommandApply:
-		commandFlags = flags.Apply
-
-	case CommandDelete:
-		commandFlags = flags.Delete
-
-	case CommandCreate:
-		commandFlags = flags.Create
-
-	case CommandGet:
-		commandFlags = flags.Get
-
-	case CommandDiff:
-		commandFlags = flags.Diff
-
-	case CommandValidate:
-		commandFlags = flags.Validate
-
-	case CommandDownload:
-		commandFlags = flags.Download
-
-	case CommandConnect:
-		commandFlags = flags.Connect
-
-	case CommandRenew:
-		commandFlags = flags.Renew
-
-	case CommandDump:
-		commandFlags = flags.Dump
-
-	default:
-		// Unknown command, skip command-specific flags.
+	// The global flags are merged already.
+	if command == CommandGlobal {
 		return nil
 	}
 
-	if commandFlags != nil {
-		if err := m.mergeCommandFlags(commandFlags, command); err != nil {
-			return fmt.Errorf("error merging %s flags: %w", command, err)
-		}
+	// A command that furyctl does not support has no supported flags, thus this merge does nothing.
+	if err := m.mergeCommandFlags(flags[command], command); err != nil {
+		return fmt.Errorf("error merging %s flags: %w", command, err)
 	}
 
 	return nil
@@ -201,108 +161,20 @@ func (*Merger) ConvertValue(value any, expectedType FlagType) (any, error) {
 	}
 }
 
-// MergeGlobalFlags is a convenience method to merge only global flags.
-func (m *Merger) MergeGlobalFlags(flags *FlagsConfig) error {
-	if flags == nil || flags.Global == nil {
-		return nil
-	}
-
-	return m.mergeCommandFlags(flags.Global, CommandGlobal)
-}
-
-// GetSupportedFlagsForCommand returns the supported flags for a specific command.
-func (m *Merger) GetSupportedFlagsForCommand(command string) map[string]FlagInfo {
-	switch command {
-	case CommandGlobal:
-		return m.supportedFlags.Global
-
-	case CommandApply:
-		return m.supportedFlags.Apply
-
-	case CommandDelete:
-		return m.supportedFlags.Delete
-
-	case CommandCreate:
-		return m.supportedFlags.Create
-
-	case CommandGet:
-		return m.supportedFlags.Get
-
-	case CommandDiff:
-		return m.supportedFlags.Diff
-
-	case CommandValidate:
-		return m.supportedFlags.Validate
-
-	case CommandDownload:
-		return m.supportedFlags.Download
-
-	case CommandConnect:
-		return m.supportedFlags.Connect
-
-	case CommandRenew:
-		return m.supportedFlags.Renew
-
-	case CommandDump:
-		return m.supportedFlags.Dump
-
-	default:
-		return nil
-	}
-}
-
 // mergeCommandFlags merges flags for a specific command into viper.
 func (m *Merger) mergeCommandFlags(flagsMap map[string]any, command string) error {
-	var supportedFlagsMap map[string]FlagInfo
-
-	switch command {
-	case CommandGlobal:
-		supportedFlagsMap = m.supportedFlags.Global
-
-	case CommandApply:
-		supportedFlagsMap = m.supportedFlags.Apply
-
-	case CommandDelete:
-		supportedFlagsMap = m.supportedFlags.Delete
-
-	case CommandCreate:
-		supportedFlagsMap = m.supportedFlags.Create
-
-	case CommandGet:
-		supportedFlagsMap = m.supportedFlags.Get
-
-	case CommandDiff:
-		supportedFlagsMap = m.supportedFlags.Diff
-
-	case CommandValidate:
-		supportedFlagsMap = m.supportedFlags.Validate
-
-	case CommandDownload:
-		supportedFlagsMap = m.supportedFlags.Download
-
-	case CommandConnect:
-		supportedFlagsMap = m.supportedFlags.Connect
-
-	case CommandRenew:
-		supportedFlagsMap = m.supportedFlags.Renew
-
-	case CommandDump:
-		supportedFlagsMap = m.supportedFlags.Dump
-
-	default:
-		return fmt.Errorf("%w: %s", ErrUnsupportedCommand, command)
-	}
+	supportedFlagsMap := m.supportedFlags[command]
 
 	for flagName, value := range flagsMap {
 		// Check if the flag is supported.
-		flagInfo, supported := supportedFlagsMap[flagName]
+		flagType, supported := supportedFlagsMap[flagName]
 		if !supported {
 			// Log warning but don't fail - might be a new flag.
 			continue
 		}
 
 		// Convert and validate the value.
-		convertedValue, err := m.ConvertValue(value, flagInfo.Type)
+		convertedValue, err := m.ConvertValue(value, flagType)
 		if err != nil {
 			return fmt.Errorf("error converting flag %s: %w", flagName, err)
 		}

--- a/internal/flags/merger_test.go
+++ b/internal/flags/merger_test.go
@@ -19,19 +19,19 @@ import (
 func TestMerger_MergeIntoViper(t *testing.T) {
 	tests := []struct {
 		name           string
-		flags          *flags.FlagsConfig
+		flags          flags.FlagsConfig
 		command        string
 		expectedValues map[string]any
 		setupViper     func()
 	}{
 		{
 			name: "merge global and apply flags",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"debug":            true,
 					"disableAnalytics": false,
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"skipDepsValidation": true,
 					"dryRun":             false,
 					"timeout":            7200,
@@ -51,11 +51,11 @@ func TestMerger_MergeIntoViper(t *testing.T) {
 		},
 		{
 			name: "flags do not override existing viper values",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"debug": true,
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"dryRun": true,
 				},
 			},
@@ -71,11 +71,11 @@ func TestMerger_MergeIntoViper(t *testing.T) {
 		},
 		{
 			name: "merge only global flags for unknown command",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"debug": true,
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"dryRun": true,
 				},
 			},
@@ -84,15 +84,6 @@ func TestMerger_MergeIntoViper(t *testing.T) {
 				"debug":   true,
 				"dry-run": nil, // Should not be set
 			},
-			setupViper: func() {
-				viper.Reset()
-			},
-		},
-		{
-			name:           "nil flags",
-			flags:          nil,
-			command:        "apply",
-			expectedValues: map[string]any{},
 			setupViper: func() {
 				viper.Reset()
 			},
@@ -267,51 +258,6 @@ func TestMerger_ConvertValue(t *testing.T) {
 				assert.NoError(t, err, "Unexpected error")
 
 				assert.Equal(t, tt.expected, actualValue)
-			}
-		})
-	}
-}
-
-func TestMerger_MergeGlobalFlags(t *testing.T) {
-	defer viper.Reset()
-
-	flagsConfig := &flags.FlagsConfig{
-		Global: map[string]any{
-			"debug":            true,
-			"disableAnalytics": false,
-		},
-	}
-
-	merger := flags.NewMerger()
-	err := merger.MergeGlobalFlags(flagsConfig)
-	require.NoError(t, err, "MergeGlobalFlags()")
-
-	assert.True(t, viper.GetBool("debug"), "Expected debug to be true")
-	assert.False(t, viper.GetBool("disableAnalytics"), "Expected disableAnalytics to be false")
-}
-
-func TestMerger_GetSupportedFlagsForCommand(t *testing.T) {
-	merger := flags.NewMerger()
-
-	tests := []struct {
-		command   string
-		expectNil bool
-	}{
-		{"global", false},
-		{"apply", false},
-		{"delete", false},
-		{"create", false},
-		{"unknown", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.command, func(t *testing.T) {
-			supportedFlags := merger.GetSupportedFlagsForCommand(tt.command)
-
-			if tt.expectNil {
-				assert.Nil(t, supportedFlags, "Expected nil for unknown command")
-			} else {
-				assert.NotNil(t, supportedFlags, "Expected supported flags for command %s", tt.command)
 			}
 		})
 	}

--- a/internal/flags/precedence_test.go
+++ b/internal/flags/precedence_test.go
@@ -35,7 +35,7 @@ func TestMergeIntoViper_CommandLineFlagWins(t *testing.T) {
 
 	require.NoError(t, viper.BindPFlags(cmd.Flags()))
 
-	cfg := &flags.FlagsConfig{Apply: map[string]any{"distroLocation": "/from-config"}}
+	cfg := flags.FlagsConfig{flags.CommandApply: {"distroLocation": "/from-config"}}
 	require.NoError(t, flags.NewMerger().MergeIntoViper(cfg, flags.CommandApply))
 
 	assert.Equal(t, "/from-cli", viper.GetString("distro-location"))

--- a/internal/flags/sections_test.go
+++ b/internal/flags/sections_test.go
@@ -7,8 +7,6 @@
 package flags_test
 
 import (
-	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -19,26 +17,17 @@ import (
 	"github.com/sighupio/furyctl/internal/flags"
 )
 
-// The merger must know each section of the `flags` field. The section must also have flags that
-// furyctl supports. furyctl parses a section with no map, or with an empty map, and then drops it.
-// The `tools` section had this fault.
+// Each section that furyctl supports must list its flags. A section with an empty map reaches the
+// user as a section that furyctl parses and then drops. The `tools` section had this fault.
 func TestEverySectionHasSupportedFlags(t *testing.T) {
 	t.Parallel()
 
-	merger := flags.NewMerger()
-	cfg := reflect.TypeOf(flags.FlagsConfig{})
+	supported := flags.GetSupportedFlags()
 
-	for i := range cfg.NumField() {
-		section := strings.Split(cfg.Field(i).Tag.Get("yaml"), ",")[0]
+	require.NotEmpty(t, supported, "furyctl supports no section at all")
 
-		t.Run(section, func(t *testing.T) {
-			t.Parallel()
-
-			supported := merger.GetSupportedFlagsForCommand(section)
-
-			require.NotNil(t, supported, "the merger does not know the %q section", section)
-			assert.NotEmpty(t, supported, "the %q section has no supported flags", section)
-		})
+	for section, sectionFlags := range supported {
+		assert.NotEmpty(t, sectionFlags, "the %q section lists no flag", section)
 	}
 }
 
@@ -69,7 +58,7 @@ func TestMergeIntoViper_CommandSections(t *testing.T) {
 
 			require.NoError(t, viper.BindPFlags(cmd.Flags()))
 
-			cfg := sectionConfig(tc.section, map[string]any{tc.flag: "/from-config"})
+			cfg := flags.FlagsConfig{tc.section: {tc.flag: "/from-config"}}
 			require.NoError(t, flags.NewMerger().MergeIntoViper(cfg, tc.section))
 
 			assert.Equal(t, "/from-config", viper.GetString(tc.key))
@@ -77,26 +66,34 @@ func TestMergeIntoViper_CommandSections(t *testing.T) {
 	}
 }
 
-// sectionConfig puts the given flags in the named section of a FlagsConfig.
-func sectionConfig(section string, values map[string]any) *flags.FlagsConfig {
-	cfg := &flags.FlagsConfig{}
+// furyctl merges the global flags for a command that it does not support, and nothing else. The
+// merge relies on the absent entry in the supported flags, thus this test keeps that behavior.
+func TestMergeIntoViper_UnsupportedCommandGetsGlobalOnly(t *testing.T) {
+	cmd := &cobra.Command{Use: "serve"}
+	cmd.Flags().String("outdir", "", "")
+	cmd.Flags().String("address", "", "")
+	require.NoError(t, cmd.ParseFlags([]string{}))
 
-	switch section {
-	case flags.CommandValidate:
-		cfg.Validate = values
+	viper.Reset()
+	t.Cleanup(viper.Reset)
 
-	case flags.CommandDownload:
-		cfg.Download = values
+	require.NoError(t, viper.BindPFlags(cmd.Flags()))
 
-	case flags.CommandConnect:
-		cfg.Connect = values
-
-	case flags.CommandRenew:
-		cfg.Renew = values
-
-	case flags.CommandDump:
-		cfg.Dump = values
+	cfg := flags.FlagsConfig{
+		flags.CommandGlobal: {"outdir": "/from-global"},
+		"serve":             {"address": "1.2.3.4"},
 	}
+	require.NoError(t, flags.NewMerger().MergeIntoViper(cfg, "serve"))
 
-	return cfg
+	assert.Equal(t, "/from-global", viper.GetString("outdir"))
+	assert.Empty(t, viper.GetString("address"), "furyctl must not merge the flags of a command that it does not support")
+}
+
+// A configuration without a `flags` field gives no error and no validation message.
+func TestNilConfigIsHarmless(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	require.NoError(t, flags.NewMerger().MergeIntoViper(nil, flags.CommandApply))
+	assert.Empty(t, flags.NewValidator().Validate(nil))
 }

--- a/internal/flags/types.go
+++ b/internal/flags/types.go
@@ -4,45 +4,14 @@
 
 package flags
 
-// FlagsConfig represents the flags section in a furyctl.yaml file.
+// FlagsConfig holds the sections of the `flags` field of furyctl.yaml, keyed by the command name.
 //
 //nolint:revive // FlagsConfig name is intentionally explicit for external API clarity
-type FlagsConfig struct {
-	Global   map[string]any `yaml:"global,omitempty"`
-	Apply    map[string]any `yaml:"apply,omitempty"`
-	Delete   map[string]any `yaml:"delete,omitempty"`
-	Create   map[string]any `yaml:"create,omitempty"`
-	Get      map[string]any `yaml:"get,omitempty"`
-	Diff     map[string]any `yaml:"diff,omitempty"`
-	Validate map[string]any `yaml:"validate,omitempty"`
-	Download map[string]any `yaml:"download,omitempty"`
-	Connect  map[string]any `yaml:"connect,omitempty"`
-	Renew    map[string]any `yaml:"renew,omitempty"`
-	Dump     map[string]any `yaml:"dump,omitempty"`
-}
+type FlagsConfig map[string]map[string]any
 
-// SupportedFlags defines the mapping between flag names and their expected types
-// This helps with validation and type conversion.
-type SupportedFlags struct {
-	Global   map[string]FlagInfo
-	Apply    map[string]FlagInfo
-	Delete   map[string]FlagInfo
-	Create   map[string]FlagInfo
-	Get      map[string]FlagInfo
-	Diff     map[string]FlagInfo
-	Validate map[string]FlagInfo
-	Download map[string]FlagInfo
-	Connect  map[string]FlagInfo
-	Renew    map[string]FlagInfo
-	Dump     map[string]FlagInfo
-}
-
-// FlagInfo contains metadata about a supported flag.
-type FlagInfo struct {
-	Type         FlagType
-	DefaultValue any
-	Description  string
-}
+// SupportedFlags holds the flags that furyctl supports in each section, keyed by the command name.
+// A section that is absent from this map is not a section that furyctl supports.
+type SupportedFlags map[string]map[string]FlagType
 
 // FlagType represents the type of a flag value.
 type FlagType string
@@ -53,11 +22,6 @@ const (
 	FlagTypeInt         FlagType = "int"
 	FlagTypeStringSlice FlagType = "stringSlice"
 	FlagTypeDuration    FlagType = "duration"
-
-	// DefaultTimeoutSeconds is the default timeout for cluster operations, in seconds.
-	DefaultTimeoutSeconds = 3600
-	// DefaultPodRunningCheckTimeout is the default timeout for the pod-running check, in seconds.
-	DefaultPodRunningCheckTimeout = 300
 
 	// ValidationSeverityFatal indicates a critical error that should stop execution.
 	ValidationSeverityFatal ValidationSeverity = "fatal"
@@ -74,13 +38,13 @@ type ConfigWithFlags struct {
 	Kind       string         `yaml:"kind"`
 	Metadata   map[string]any `yaml:"metadata"`
 	Spec       map[string]any `yaml:"spec"`
-	Flags      *FlagsConfig   `yaml:"flags,omitempty"`
+	Flags      FlagsConfig    `yaml:"flags,omitempty"`
 }
 
 // LoadResult contains the result of loading and processing flags.
 type LoadResult struct {
 	ConfigPath string
-	Flags      *FlagsConfig
+	Flags      FlagsConfig
 	Errors     []error
 }
 
@@ -105,118 +69,102 @@ func (e ValidationError) Error() string {
 // GetSupportedFlags returns the complete mapping of supported flags for all commands.
 func GetSupportedFlags() SupportedFlags {
 	return SupportedFlags{
-		Global: map[string]FlagInfo{
-			"debug":            {Type: FlagTypeBool, DefaultValue: false, Description: "Enable debug output"},
-			"disableAnalytics": {Type: FlagTypeBool, DefaultValue: false, Description: "Disable analytics"},
-			"noTty":            {Type: FlagTypeBool, DefaultValue: false, Description: "Disable TTY"},
-			"workdir":          {Type: FlagTypeString, DefaultValue: "", Description: "Working directory"},
-			"outdir":           {Type: FlagTypeString, DefaultValue: "", Description: "Output directory"},
-			"log":              {Type: FlagTypeString, DefaultValue: "", Description: "Log file path"},
-			"gitProtocol":      {Type: FlagTypeString, DefaultValue: "https", Description: "Git protocol to use"},
+		CommandGlobal: {
+			"debug":            FlagTypeBool,
+			"disableAnalytics": FlagTypeBool,
+			"noTty":            FlagTypeBool,
+			"workdir":          FlagTypeString,
+			"outdir":           FlagTypeString,
+			"log":              FlagTypeString,
+			"gitProtocol":      FlagTypeString,
 		},
-		Apply: map[string]FlagInfo{
-			"phase": {Type: FlagTypeString, DefaultValue: "", Description: "Limit execution to specific phase"},
-			"startFrom": {
-				Type:         FlagTypeString,
-				DefaultValue: "",
-				Description:  "Start execution from specific phase",
-			},
-			"distroLocation":      {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
-			"distroPatches":       {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
-			"binPath":             {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
-			"skipNodesUpgrade":    {Type: FlagTypeBool, DefaultValue: false, Description: "Skip nodes upgrade"},
-			"skipDepsDownload":    {Type: FlagTypeBool, DefaultValue: false, Description: "Skip dependencies download"},
-			"skipDepsValidation":  {Type: FlagTypeBool, DefaultValue: false, Description: "Skip dependencies validation"},
-			"dryRun":              {Type: FlagTypeBool, DefaultValue: false, Description: "Dry run mode"},
-			"vpnAutoConnect":      {Type: FlagTypeBool, DefaultValue: false, Description: "Auto connect VPN"},
-			"skipVpnConfirmation": {Type: FlagTypeBool, DefaultValue: false, Description: "Skip VPN confirmation"},
-			"force":               {Type: FlagTypeStringSlice, DefaultValue: []string{}, Description: "Force options"},
-			"postApplyPhases":     {Type: FlagTypeStringSlice, DefaultValue: []string{}, Description: "Post apply phases"},
-			"timeout": {
-				Type:         FlagTypeInt,
-				DefaultValue: DefaultTimeoutSeconds,
-				Description:  "Timeout in seconds",
-			},
-			"podRunningCheckTimeout": {
-				Type:         FlagTypeInt,
-				DefaultValue: DefaultPodRunningCheckTimeout,
-				Description:  "Pod running check timeout",
-			},
-			"upgrade":             {Type: FlagTypeBool, DefaultValue: false, Description: "Enable upgrade mode"},
-			"upgradePathLocation": {Type: FlagTypeString, DefaultValue: "", Description: "Upgrade path location"},
-			"upgradeNode":         {Type: FlagTypeString, DefaultValue: "", Description: "Specific node to upgrade"},
-			"airgapBundle":        {Type: FlagTypeString, DefaultValue: "", Description: "Air-gapped bundle path"},
-			"forceExtract":        {Type: FlagTypeBool, DefaultValue: false, Description: "Force bundle re-extraction"},
+		CommandApply: {
+			"phase":                  FlagTypeString,
+			"startFrom":              FlagTypeString,
+			"distroLocation":         FlagTypeString,
+			"distroPatches":          FlagTypeString,
+			"binPath":                FlagTypeString,
+			"skipNodesUpgrade":       FlagTypeBool,
+			"skipDepsDownload":       FlagTypeBool,
+			"skipDepsValidation":     FlagTypeBool,
+			"dryRun":                 FlagTypeBool,
+			"vpnAutoConnect":         FlagTypeBool,
+			"skipVpnConfirmation":    FlagTypeBool,
+			"force":                  FlagTypeStringSlice,
+			"postApplyPhases":        FlagTypeStringSlice,
+			"timeout":                FlagTypeInt,
+			"podRunningCheckTimeout": FlagTypeInt,
+			"upgrade":                FlagTypeBool,
+			"upgradePathLocation":    FlagTypeString,
+			"upgradeNode":            FlagTypeString,
+			"airgapBundle":           FlagTypeString,
+			"forceExtract":           FlagTypeBool,
 		},
-		Delete: map[string]FlagInfo{
-			"phase":               {Type: FlagTypeString, DefaultValue: "", Description: "Limit execution to specific phase"},
-			"startFrom":           {Type: FlagTypeString, DefaultValue: "", Description: "Start execution from specific phase"},
-			"distroLocation":      {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
-			"distroPatches":       {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
-			"binPath":             {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
-			"dryRun":              {Type: FlagTypeBool, DefaultValue: false, Description: "Dry run mode"},
-			"skipVpnConfirmation": {Type: FlagTypeBool, DefaultValue: false, Description: "Skip VPN confirmation"},
-			"autoApprove":         {Type: FlagTypeBool, DefaultValue: false, Description: "Auto approve deletion"},
-			"airgapBundle":        {Type: FlagTypeString, DefaultValue: "", Description: "Air-gapped bundle path"},
-			"forceExtract":        {Type: FlagTypeBool, DefaultValue: false, Description: "Force bundle re-extraction"},
+		CommandDelete: {
+			"phase":               FlagTypeString,
+			"startFrom":           FlagTypeString,
+			"distroLocation":      FlagTypeString,
+			"distroPatches":       FlagTypeString,
+			"binPath":             FlagTypeString,
+			"dryRun":              FlagTypeBool,
+			"skipVpnConfirmation": FlagTypeBool,
+			"autoApprove":         FlagTypeBool,
+			"airgapBundle":        FlagTypeString,
+			"forceExtract":        FlagTypeBool,
 		},
-		Create: map[string]FlagInfo{
-			"name":     {Type: FlagTypeString, DefaultValue: "", Description: "Cluster name"},
-			"version":  {Type: FlagTypeString, DefaultValue: "", Description: "Distribution version"},
-			"provider": {Type: FlagTypeString, DefaultValue: "", Description: "Provider type"},
-			"path":     {Type: FlagTypeString, DefaultValue: "pki", Description: "Path where to save PKI files"},
-			"etcd":     {Type: FlagTypeBool, DefaultValue: false, Description: "Create PKI only for etcd"},
-			"controlplane": {
-				Type:         FlagTypeBool,
-				DefaultValue: false,
-				Description:  "Create PKI only for Kubernetes control plane",
-			},
+		CommandCreate: {
+			"name":         FlagTypeString,
+			"version":      FlagTypeString,
+			"provider":     FlagTypeString,
+			"path":         FlagTypeString,
+			"etcd":         FlagTypeBool,
+			"controlplane": FlagTypeBool,
 		},
-		Get: map[string]FlagInfo{
-			"binPath":            {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
-			"distroLocation":     {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
-			"skipDepsDownload":   {Type: FlagTypeBool, DefaultValue: false, Description: "Skip dependencies download"},
-			"skipDepsValidation": {Type: FlagTypeBool, DefaultValue: false, Description: "Skip dependencies validation"},
-			"airgapBundle":       {Type: FlagTypeString, DefaultValue: "", Description: "Air-gapped bundle path"},
-			"forceExtract":       {Type: FlagTypeBool, DefaultValue: false, Description: "Force bundle re-extraction"},
+		CommandGet: {
+			"binPath":            FlagTypeString,
+			"distroLocation":     FlagTypeString,
+			"skipDepsDownload":   FlagTypeBool,
+			"skipDepsValidation": FlagTypeBool,
+			"airgapBundle":       FlagTypeString,
+			"forceExtract":       FlagTypeBool,
 		},
-		Diff: map[string]FlagInfo{
-			"phase":               {Type: FlagTypeString, DefaultValue: "", Description: "Limit execution to specific phase"},
-			"distroLocation":      {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
-			"distroPatches":       {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
-			"binPath":             {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
-			"upgradePathLocation": {Type: FlagTypeString, DefaultValue: "", Description: "Upgrade path location"},
-			"airgapBundle":        {Type: FlagTypeString, DefaultValue: "", Description: "Air-gapped bundle path"},
-			"forceExtract":        {Type: FlagTypeBool, DefaultValue: false, Description: "Force bundle re-extraction"},
+		CommandDiff: {
+			"phase":               FlagTypeString,
+			"distroLocation":      FlagTypeString,
+			"distroPatches":       FlagTypeString,
+			"binPath":             FlagTypeString,
+			"upgradePathLocation": FlagTypeString,
+			"airgapBundle":        FlagTypeString,
+			"forceExtract":        FlagTypeBool,
 		},
-		Validate: map[string]FlagInfo{
-			"distroLocation": {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
-			"distroPatches":  {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
-			"binPath":        {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
+		CommandValidate: {
+			"distroLocation": FlagTypeString,
+			"distroPatches":  FlagTypeString,
+			"binPath":        FlagTypeString,
 		},
-		Download: map[string]FlagInfo{
-			"binPath":        {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
-			"distroLocation": {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
-			"distroPatches":  {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
-			"bundleOutput":   {Type: FlagTypeString, DefaultValue: "", Description: "Bundle tarball output path"},
+		CommandDownload: {
+			"binPath":        FlagTypeString,
+			"distroLocation": FlagTypeString,
+			"distroPatches":  FlagTypeString,
+			"bundleOutput":   FlagTypeString,
 		},
-		Connect: map[string]FlagInfo{
-			"profile": {Type: FlagTypeString, DefaultValue: "", Description: "OpenVPN profile name"},
+		CommandConnect: {
+			"profile": FlagTypeString,
 		},
-		Renew: map[string]FlagInfo{
-			"airgapBundle":       {Type: FlagTypeString, DefaultValue: "", Description: "Air-gapped bundle path"},
-			"forceExtract":       {Type: FlagTypeBool, DefaultValue: false, Description: "Force bundle re-extraction"},
-			"binPath":            {Type: FlagTypeString, DefaultValue: "", Description: "Binary path"},
-			"distroLocation":     {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
-			"skipDepsDownload":   {Type: FlagTypeBool, DefaultValue: false, Description: "Skip dependencies download"},
-			"skipDepsValidation": {Type: FlagTypeBool, DefaultValue: false, Description: "Skip dependencies validation"},
+		CommandRenew: {
+			"airgapBundle":       FlagTypeString,
+			"forceExtract":       FlagTypeBool,
+			"binPath":            FlagTypeString,
+			"distroLocation":     FlagTypeString,
+			"skipDepsDownload":   FlagTypeBool,
+			"skipDepsValidation": FlagTypeBool,
 		},
-		Dump: map[string]FlagInfo{
-			"distroLocation": {Type: FlagTypeString, DefaultValue: "", Description: "Distribution location"},
-			"distroPatches":  {Type: FlagTypeString, DefaultValue: "", Description: "Distribution patches location"},
-			"dryRun":         {Type: FlagTypeBool, DefaultValue: false, Description: "Dry run"},
-			"noOverwrite":    {Type: FlagTypeBool, DefaultValue: false, Description: "Do not overwrite existing files"},
-			"skipValidation": {Type: FlagTypeBool, DefaultValue: false, Description: "Skip validation"},
+		CommandDump: {
+			"distroLocation": FlagTypeString,
+			"distroPatches":  FlagTypeString,
+			"dryRun":         FlagTypeBool,
+			"noOverwrite":    FlagTypeBool,
+			"skipValidation": FlagTypeBool,
 		},
 	}
 }

--- a/internal/flags/validator.go
+++ b/internal/flags/validator.go
@@ -7,6 +7,7 @@ package flags
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -38,57 +39,12 @@ func NewValidator() *Validator {
 }
 
 // Validate validates the entire flags configuration.
-func (v *Validator) Validate(flags *FlagsConfig) []ValidationError {
-	var validationErrors []ValidationError
+func (v *Validator) Validate(flags FlagsConfig) []ValidationError {
+	validationErrors := make([]ValidationError, 0, len(flags))
 
-	if flags == nil {
-		return validationErrors
-	}
-
-	// Validate global flags.
-	if flags.Global != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Global, CommandGlobal)...)
-	}
-
-	// Validate command-specific flags.
-	if flags.Apply != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Apply, CommandApply)...)
-	}
-
-	if flags.Delete != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Delete, CommandDelete)...)
-	}
-
-	if flags.Create != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Create, CommandCreate)...)
-	}
-
-	if flags.Get != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Get, CommandGet)...)
-	}
-
-	if flags.Diff != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Diff, CommandDiff)...)
-	}
-
-	if flags.Validate != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Validate, CommandValidate)...)
-	}
-
-	if flags.Download != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Download, CommandDownload)...)
-	}
-
-	if flags.Connect != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Connect, CommandConnect)...)
-	}
-
-	if flags.Renew != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Renew, CommandRenew)...)
-	}
-
-	if flags.Dump != nil {
-		validationErrors = append(validationErrors, v.validateCommandFlags(flags.Dump, CommandDump)...)
+	// Sort the sections so that the messages keep the same order between runs.
+	for _, section := range slices.Sorted(maps.Keys(flags)) {
+		validationErrors = append(validationErrors, v.validateCommandFlags(flags[section], section)...)
 	}
 
 	// Cross-validation: check for conflicting flags.
@@ -97,66 +53,24 @@ func (v *Validator) Validate(flags *FlagsConfig) []ValidationError {
 	return validationErrors
 }
 
-// ValidateIndividualFlag is a public wrapper around validateFlagValue, exposed for testing.
-func (v *Validator) ValidateIndividualFlag(flagName string, value any, flagInfo FlagInfo) error {
-	return v.validateFlagValue(flagName, value, flagInfo)
-}
-
 // validateCommandFlags validates flags for a specific command.
 func (v *Validator) validateCommandFlags(flagsMap map[string]any, command string) []ValidationError {
 	var validationErrors []ValidationError
 
-	var supportedFlagsMap map[string]FlagInfo
-
-	switch command {
-	case CommandGlobal:
-		supportedFlagsMap = v.supportedFlags.Global
-
-	case CommandApply:
-		supportedFlagsMap = v.supportedFlags.Apply
-
-	case CommandDelete:
-		supportedFlagsMap = v.supportedFlags.Delete
-
-	case CommandCreate:
-		supportedFlagsMap = v.supportedFlags.Create
-
-	case CommandGet:
-		supportedFlagsMap = v.supportedFlags.Get
-
-	case CommandDiff:
-		supportedFlagsMap = v.supportedFlags.Diff
-
-	case CommandValidate:
-		supportedFlagsMap = v.supportedFlags.Validate
-
-	case CommandDownload:
-		supportedFlagsMap = v.supportedFlags.Download
-
-	case CommandConnect:
-		supportedFlagsMap = v.supportedFlags.Connect
-
-	case CommandRenew:
-		supportedFlagsMap = v.supportedFlags.Renew
-
-	case CommandDump:
-		supportedFlagsMap = v.supportedFlags.Dump
-
-	default:
-		validationErrors = append(validationErrors, ValidationError{
+	supportedFlagsMap, supported := v.supportedFlags[command]
+	if !supported {
+		return []ValidationError{{
 			Command:  command,
 			Flag:     "",
 			Value:    nil,
 			Reason:   "unsupported command",
 			Severity: ValidationSeverityFatal,
-		})
-
-		return validationErrors
+		}}
 	}
 
 	for flagName, value := range flagsMap {
 		// Check if flag is supported.
-		flagInfo, supported := supportedFlagsMap[flagName]
+		flagType, supported := supportedFlagsMap[flagName]
 		if !supported {
 			validationErrors = append(validationErrors, ValidationError{
 				Command: command,
@@ -177,7 +91,7 @@ func (v *Validator) validateCommandFlags(flagsMap map[string]any, command string
 		}
 
 		// Validate the value type and content.
-		if err := v.validateFlagValue(flagName, value, flagInfo); err != nil {
+		if err := v.validateFlagValue(flagName, value, flagType); err != nil {
 			validationErrors = append(validationErrors, ValidationError{
 				Command:  command,
 				Flag:     flagName,
@@ -192,9 +106,9 @@ func (v *Validator) validateCommandFlags(flagsMap map[string]any, command string
 }
 
 // validateFlagValue validates a single flag's value.
-func (v *Validator) validateFlagValue(flagName string, value any, flagInfo FlagInfo) error {
+func (v *Validator) validateFlagValue(flagName string, value any, flagType FlagType) error {
 	// Basic type validation.
-	switch flagInfo.Type {
+	switch flagType {
 	case FlagTypeBool:
 		if _, ok := value.(bool); !ok {
 			if str, ok := value.(string); !ok {
@@ -228,7 +142,7 @@ func (v *Validator) validateFlagValue(flagName string, value any, flagInfo FlagI
 		_ = value // No-op to satisfy WSL linter.
 
 	default:
-		logrus.Debugf("flag %q has unknown type %v; skipping basic type validation", flagName, flagInfo.Type)
+		logrus.Debugf("flag %q has unknown type %v; skipping basic type validation", flagName, flagType)
 	}
 
 	// Specific flag validations.
@@ -287,84 +201,42 @@ func (*Validator) validateSpecificFlag(flagName string, value any) error {
 }
 
 // validateFlagCombinations validates combinations of flags that might be incompatible.
-func (*Validator) validateFlagCombinations(flags *FlagsConfig) []ValidationError {
-	var validationErrors []ValidationError
+func (*Validator) validateFlagCombinations(flags FlagsConfig) []ValidationError {
+	apply := flags[CommandApply]
 
-	// Check apply-specific flag combinations.
-	if flags.Apply != nil {
-		// Check skipVpnConfirmation vs vpnAutoConnect.
-		if skipVpn, hasSkipVpn := flags.Apply["skipVpnConfirmation"]; hasSkipVpn {
-			if autoConnect, hasAutoConnect := flags.Apply["vpnAutoConnect"]; hasAutoConnect {
-				if skipVpnBool, ok := skipVpn.(bool); ok && skipVpnBool {
-					if autoConnectBool, ok := autoConnect.(bool); ok && autoConnectBool {
-						validationErrors = append(validationErrors, ValidationError{
-							Command:  CommandApply,
-							Flag:     "vpnAutoConnect",
-							Value:    autoConnect,
-							Reason:   "vpnAutoConnect=true conflicts with skipVpnConfirmation=true. Use only one of these flags.",
-							Severity: ValidationSeverityFatal,
-						})
-					}
-				}
-			}
-		}
+	isTrue := func(name string) bool { v, ok := apply[name].(bool); return ok && v }
+	isSet := func(name string) bool { v, ok := apply[name].(string); return ok && v != "" }
+	hasItems := func(name string) bool { v, ok := apply[name].([]any); return ok && len(v) > 0 }
+	phaseSet := isSet("phase") && apply["phase"] != "all"
 
-		// Check upgrade vs upgradeNode.
-		if upgrade, hasUpgrade := flags.Apply["upgrade"]; hasUpgrade {
-			if upgradeNode, hasUpgradeNode := flags.Apply["upgradeNode"]; hasUpgradeNode {
-				if upgradeBool, ok := upgrade.(bool); ok && upgradeBool {
-					if upgradeNodeStr, ok := upgradeNode.(string); ok && upgradeNodeStr != "" {
-						validationErrors = append(validationErrors, ValidationError{
-							Command: CommandApply,
-							Flag:    "upgradeNode",
-							Value:   upgradeNode,
-							Reason: "upgradeNode cannot be used when upgrade=true. " +
-								"Use either 'upgrade' for all nodes or 'upgradeNode' for a specific node.",
-							Severity: ValidationSeverityFatal,
-						})
-					}
-				}
-			}
-		}
+	var errs []ValidationError
 
-		// Check phase vs startFrom.
-		if phase, hasPhase := flags.Apply["phase"]; hasPhase {
-			if startFrom, hasStartFrom := flags.Apply["startFrom"]; hasStartFrom {
-				if phaseStr, ok := phase.(string); ok && phaseStr != "" && phaseStr != "all" {
-					if startFromStr, ok := startFrom.(string); ok && startFromStr != "" {
-						validationErrors = append(validationErrors, ValidationError{
-							Command: CommandApply,
-							Flag:    "startFrom",
-							Value:   startFrom,
-							Reason: "startFrom cannot be used when phase is specified (and not 'all'). " +
-								"Use either 'phase' or 'startFrom', not both.",
-							Severity: ValidationSeverityFatal,
-						})
-					}
-				}
-			}
-		}
-
-		// Check phase vs postApplyPhases.
-		if phase, hasPhase := flags.Apply["phase"]; hasPhase {
-			if postApplyPhases, hasPostApply := flags.Apply["postApplyPhases"]; hasPostApply {
-				if phaseStr, ok := phase.(string); ok && phaseStr != "" && phaseStr != "all" {
-					if phases, ok := postApplyPhases.([]any); ok && len(phases) > 0 {
-						validationErrors = append(validationErrors, ValidationError{
-							Command: CommandApply,
-							Flag:    "postApplyPhases",
-							Value:   postApplyPhases,
-							Reason: "postApplyPhases cannot be used when phase is specified (and not 'all'). " +
-								"Use either 'phase' or 'postApplyPhases', not both.",
-							Severity: ValidationSeverityFatal,
-						})
-					}
-				}
-			}
-		}
+	add := func(flag, reason string) {
+		errs = append(errs, ValidationError{
+			Command: CommandApply, Flag: flag, Value: apply[flag], Reason: reason, Severity: ValidationSeverityFatal,
+		})
 	}
 
-	return validationErrors
+	if isTrue("skipVpnConfirmation") && isTrue("vpnAutoConnect") {
+		add("vpnAutoConnect", "vpnAutoConnect=true conflicts with skipVpnConfirmation=true. Use only one of these flags.")
+	}
+
+	if isTrue("upgrade") && isSet("upgradeNode") {
+		add("upgradeNode", "upgradeNode cannot be used when upgrade=true. "+
+			"Use either 'upgrade' for all nodes or 'upgradeNode' for a specific node.")
+	}
+
+	if phaseSet && isSet("startFrom") {
+		add("startFrom", "startFrom cannot be used when phase is specified (and not 'all'). "+
+			"Use either 'phase' or 'startFrom', not both.")
+	}
+
+	if phaseSet && hasItems("postApplyPhases") {
+		add("postApplyPhases", "postApplyPhases cannot be used when phase is specified (and not 'all'). "+
+			"Use either 'phase' or 'postApplyPhases', not both.")
+	}
+
+	return errs
 }
 
 // getValidationSeverity determines the severity level for a validation error.

--- a/internal/flags/validator_invalid_test.go
+++ b/internal/flags/validator_invalid_test.go
@@ -22,15 +22,15 @@ func TestValidator_InvalidFlags_ShouldBeFatal(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		flagsConfig    *flags.FlagsConfig
+		flagsConfig    flags.FlagsConfig
 		expectedErrors int
 		expectFatal    bool
 		errorContains  []string
 	}{
 		{
 			name: "invalid global flags should be fatal",
-			flagsConfig: &flags.FlagsConfig{
-				Global: map[string]any{
+			flagsConfig: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"debug":          true,  // Valid.
 					"invalidFlag":    "bad", // Invalid.
 					"anotherBadFlag": 42,    // Invalid.
@@ -42,8 +42,8 @@ func TestValidator_InvalidFlags_ShouldBeFatal(t *testing.T) {
 		},
 		{
 			name: "invalid apply flags should be fatal",
-			flagsConfig: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flagsConfig: flags.FlagsConfig{
+				flags.CommandApply: {
 					"dryRun":          true,  // Valid.
 					"unsupportedFlag": "bad", // Invalid.
 					"fakeApplyFlag":   false, // Invalid.
@@ -55,11 +55,21 @@ func TestValidator_InvalidFlags_ShouldBeFatal(t *testing.T) {
 		},
 		{
 			name: "all valid flags should pass",
-			flagsConfig: &flags.FlagsConfig{
-				Global: map[string]any{
-					"debug":       true,
-					"log":         "/tmp/furyctl.log",
-					"gitProtocol": "ssh",
+			flagsConfig: flags.FlagsConfig{
+				flags.CommandGlobal: {
+					"debug":            true,
+					"disableAnalytics": false,
+					"noTty":            false,
+					"workdir":          "/tmp",
+					"outdir":           "/tmp/out",
+					"log":              "/tmp/furyctl.log",
+					"gitProtocol":      "ssh",
+				},
+				flags.CommandApply: {
+					"phase":              "infrastructure",
+					"dryRun":             true,
+					"skipDepsDownload":   false,
+					"skipDepsValidation": false,
 				},
 			},
 			expectedErrors: 0,
@@ -67,8 +77,8 @@ func TestValidator_InvalidFlags_ShouldBeFatal(t *testing.T) {
 		},
 		{
 			name: "mixed valid and invalid flags should be fatal",
-			flagsConfig: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flagsConfig: flags.FlagsConfig{
+				flags.CommandApply: {
 					"dryRun":  true,    // Valid.
 					"phase":   "infra", // Valid.
 					"badFlag": "oops",  // Invalid.
@@ -120,8 +130,8 @@ func TestValidator_InvalidFlags_ErrorMessages(t *testing.T) {
 	t.Parallel()
 
 	validator := flags.NewValidator()
-	flagsConfig := &flags.FlagsConfig{
-		Global: map[string]any{
+	flagsConfig := flags.FlagsConfig{
+		flags.CommandGlobal: {
 			"invalidFlag": "value",
 		},
 	}
@@ -137,55 +147,4 @@ func TestValidator_InvalidFlags_ErrorMessages(t *testing.T) {
 	assert.Equal(t, "value", err.Value)
 	assert.Contains(t, err.Reason, "flag 'invalidFlag' is not supported for 'global' configuration")
 	assert.Contains(t, err.Reason, "Check documentation for supported flags")
-}
-
-func TestValidator_SupportedFlags_DoNotCauseFatalErrors(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		flagsConfig *flags.FlagsConfig
-	}{
-		{
-			name: "all global flags should be valid",
-			flagsConfig: &flags.FlagsConfig{
-				Global: map[string]any{
-					"debug":            true,
-					"disableAnalytics": false,
-					"noTty":            false,
-					"workdir":          "/tmp",
-					"outdir":           "/tmp/out",
-					"log":              "/tmp/furyctl.log",
-					"gitProtocol":      "https",
-				},
-			},
-		},
-		{
-			name: "common apply flags should be valid",
-			flagsConfig: &flags.FlagsConfig{
-				Apply: map[string]any{
-					"phase":              "infrastructure",
-					"dryRun":             true,
-					"skipDepsDownload":   false,
-					"skipDepsValidation": false,
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			validator := flags.NewValidator()
-			validationErrors := validator.Validate(tt.flagsConfig)
-
-			// Check that no fatal errors occurred due to unsupported flags.
-			for _, err := range validationErrors {
-				if err.Severity == flags.ValidationSeverityFatal {
-					assert.NotContains(t, err.Reason, "not supported", "Unexpected fatal error for supported flag: %v", err)
-				}
-			}
-		})
-	}
 }

--- a/internal/flags/validator_test.go
+++ b/internal/flags/validator_test.go
@@ -19,18 +19,18 @@ func TestValidator_Validate(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		flags          *flags.FlagsConfig
+		flags          flags.FlagsConfig
 		expectedErrors int
 	}{
 		{
 			name: "valid flags configuration",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"debug":            true,
 					"disableAnalytics": false,
 					"gitProtocol":      "https",
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"skipDepsValidation": true,
 					"dryRun":             false,
 					"timeout":            3600,
@@ -41,11 +41,11 @@ func TestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "unsupported flags",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"unknownFlag": "value",
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"anotherUnknownFlag": true,
 				},
 			},
@@ -53,8 +53,8 @@ func TestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid git protocol",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"gitProtocol": "invalid",
 				},
 			},
@@ -62,8 +62,8 @@ func TestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid force options",
-			flags: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandApply: {
 					"force": []any{"invalid-option"},
 				},
 			},
@@ -71,8 +71,8 @@ func TestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid timeout",
-			flags: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandApply: {
 					"timeout": -1,
 				},
 			},
@@ -80,8 +80,8 @@ func TestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "conflicting vpn flags",
-			flags: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandApply: {
 					"skipVpnConfirmation": true,
 					"vpnAutoConnect":      true,
 				},
@@ -90,8 +90,8 @@ func TestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "conflicting upgrade flags",
-			flags: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandApply: {
 					"upgrade":     true,
 					"upgradeNode": "worker1",
 				},
@@ -100,8 +100,8 @@ func TestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "conflicting phase and startFrom",
-			flags: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandApply: {
 					"phase":     "distribution",
 					"startFrom": "infrastructure",
 				},
@@ -110,18 +110,13 @@ func TestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "conflicting phase and postApplyPhases",
-			flags: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandApply: {
 					"phase":           "distribution",
 					"postApplyPhases": []any{"distribution"},
 				},
 			},
 			expectedErrors: 1, // Conflicting flags
-		},
-		{
-			name:           "nil flags",
-			flags:          nil,
-			expectedErrors: 0,
 		},
 	}
 
@@ -130,85 +125,6 @@ func TestValidator_Validate(t *testing.T) {
 			errors := validator.Validate(tt.flags)
 
 			assert.Len(t, errors, tt.expectedErrors, "Expected %d errors, got %d: %v", tt.expectedErrors, len(errors), errors)
-		})
-	}
-}
-
-func TestValidator_ValidateSpecificFlag(t *testing.T) {
-	validator := flags.NewValidator()
-
-	tests := []struct {
-		name        string
-		flagName    string
-		value       any
-		expectError bool
-	}{
-		{
-			name:        "valid gitProtocol https",
-			flagName:    "gitProtocol",
-			value:       "https",
-			expectError: false,
-		},
-		{
-			name:        "valid gitProtocol ssh",
-			flagName:    "gitProtocol",
-			value:       "ssh",
-			expectError: false,
-		},
-		{
-			name:        "invalid gitProtocol",
-			flagName:    "gitProtocol",
-			value:       "ftp",
-			expectError: true,
-		},
-		{
-			name:        "valid timeout",
-			flagName:    "timeout",
-			value:       3600,
-			expectError: false,
-		},
-		{
-			name:        "invalid timeout negative",
-			flagName:    "timeout",
-			value:       -1,
-			expectError: true,
-		},
-		{
-			name:        "valid force options",
-			flagName:    "force",
-			value:       []any{"all", "upgrades"},
-			expectError: false,
-		},
-		{
-			name:        "invalid force option",
-			flagName:    "force",
-			value:       []any{"invalid"},
-			expectError: true,
-		},
-		{
-			name:        "unknown flag",
-			flagName:    "unknownFlag",
-			value:       "value",
-			expectError: false, // Should not error for unknown flags
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a simple flag info for testing
-			flagInfo := flags.FlagInfo{
-				Type:        flags.FlagTypeString,
-				Description: "Test flag",
-			}
-
-			// Test through validateFlagValue which calls validateSpecificFlag
-			err := validator.ValidateIndividualFlag(tt.flagName, tt.value, flagInfo)
-
-			if tt.expectError {
-				assert.Error(t, err, "Expected error for flag %s with value %v, but got none", tt.flagName, tt.value)
-			} else {
-				assert.NoError(t, err, "Unexpected error for flag %s with value %v", tt.flagName, tt.value)
-			}
 		})
 	}
 }
@@ -266,17 +182,17 @@ func TestValidator_ErrorSeverityClassification(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		flags            *flags.FlagsConfig
+		flags            flags.FlagsConfig
 		expectedFatal    int
 		expectedWarnings int
 	}{
 		{
 			name: "fatal errors - invalid protocol and negative timeout",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"gitProtocol": "ftp", // Fatal: invalid protocol
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"timeout": -5, // Fatal: negative timeout
 				},
 			},
@@ -285,11 +201,11 @@ func TestValidator_ErrorSeverityClassification(t *testing.T) {
 		},
 		{
 			name: "fatal errors - unsupported flags",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"unknownGlobalFlag": "value", // Fatal: unsupported
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"unknownApplyFlag": true, // Fatal: unsupported
 				},
 			},
@@ -298,8 +214,8 @@ func TestValidator_ErrorSeverityClassification(t *testing.T) {
 		},
 		{
 			name: "fatal errors - conflicting flags",
-			flags: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandApply: {
 					"vpnAutoConnect":      true, // Fatal: conflicts with skipVpnConfirmation
 					"skipVpnConfirmation": true,
 					"upgrade":             true, // Fatal: conflicts with upgradeNode
@@ -311,8 +227,8 @@ func TestValidator_ErrorSeverityClassification(t *testing.T) {
 		},
 		{
 			name: "fatal errors - invalid force options",
-			flags: &flags.FlagsConfig{
-				Apply: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandApply: {
 					"force": []any{"invalid-option"}, // Fatal: invalid force option
 				},
 			},
@@ -321,12 +237,12 @@ func TestValidator_ErrorSeverityClassification(t *testing.T) {
 		},
 		{
 			name: "mixed fatal errors",
-			flags: &flags.FlagsConfig{
-				Global: map[string]any{
+			flags: flags.FlagsConfig{
+				flags.CommandGlobal: {
 					"gitProtocol": "invalid", // Fatal: invalid protocol
 					"unknownFlag": "value",   // Fatal: unsupported
 				},
-				Apply: map[string]any{
+				flags.CommandApply: {
 					"timeout":        -1,     // Fatal: negative timeout
 					"anotherUnknown": "test", // Fatal: unsupported
 				},


### PR DESCRIPTION
### Summary 💡

Seven functions of the `internal/flags` package each listed every section of the `flags` field of `furyctl.yaml`. A new section needed a change in each one. This PR keys the sections by the command name, thus one map holds them.

Relates:
- #746
- #750

### Description 📝

Before this change, `FlagsConfig` and `SupportedFlags` were structs with one field for each section. Five switch statements, one chain of if statements and one list of eleven calls read those fields. Issue #746 came from this shape: five sections reached the structs but not the switch statements.

Both types are now a map, keyed by the command name. `GetSupportedFlags` is the only list of sections. A new section needs one entry there, and every consumer finds it.

```go
type FlagsConfig map[string]map[string]any
type SupportedFlags map[string]map[string]FlagType
```

The switch statements become a lookup of the map, and the chain of if statements becomes a loop:

| Function | Before | After |
|---|---:|---:|
| `Merger.MergeIntoViper` | 57 | 18 |
| `Merger.GetSupportedFlagsForCommand` | 39 | deleted |
| `Merger.mergeCommandFlags` | 67 | 29 |
| `Validator.Validate` | 58 | 13 |
| `Validator.validateCommandFlags` | 87 | 50 |
| `Loader.processDynamicValues` | 49 | 14 |
| `config.validateFlagsSection` | 84 | 46 |

The change also removes what the map makes unnecessary. Nothing read `DefaultValue` or `Description` of `FlagInfo`, thus the table holds a `FlagType` now. Three exported helpers had no caller outside the tests: `Merger.MergeGlobalFlags`, `Merger.GetSupportedFlagsForCommand` and `Validator.ValidateIndividualFlag`. `Loader.processField` and the error `ErrUnsupportedFlagsCommand` also go, because the loop and the validator make them unnecessary. `validateFlagCombinations` goes from 79 lines to 37, because its checks for the presence of a key repeat the type assertions inside them.

**This PR does not correct the contents of the table.** Issue #750 holds that work. The entries are the same as before: a dump of the 75 pairs of name and type from both trees gives no difference. The shape of the table changes, not its data.

**Note for the reviewer.** The code now relies on the behavior of a nil map: a key that is absent gives `nil`, and a loop over `nil` runs zero times. A command that furyctl does not support thus gets the global flags only, as before, with no branch for it. `TestMergeIntoViper_UnsupportedCommandGetsGlobalOnly` and `TestNilConfigIsHarmless` keep that behavior, because a reader could remove the reliance without them.

### Breaking Changes 💔

None. A section name with a spelling fault stops the validation before and after this change. The message comes from the validator now, thus its text changes: `unsupported flags command: aply` becomes `validation error for aply: unsupported command`.

### Tests performed 🧪

- [x] The table of supported flags is unchanged. A dump of the 75 pairs of name and type from both trees, through reflection, gives no difference
- [x] A differential run of the loader and the validator over 18 configurations gives the same messages, except the text for an unknown section name
- [x] `furyctl validate config` with `flags.aply` (a spelling fault) stops on both trees. Only the text of the message differs
- [x] `furyctl renew certificates` with `flags.renew.distroLocation` still reads the value
- [x] `furyctl renew certificates --distro-location` still wins over the same flag in the
      configuration file
- [x] `furyctl renew certificates` with `flags.renew.bogusFlag` still stops with
      `flag 'bogusFlag' is not supported for 'renew' command`
- [x] `furyctl apply` with `flags.apply.distroLocation` still reads the value, thus a section that worked before still works
- [x] `flags.global.debug` still reaches `furyctl renew certificates`, which is a command that furyctl does not support
- [x] A `furyctl.yaml` with no `flags` field runs normally
- [x] The four rules of `validateFlagCombinations` still stop the command: `upgrade` with `upgradeNode`, and `phase` with `startFrom`. `phase: all` with `startFrom` does not stop
- [x] `furyctl validate config` with `flags.tools` stops, because furyctl has no `tools` command

### Future work 🔧

Issue #750 holds the contents of the table: entries for flags that no command has, and real flags that the table does not list. This PR makes that fix smaller, because the correction is now one map instead of seven switch statements.

A probe found the gaps of #750. It walks the command tree of cobra from `cmd.NewRootCmd()` and compares each section with the flags of its commands. A test of that shape belongs with #750, because it fails when a command gains a flag that the table does not list.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~ internal refactor, no user-facing change.
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
