### PR TITLE
fix(tool/butane): surface errors

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -15,6 +15,7 @@ Welcome to the latest release of `furyctl` maintained by SIGHUP by ReeVo team.
 - [[#739](https://github.com/sighupio/furyctl/pull/739)] Makes furyctl distinguish an error "the cluster doesn't exist yet" from any other preflight failure on OnPremises clusters. Supports both the renamed `fetch-admin-conf-playbook.yaml` and the legacy `verify-playbook.yaml` used by older SD versions.
 - [[#750](https://github.com/sighupio/furyctl/issues/750)] All kinds: the `flags` section of `furyctl.yaml` now accepts every flag of its commands. `delete` accepts `force`, `skipDepsDownload`, `skipDepsValidation` and `vpnAutoConnect`. `get` accepts `format`, `from` and `kind`. Before this release furyctl stopped with `flag 'X' is not supported`, although the command has the flag. The documentation of the `flags` section now gives the same list of flags as furyctl accepts.
 - [[#754](https://github.com/sighupio/furyctl/pull/754)] OnPremises: after `apply --upgrade --skip-nodes-upgrade`, a later `apply --upgrade` now upgrades only the worker nodes that are still pending or failed, one at a time. furyctl saves the result after each worker node, so an interrupted upgrade continues from the remaining nodes. While worker nodes are pending, a plain apply and partial upgrade options stop to prevent an unsafe apply; `--force upgrades` or `--force all` allows partial upgrade options to continue with a warning.
+- [[#759](https://github.com/sighupio/furyctl/pull/759)] Immutable: surface butane-to-ignition translation errors to the user.
 
 ## Breaking Changes 💔
 

--- a/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootstrap.go
+++ b/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootstrap.go
@@ -35,8 +35,6 @@ var (
 	ErrKubernetesVersionNotFound = errors.New("kubernetes version not found in immutable installer spec")
 	ErrSandboxTagOrRegistryEmpty = errors.New("sandboxTag and imageRegistry are required in immutable installer spec")
 	ErrFlatcarArtifactsNotFound  = errors.New("flatcar artifacts not found for architecture")
-	ErrButaneConversionFatal     = errors.New("butane conversion fatal errors")
-	ErrButaneFatalErrors         = errors.New("butane translation has fatal errors")
 	ErrImmutableConfigMalformed  = errors.New("immutable furyctl config is malformed")
 	ErrSysextChecksumMismatch    = errors.New("sysext package checksum mismatch")
 )
@@ -482,11 +480,6 @@ func (i *Infrastructure) generateInstallFlatcarIgnitionFiles() error {
 			return fmt.Errorf("error converting %s to ignition: %w", nodeConfigPath, err)
 		}
 
-		// Check for fatal errors in report.
-		if report.IsFatal() {
-			return fmt.Errorf("%w for %s: %s", ErrButaneConversionFatal, node.Hostname, report.String())
-		}
-
 		// Log warnings if present.
 		if len(report.Entries) > 0 {
 			logrus.Warnf("Butane conversion warnings for %s: %s", node.Hostname, report.String())
@@ -584,17 +577,12 @@ func convertButaneToIgnition(butanePath, ignitionPath string) error {
 		return fmt.Errorf("error converting butane to ignition: %w", err)
 	}
 
-	// 4. Check for fatal errors in report.
-	if report.IsFatal() {
-		return fmt.Errorf("%w: %s", ErrButaneFatalErrors, report.String())
-	}
-
-	// 5. Log warnings if present.
+	// 4. Log warnings if present.
 	if len(report.Entries) > 0 {
 		logrus.Warnf("Butane conversion warnings: %s", report.String())
 	}
 
-	// 6. Write Ignition JSON.
+	// 5. Write Ignition JSON.
 	if err := os.WriteFile(ignitionPath, ignitionJSON, iox.FullRWPermAccess); err != nil {
 		return fmt.Errorf("error writing ignition file %s: %w", ignitionPath, err)
 	}

--- a/internal/tool/butane/runner.go
+++ b/internal/tool/butane/runner.go
@@ -7,6 +7,7 @@ package butane
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/coreos/butane/config"
 	"github.com/coreos/butane/config/common"
@@ -49,7 +50,7 @@ func NewRunnerWithOptions(options common.TranslateBytesOptions) *Runner {
 func (r *Runner) Convert(butaneConfig []byte) ([]byte, error) {
 	ignitionJSON, rpt, err := config.TranslateBytes(butaneConfig, r.options)
 	if err != nil {
-		return nil, fmt.Errorf("error translating butane config: %w", err)
+		return nil, translationError(err, rpt)
 	}
 
 	if rpt.IsFatal() {
@@ -64,10 +65,21 @@ func (r *Runner) Convert(butaneConfig []byte) ([]byte, error) {
 func (r *Runner) ConvertWithReport(butaneConfig []byte) ([]byte, report.Report, error) {
 	ignitionJSON, rpt, err := config.TranslateBytes(butaneConfig, r.options)
 	if err != nil {
-		return nil, rpt, fmt.Errorf("error translating butane config: %w", err)
+		return nil, rpt, translationError(err, rpt)
 	}
 
 	return ignitionJSON, rpt, nil
+}
+
+// translationError wraps a translation failure together with the report, which
+// holds the details the user needs to fix the config (path, line, column and
+// reason). Butane returns those in the report, not in the error.
+func translationError(err error, rpt report.Report) error {
+	if details := strings.TrimSpace(rpt.String()); details != "" {
+		return fmt.Errorf("error translating butane config: %w:\n%s", err, details)
+	}
+
+	return fmt.Errorf("error translating butane config: %w", err)
 }
 
 // SetFilesDir sets the directory for embedding local files in butane configs.

--- a/internal/tool/butane/runner_test.go
+++ b/internal/tool/butane/runner_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unit
+
+package butane_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sighupio/furyctl/internal/tool/butane"
+)
+
+// An XFS filesystem with a label longer than 12 characters passes source
+// validation but fails validation of the generated Ignition config, so Butane
+// reports the reason in the report and not in the error.
+const invalidXFSLabelConfig = `variant: flatcar
+version: 1.1.0
+storage:
+  filesystems:
+    - device: /dev/disk/by-partlabel/data
+      format: xfs
+      label: way-too-long-label
+`
+
+func TestRunner_Convert_SurfacesValidationDetails(t *testing.T) {
+	t.Parallel()
+
+	_, err := butane.NewRunner().Convert([]byte(invalidXFSLabelConfig))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config generated was invalid")
+	assert.Contains(t, err.Error(), "$.storage.filesystems.0.label")
+	assert.Contains(t, err.Error(), "cannot be longer than 12 characters")
+}
+
+func TestRunner_ConvertWithReport_SurfacesValidationDetails(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := butane.NewRunner().ConvertWithReport([]byte(invalidXFSLabelConfig))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "$.storage.filesystems.0.label")
+	assert.Contains(t, err.Error(), "cannot be longer than 12 characters")
+}
+
+func TestRunner_Convert_KeepsBareErrorWithoutReport(t *testing.T) {
+	t.Parallel()
+
+	// No variant: Butane fails before it produces a report.
+	_, err := butane.NewRunner().Convert([]byte("version: 1.1.0\n"))
+	require.Error(t, err)
+	assert.Equal(t, "error translating butane config: error parsing variant; must be specified", err.Error())
+}


### PR DESCRIPTION
### Summary 💡

Surface butane to ignition translation errors to the user.

Fixes #735

### Description 📝

Surface butane to ignition translation errors to the user instead of showing a generic error.

Example:

```bash
$ furyctl apply
INFO Downloading distribution...
INFO Validating configuration file...
INFO Downloading dependencies...
INFO Tools ready (7 installed via mise)
INFO Installing ansible collections...
INFO Validating dependencies...
INFO Running preflight checks...
INFO Preflight checks completed successfully
INFO Running preupgrade phase...
INFO Preupgrade phase completed successfully
ERRO error while creating cluster: error while executing cluster creation: error while executing infrastructure phase: error while executing phase: preparing for infrastructure phase failed: error rendering butane templates: error generating install-flatcar ignition files: error converting <redacted>/.furyctl/<cluster-name>/infrastructure/butane/node-config/cp1.flatcar.bu to ignition: error translating butane config: config generated was invalid:
error at $.storage.filesystems.0.label, line 261 col 14: filesystem labels cannot be longer than 12 characters when using xfs
```

### Dead code removed 🧹

This PR also removes two dead branches and the two error values they use:

- `ErrButaneConversionFatal` in `generateInstallFlatcarIgnitionFiles`
- `ErrButaneFatalErrors` in `convertButaneToIgnition`

Both branches test `report.IsFatal()` after an earlier `if err != nil` return. Butane returns a non-nil error on every path that leaves a fatal report. An `err` of `nil` therefore means the report is not fatal, so neither branch can run.

These branches also explain how the bug passed review. They read as "a fatal report prints `report.String()`", so the report looks handled. The fatal case always returns one branch earlier, at `err != nil`. Before this fix, that branch discarded the report.

No code matches the two error values with `errors.Is`, so behavior does not change. `ErrFatalTranslation` in the runner stays as a guard at the library boundary.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Render a node butane with an XFS filesystem whose label is over 12 characters, run furyctl apply, and confirm the error now names the field, line, column, and reason instead of only config generated was invalid.
- [x] A clean furyctl.yaml still renders butane properly

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green


